### PR TITLE
correct stanley sudoers.d permission

### DIFF
--- a/docs/source/config/config.rst
+++ b/docs/source/config/config.rst
@@ -68,7 +68,7 @@ To run actions on remote hosts, |st2| uses SSH. It is advised to configure ident
 
 |st2| ssh user and a path to SSH key are set in ``/etc/st2/st2.conf``. During installation, ``st2_deploy.sh`` script configures ssh on the local box for a user `stanley`.
 
-Follow these steps on a remote box to setup `stanley` user on remote boxes.
+Follow these steps on a remote box to setup `stanley` user on remote boxes. You will need elevated privileges (root) to do this.
 
 .. code-block:: bash
 
@@ -85,6 +85,7 @@ Follow these steps on a remote box to setup `stanley` user on remote boxes.
     chmod 0600 /home/stanley/.ssh/authorized_keys
     chown -R stanley:stanley /home/stanley
     echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
+    chmod 0440 /etc/sudoers.d/st2
 
     # ensure requiretty is not set to default in the /etc/sudoers file.
 

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -75,7 +75,7 @@ Configure SSH and SUDO
 To run local and remote shell actions, StackStorm uses a special system user (default ``stanley``).
 For remote linux actions, SSH is used. It is advised to configure identity file based SSH access on all remote hosts. We also recommend configuring SSH access to localhost for running examples and testing.
 
-* Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so that SSH-based action can be tried and tested locally. You will need elevated privileges to do this.
+* Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so that SSH-based action can be tried and tested locally. You will need elevated privileges (root) to do this.
 
   .. code-block:: bash
 
@@ -94,6 +94,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
 
     # Enable passwordless sudo
     echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
+    chmod 0440 /etc/sudoers.d/st2
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.


### PR DESCRIPTION
This is a MUST. Otherwise privileged access is broken if there's no direct ability to login as `root`. Since after breaking sudo, there's no chance for `sudo -i` or `sudo su` anymore. It's haters issue)
