### PR TITLE
RFR: Add examples for ssl_cert and ssl_key specification in answers.yaml

### DIFF
--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -295,24 +295,24 @@ How do I specify st2_ssl_cert and st2_ssl_key in answers.yaml file?
 
 If you have your own SSL cert and key and want to supply it with answers.yaml file, you can do so. This has been tested and reported as working by users.
 
-```
-st2_ssl_cert: ! '-----BEGIN CERTIFICATE-----
-  LINE 1
-  LINE 2
-  LINE 3
-  LINE 4
-  ....
-  -----END CERTIFICATE-----
-'
+.. yaml
+    st2_ssl_cert: ! '-----BEGIN CERTIFICATE-----
+      LINE 1
+      LINE 2
+      LINE 3
+      LINE 4
+      ....
+      -----END CERTIFICATE-----
+    '
 
-st2_ssl_key: ! '-----BEGIN RSA PRIVATE KEY-----
-  LINE 1
-  LINE 2
-  LINE 3
-  ....
-  -----END RSA PRIVATE KEY-----
-'
-```
+    st2_ssl_key: ! '-----BEGIN RSA PRIVATE KEY-----
+      LINE 1
+      LINE 2
+      LINE 3
+      ....
+      -----END RSA PRIVATE KEY-----
+    '
+
 
 Note the usage of ``!``. Other multi-line string markers in YAML might work (YMMV).
 

--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -290,6 +290,32 @@ Example Answers File
       "hubot-hipchat": ">=2.12.0 < 3.0.0"
       "hubot-stackstorm": ">= 0.1.0 < 0.2.0"
 
+How do I specify st2_ssl_cert and st2_ssl_key in answers.yaml file?
+####################################################################
+
+If you have your own SSL cert and key and want to supply it with answers.yaml file, you can do so. This has been tested and reported as working by users.
+
+```
+st2_ssl_cert: ! '-----BEGIN CERTIFICATE-----
+  LINE 1
+  LINE 2
+  LINE 3
+  LINE 4
+  ....
+  -----END CERTIFICATE-----
+'
+
+st2_ssl_key: ! '-----BEGIN RSA PRIVATE KEY-----
+  LINE 1
+  LINE 2
+  LINE 3
+  ....
+  -----END RSA PRIVATE KEY-----
+'
+```
+
+Note the usage of ``!``. Other multi-line string markers in YAML might work (YMMV).
+
 Updating
 ########
 

--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -295,7 +295,8 @@ How do I specify st2_ssl_cert and st2_ssl_key in answers.yaml file?
 
 If you have your own SSL cert and key and want to supply it with answers.yaml file, you can do so. This has been tested and reported as working by users.
 
-.. yaml
+.. sourcecode:: yaml
+
     st2_ssl_cert: ! '-----BEGIN CERTIFICATE-----
       LINE 1
       LINE 2


### PR DESCRIPTION
Thanks to @logikal for finding the solution and testing it. 

https://stackstorm-community.slack.com/archives/community/p1452212764011080

https://www.evernote.com/l/ANGHKRG1inlCw7HTRxikIRNOlYqVZ8pa79IB/image.png