### PR TITLE
HipChat mention in the ChatOps plaintext formatting

### DIFF
--- a/docs/source/chatops/aliases.rst
+++ b/docs/source/chatops/aliases.rst
@@ -256,10 +256,10 @@ Same as with `ack`, you can configure `result` to disable result messages or set
 
 To disable the result message, you can use the `enabled` flag same way as in `ack`.
 
-Plaintext/attachment (slack-only)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Plaintext messages (Slack and HipChat)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Slack uses attachments to format the result message. While we found attachments to be the best way to handle very long messages (which StackStorm execution results tend to be), sometimes you want part of your message — or all of it — in plaintext. Use `{~}` as a delimiter to do that:
+Result messages tend to be quite long, and Hubot will utilize extra formatting capabilities of some chat clients: Slack messages will be sent as attachments, and HipChat messages are formatted as code blocks. While this is a good fit in most cases, sometimes you want part of your message — or all of it — in plaintext. Use `{~}` as a delimiter to split a message into a plaintext/attachment pair:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
We support the plaintext delimiter in HipChat now, so the docs should be updated accordingly.