### PR TITLE
Update section for the LDAP auth backend

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -98,25 +98,31 @@ LDAP
 The LDAP backend authenticates user against an LDAP server. The following is a list of
 configuration options for the backend.
 
-+----------+----------+---------+------------------------------------------------------------+
-| option   | required | default | description                                                |
-+==========+==========+=========+============================================================+
-| users_ou | yes      |         | OU of the user accounts                                    |
-+----------+----------+---------+------------------------------------------------------------+
-| host     | yes      |         | Hostname of the LDAP server                                |
-+----------+----------+---------+------------------------------------------------------------+
-| port     | yes      |         | Port of the LDAP server                                    |
-+----------+----------+---------+------------------------------------------------------------+
-| use_ssl  | no       | false   | Use LDAPS to connect                                       |
-+----------+----------+---------+------------------------------------------------------------+
-| use_tls  | no       | false   | Start TLS on LDAP to connect                               |
-+----------+----------+---------+------------------------------------------------------------+
-| cacert   | no       | None    | Path to the CA cert used to validate certificate           |
-+----------+----------+---------+------------------------------------------------------------+
-| id_attr  | no       | uid     | Field name of the user ID attribute                        |
-+----------+----------+---------+------------------------------------------------------------+
-| scope    | no       | subtree | Search scope (base, onelevel, or subtree)                  |
-+----------+----------+---------+------------------------------------------------------------+
++---------------+----------+---------+------------------------------------------------------------+
+| option        | required | default | description                                                |
++===============+==========+=========+============================================================+
+| bind_dn       | yes      |         | DN of the service account to bind with the LDAP server     |
++---------------+----------+---------+------------------------------------------------------------+
+| bind_password | yes      |         | Password of the service account                            |
++---------------+----------+---------+------------------------------------------------------------+
+| base_ou       | yes      |         | Base OU to search for user and group entries               |
++---------------+----------+---------+------------------------------------------------------------+
+| group_dns     | yes      |         | User must be member of this list of groups to get access   |
++---------------+----------+---------+------------------------------------------------------------+
+| host          | yes      |         | Hostname of the LDAP server                                |
++---------------+----------+---------+------------------------------------------------------------+
+| port          | yes      |         | Port of the LDAP server                                    |
++---------------+----------+---------+------------------------------------------------------------+
+| use_ssl       | no       | false   | Use LDAPS to connect                                       |
++---------------+----------+---------+------------------------------------------------------------+
+| use_tls       | no       | false   | Start TLS on LDAP to connect                               |
++---------------+----------+---------+------------------------------------------------------------+
+| cacert        | no       | None    | Path to the CA cert used to validate certificate           |
++---------------+----------+---------+------------------------------------------------------------+
+| id_attr       | no       | uid     | Field name of the user ID attribute                        |
++---------------+----------+---------+------------------------------------------------------------+
+| scope         | no       | subtree | Search scope (base, onelevel, or subtree)                  |
++---------------+----------+---------+------------------------------------------------------------+
 
 The following is a sample auth section for the LDAP backend in the st2 config file.
 
@@ -125,13 +131,13 @@ The following is a sample auth section for the LDAP backend in the st2 config fi
     [auth]
     mode = standalone
     backend = ldap
-    backend_kwargs = {"users_ou": "ou=users,dc=example,dc=com", "host": "identity.example.com", "port": 636, "use_ssl": true, "cacert": "/path/to/cacert.pem"}
+    backend_kwargs = {"bind_dn": "CN=st2admin,ou=users,dc=example,dc=com", "bind_password": "foobar123", "base_ou": "dc=example,dc=com", "group_dns": ["CN=st2users,ou=groups,dc=example,dc=com", "CN=st2developers,ou=groups,dc=example,dc=com"], "host": "identity.example.com", "port": 636, "use_ssl": true, "cacert": "/path/to/cacert.pem"}
     enable = True
     use_ssl = True
     cert = /path/to/mycert.crt
     key = /path/to/mycert.key
     logging = /path/to/st2auth.logging.conf
-    api_url = https://myhost.example.com/api/
+    api_url = https://myhost.example.com:9101/
     debug = False
 
 Running the Service

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -31,6 +31,12 @@ Upgrade Notes
   More information about new positional parameter serialization rules can be found in the
   :ref:`documentation<ref-positional-parameters-serialization>`.
 
+* The list of required and optional configuration arguments for the LDAP auth backend has changed.
+  The LDAP auth backend supports other login name such as sAMAccountName. This requires a separate
+  service account for the LDAP backend to query for the DN related to the login name for bind to
+  validate the user password. Also, users must be in one or more groups specified in group_dns to
+  be granted access. 
+
 |st2| 1.3
 ---------
 


### PR DESCRIPTION
The list of required and optional backend kwargs has changed to accomodate additional support for Active Directory.