### PR TITLE
Add deprecation notices to the old and out-of-date installation methods

### DIFF
--- a/docs/source/install/__packages_beta_warning.rst
+++ b/docs/source/install/__packages_beta_warning.rst
@@ -1,7 +1,1 @@
-.. warning::
 
-   Packages based installation is currently is beta and upgrades are not yet
-   supported.
-
-   If you encounter any bugs, please report them at
-   `github.com/StackStorm/st2-packages <https://github.com/StackStorm/st2-packages/issues/new>`_.

--- a/docs/source/install/__packages_beta_warning.rst
+++ b/docs/source/install/__packages_beta_warning.rst
@@ -1,0 +1,7 @@
+.. warning::
+
+   Packages based installation is currently is beta and upgrades are not yet
+   supported.
+
+   If you encounter any bugs, please report them at
+   `github.com/StackStorm/st2-packages <https://github.com/StackStorm/st2-packages/issues/new>`_.

--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -1,5 +1,13 @@
 All-in-one Installer
 ********************
+
+.. note::
+
+    All-in-one Installer has been deprecated and replaced with packages which are now preferred
+    way of installing |st2|.
+    For more more information, please see distribution-specific package based installation
+    instructions - :doc:`deb`, :doc:`rhel6`, :doc:`rhel7`.
+
 |st2| provides an all-in-one installer aimed at assisting users with the initial setup and
 configuration for quick and convenient evaluation.
 

--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 All-in-one Installer
 ********************
 

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -1,21 +1,14 @@
 Ubuntu / Debian
 ===============
 
+.. include:: __packages_beta_warning.rst
+
 This guide provides step-by step instructions on installing StackStorm on a single box per
 :doc:`Reference deployment </install/overview>` on a Ubuntu/Debian. A script `st2bootstrap-deb.sh
 <https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-deb.sh>`_, codifies the
 instructions below.
 
-.. warning :: Currently in BETA! Upgrades are being tested, but will be supprted only once packages graduate
-    from BETA, likely from 1.4 onwards. At that point, package-based installation will be
-    the preferred path to installing StackStorm.
-
-    Please try, use and report bugs on
-    `github.com/StackStorm/st2-packages <https://github.com/StackStorm/st2-packages/issues/new>`_.
-
-
 .. contents::
-
 
 Supported versions
 ------------------

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -1,10 +1,8 @@
 Installation
 ============
 
-For a quick evaluation of StackStorm, get a clean box and fast-forward to :doc:`all_in_one`.
-
-For package-based installation, start from :doc:`Overview <./overview>`, and proceed with
-the guide for your Linux distribution.
+For a quick evaluation of |st2| and package-based installation, start from
+:doc:`Overview <./overview>`, and proceed with the guide for your Linux distribution.
 
 
 .. rubric:: Installations

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -15,6 +15,4 @@ For a quick evaluation of |st2| and package-based installation, start from
     RHEL 7 / CentOS 7 <rhel7>
     RHEL 6 / CentOS 6 <rhel6>
     StackStorm Enterprise <enterprise>
-    All-In-One Installer  <all_in_one>
-    Chef, Puppet, Salt, Ansible <puppet_chef_salt_ansible>
     Updates and Upgrades <upgrades>

--- a/docs/source/install/puppet_chef_salt_ansible.rst
+++ b/docs/source/install/puppet_chef_salt_ansible.rst
@@ -1,13 +1,18 @@
 Installing StackStorm with configuration management tools
 #########################################################
 
+.. note::
+
+    Some of the installation methods described on this page might be out of date. If you experience
+    issues, please follow distribution-specific package based installation instructions.
+
 In this section we gathered the pointers to . Some are used internally by StackStorm, some
 are contributed by our users, some others are community contributions.
 Maintaining this section is a community effort, thus if you are Chef, Ansible, Puppet, or Salt expert,
 your contributions here are very welcome.
 
 .. contents::
-		:depth: 3
+    :depth: 3
 
 Puppet
 ======

--- a/docs/source/install/puppet_chef_salt_ansible.rst
+++ b/docs/source/install/puppet_chef_salt_ansible.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Installing StackStorm with configuration management tools
 #########################################################
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -1,17 +1,12 @@
 RHEL 6 / CentOS 6
 =================
 
+.. include:: __packages_beta_warning.rst
+
 This guide provides step-by step instructions on installing StackStorm on a single box per
 :doc:`Reference deployment </install/overview>` on RHEL 6/CentOS 6. A script `st2bootstrap-el6.sh
 <https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el6.sh>`_, codifies the
 instructions below.
-
-.. warning :: Currently in BETA! Upgrades are being tested, but will be supported only once packages graduate
-    from BETA, likely from 1.4 onwards. At that point, package-based installation will be
-    the preferred path to installing StackStorm.
-
-    Please try, use and report bugs on
-    `github.com/StackStorm/st2-packages <https://github.com/StackStorm/st2-packages/issues/new>`_.
 
 .. contents::
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -1,16 +1,11 @@
 RHEL 7 / CentOS 7
 =================
 
+.. include:: __packages_beta_warning.rst
+
 This guide provides step-by step instructions on installing StackStorm on a single box on RHEL 7/CentOS 7.
 A script `st2bootstrap-el7.sh <https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el7.sh>`_,
 codifies the instructions below.
-
-.. warning :: Currently in BETA! Upgrades are being tested, but will be supported only once packages graduate
-    from BETA, likely from 1.4 onwards. At that point, package-based installation will be
-    the preferred path to installing StackStorm.
-
-    Please try, use and report bugs on
-    `github.com/StackStorm/st2-packages <https://github.com/StackStorm/st2-packages/issues/new>`_.
 
 .. contents::
 


### PR DESCRIPTION
Users are keep stumbling on out of date instructions and AIO installer issue and this PR clears things up a bit.

* Remove big red warning from the packages installation pages - package are preferred installation method going forward.
* Add deprecation notice to the "AIO" installer page.
* Add "out of date" notice to the Chef / Puppet / Salt / Ansible installation page
* Drop link to the AIO page in the "Installation" index page

## TODO / To decide

- [x] Remove AIO entry from "Installation" TOC
- [x] Remove Chef / Puppet / Salt / Ansible entry from "Installation" TOC