### PR TITLE
docs: Add hubot::docker option for answers.yaml

### DIFF
--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -251,6 +251,7 @@ If for whatever reason your chat client is not listed as an example, it is possi
 
 Below are the values you can set
 
+* :code:`hubot::docker`            - Boolean: Should puppet install hubot? Required if you're not using /setup to enable hubot.
 * :code:`hubot::chat_alias`        - A short for a command used at the beginning of task. (e.g.: !)
 * :code:`hubot::adapter`           - The name of the npm adapter used to connect to your chat service
 * :code:`hubot::env_export`        - A hash of all environment variables necessary to configure the :code:`hubot::adapter`
@@ -269,6 +270,7 @@ Example Answers File
     st2enterprise::token: myawesometokentogetenterprisefeatures
     st2::version: 1.0.0
     st2::revision: 1
+    hubot::docker: True
     hubot::chat_alias: "!"
     hubot::adapter: "hipchat"
     hubot::env_export:


### PR DESCRIPTION
If you're trying to use answers.yaml to automate installation of stackstorm including chatops setup, `hubot::docker: True` is required, if you don't want to use the webgui installer. This adds documentation for that to the docs.