### PR TITLE
Add a note about st2auth requirements when using PAM auth backend with the new packages

### DIFF
--- a/docs/source/install/__pam_auth_backend_requirements.rst
+++ b/docs/source/install/__pam_auth_backend_requirements.rst
@@ -1,0 +1,8 @@
+.. note::
+
+    When using ``pam`` authentication backend you need to make sure that
+    ``st2auth`` process runs as ``root`` system user otherwise the
+    authentication will fail. For security reasons ``st2auth`` process runs
+    under ``st2`` user by default. If you want to use ``pam`` auth backend and
+    change it to run as ``root``, you can do that by editing service manager
+    file for the ``st2`` auth service.

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -183,9 +183,12 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
-Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
+Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
+to configure and use PAM or LDAP autentication backends. 
 
 .. include:: __pam_auth_backend_requirements.rst
+
+To set up authentication with File Based provider:
 
 * Create a user with a password:
 

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -183,6 +183,8 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
+.. include:: __pam_auth_backend_requirements.rst
+
 Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
 
 * Create a user with a password:

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -183,9 +183,9 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
-.. include:: __pam_auth_backend_requirements.rst
-
 Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
+
+.. include:: __pam_auth_backend_requirements.rst
 
 * Create a user with a password:
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -258,6 +258,8 @@ and no money without Enterprise edition. Read on, move on!
 Configure Authentication
 ------------------------
 
+.. include:: __pam_auth_backend_requirements.rst
+
 Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
 
 * Create a user with a password:

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -258,9 +258,12 @@ and no money without Enterprise edition. Read on, move on!
 Configure Authentication
 ------------------------
 
-Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
+Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
+to configure and use PAM or LDAP autentication backends. 
 
 .. include:: __pam_auth_backend_requirements.rst
+
+To set up authentication with File Based provider:
 
 * Create a user with a password:
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -258,9 +258,9 @@ and no money without Enterprise edition. Read on, move on!
 Configure Authentication
 ------------------------
 
-.. include:: __pam_auth_backend_requirements.rst
-
 Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
+
+.. include:: __pam_auth_backend_requirements.rst
 
 * Create a user with a password:
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -227,9 +227,9 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
-.. include:: __pam_auth_backend_requirements.rst
-
 Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
+
+.. include:: __pam_auth_backend_requirements.rst
 
 * Create a user with a password:
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -227,6 +227,8 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
+.. include:: __pam_auth_backend_requirements.rst
+
 Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
 
 * Create a user with a password:

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -227,9 +227,12 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
-Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication` to configure and use PAM or LDAP autentication backends. To set up authentication with File Based provider:
+Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
+to configure and use PAM or LDAP autentication backends. 
 
 .. include:: __pam_auth_backend_requirements.rst
+
+To set up authentication with File Based provider:
 
 * Create a user with a password:
 


### PR DESCRIPTION
Previously when using AIO installer, the ``st2auth`` process ran as root (yeah, I know, terrible) so this was not an issue unless user didn't use AIO installer and used a custom deployment.