### PR TITLE
Auto generate a list with overridable runner parameter attributes

### DIFF
--- a/docs/source/_includes/runner_parameters_overridable_attributes.rst
+++ b/docs/source/_includes/runner_parameters_overridable_attributes.rst
@@ -1,0 +1,5 @@
+* default
+* description
+* enum
+* immutable
+* required

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -277,11 +277,14 @@ linux.rsync action.
 
 .. literalinclude:: /../../st2/contrib/linux/actions/rsync.yaml
 
-Not all attributes for the runner parameters can be overridden. Only ``default``, ``description``,
-``enum``, ``immutable``, and ``required`` attributes can be overridden. Overriding attributes such
-as ``type`` and ``position`` are not allowed because overriding them can potentially break the
-action since the runner will not be able to consume the type of value being passed (i.e. runner
-parameter is expecting an integer but a string is passed).
+Not all attributes for the runner parameters can be overridden. A list of attributes which can be
+overriden is included below.
+
+.. include:: _includes/runner_parameters_overridable_attributes.rst
+
+Overriding attributes such as ``type`` and ``position`` are not allowed because overriding them can
+potentially break the action since the runner will not be able to consume the type of value being
+passed (i.e. runner parameter is expecting an integer but a string is passed).
 
 Common environment variables available to the actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/scripts/generate-overridable-runner-parameter-attributes-list.py
+++ b/scripts/generate-overridable-runner-parameter-attributes-list.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Script which generates a list with runner parameter attributes which can be
+overriden inside an action.
+"""
+
+import os
+
+from st2common.util.schema import RUNNER_PARAM_OVERRIDABLE_ATTRS
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+HEADER = '.. NOTE: This file has been generated automatically, don\'t manually edit it'
+
+
+def main():
+    result = []
+    for attribute_name in RUNNER_PARAM_OVERRIDABLE_ATTRS:
+        result.append('* %s' % (attribute_name))
+
+    path = '../docs/source/_includes/runner_parameters_overridable_attributes.rst'
+    destination_path = os.path.join(CURRENT_DIR, path)
+    result = '\n'.join(result)
+
+    with open(destination_path, 'w') as fp:
+        fp.write(result)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Instead of hard-coding it, we now auto generate it.