### PR TITLE
Use a less strict modified which allows multiple spaces in /etc/sudoers file

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -118,6 +118,9 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
     sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
     sudo chmod 0440 /etc/sudoers.d/st2
 
+    # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
+    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.
   To control Windows boxes, configure access for :doc:`Windows runners </config/windows_runners>`.

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -119,7 +119,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
     sudo chmod 0440 /etc/sudoers.d/st2
 
     # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -191,7 +191,7 @@ testing.
     sudo chmod 0440 /etc/sudoers.d/st2
 
     # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -191,7 +191,7 @@ testing.
     sudo chmod 0440 /etc/sudoers.d/st2
 
     # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -162,7 +162,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
     sudo chmod 0440 /etc/sudoers.d/st2
 
     # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
+    sudo sed -i -r s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -162,7 +162,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
     sudo chmod 0440 /etc/sudoers.d/st2
 
     # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+    sudo sed -i -r s/^Defaults\s+\+requiretty/# Defaults requiretty/g" /etc/sudoers
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.


### PR DESCRIPTION
Modified the sed regular expression to allow multiple spaces and performs the same on Ubuntu (if that line is not present it's a no-op so it's not a big deal).