### PR TITLE
ssh owning inconsistencies

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -110,8 +110,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
 
     # Authorize key-base acces
     sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-    sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-    sudo chown -R stanley:stanley /home/stanley
+    sudo chown -R stanley:stanley /home/stanley/.ssh
 
     # Enable passwordless sudo
     sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -183,8 +183,7 @@ testing.
 
     # Authorize key-base acces
     sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-    sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-    sudo chown -R stanley:stanley /home/stanley
+    sudo chown -R stanley:stanley /home/stanley/.ssh
 
     # Enable passwordless sudo
     sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -154,8 +154,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
 
     # Authorize key-base acces
     sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-    sudo chmod 0600 /home/stanley/.ssh/authorized_keys
-    sudo chown -R stanley:stanley /home/stanley
+    sudo chown -R stanley:stanley /home/stanley/.ssh
 
     # Enable passwordless sudo
     sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'


### PR DESCRIPTION
`authorized_keys` is a list of **public** keys which are allowed to use key-based logins. Setting mode to `0600` doesn't make any sense, even if a user can not read `/home/stanley/.ssh/authorized_keys`, well he can always read `/home/stanley/.ssh/stanley_rsa.pub` which has been created without such restrictive permissions. So setting `0600` for `authorized_keys` is quite ambiguous... 

