### PR TITLE
Add a toctree to development/index.rst with links to other pages.

### DIFF
--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -193,3 +193,10 @@ us to perform basic "static" analysis on the code.
 .. _`PEP8 Python Style Guide`: http://www.python.org/dev/peps/pep-0008/
 .. _irc`: http://webchat.freenode.net/?channels=stackstorm
 .. _`Docstring conventions`: https://libcloud.readthedocs.org/en/latest/development.html#docstring-conventions
+
+.. toctree::
+    :maxdepth: 1
+
+    Code Structure <code_structure>
+    testing
+    Pack Testing <pack_testing>

--- a/docs/source/development/pack_testing.rst
+++ b/docs/source/development/pack_testing.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Pack Testing
 ============
 

--- a/docs/source/development/testing.rst
+++ b/docs/source/development/testing.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Testing
 =======
 


### PR DESCRIPTION
I've found the code_structure, pack_testing and testing hard to find
as they were hidden as small links within the body of text. So this PR
adds a toctree with the 3 other pages under development.