### PR TITLE
Add more prominent link to the YAQL evaluator website

### DIFF
--- a/docs/source/mistral_yaql.rst
+++ b/docs/source/mistral_yaql.rst
@@ -259,6 +259,5 @@ Testing YAQL Expressions
 The best and fastest way to test YAQL expression on your data is to use the online YAQL evaluator
 at http://yaqluator.com/.
 
-This YAQL evaluator allows you to provide sample data and YAQL expression which you can evaluate
-in real time and see the result. This comes especially handy when working with more complex
-expressions.
+The website allows you to provide sample data and YAQL expression which you can evaluate in real
+time and see the result. This comes especially handy when working with more complex expressions.

--- a/docs/source/mistral_yaql.rst
+++ b/docs/source/mistral_yaql.rst
@@ -1,5 +1,6 @@
 Mistral + YAQL
 ==============
+
 YAQL is typically used for simple conditional evaulation and data transformation in Mistral
 workflows. There will be many cases where you did not author the actions but there's a need to
 decide from the result of the action whether to continue or there's a need to transform the
@@ -251,3 +252,13 @@ documentation and git repo to explore more options.
 * ``env()`` returns the environment variables passed to the workflow execution on invocation such as the StackStorm Action Execution ID ``st2_execution_id``. For example, the expression ``<% env().st2_action_api_url %>/actionexecutions/<% env().st2_execution_id %>`` returns the API endpoint for the current workflow execution in StackStorm as something like ``https://127.0.0.1:9101/v1/actionexecutions/874d3d5b3f024c1aa93225ef0bcfcf3a``.
 * To access infomation about the parent action like in an ActionChain with ``{{action_context.parent.source_channel}}``, ``{{action_context.parent.user`` or ``{{action_context.parent.api_user}}``. The following expressions can be used ``<% env().get('__actions').get('st2.action').st2_context.parent.api_user %>``, ``<% env().get('__actions').get('st2.action').st2_context.parent.source_channel %>`` or ``<% env().get('__actions').get('st2.action').st2_context.parent.user %>``.
 * ``task(task_name)`` returns the state, state_info, and result of task given task_name.
+
+Testing YAQL Expressions
+++++++++++++++++++++++++
+
+The best and fastest way to test YAQL expression on your data is to use the online YAQL evaluator
+at http://yaqluator.com/.
+
+This YAQL evaluator allows you to provide sample data and YAQL expression which you can evaluate
+in real time and see the result. This comes especially handy when working with more complex
+expressions.


### PR DESCRIPTION
It turns out we already link to that website, but we only link to it on the Mistral page and there are no links to it in the YAQL section of our documentation.