### PR TITLE
Remove 'd' from enabled for setting up auth using debs

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -200,7 +200,7 @@ Reference deployment uses File Based auth provider for simplicity. Refer to :doc
 
     [auth]
     # ...
-    enabled = True
+    enable = True
     backend = flat_file
     backend_kwargs = {"file_path": "/etc/st2/htpasswd"}
     # ...


### PR DESCRIPTION
Reported in community by @ogenstad.

The config file has `enable` and the docs say `enabled` so it's a little confusing.