### PR TITLE
Fixed v1.4 typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ actions in response to events. Learn more at [www.stackstorm.com](http://www.sta
 # Writing the Docs
 
 Product documentation for StackStorm is maintained in this repository. These docs are built using
-[sphinx](http://www.sphinx-doc.org/en/stable/).
+[Sphinx](http://www.sphinx-doc.org/en/stable/).
 
 ## Contributing
 
-* Fork this repo on github. (https://help.github.com/articles/fork-a-repo/)
-* Make changes to the docs using your favorite editor
-* To update docs for the latest i.e. unstable release of StackStorm base changes of the `master` branch.
+* Fork this repo on GitHub (https://help.github.com/articles/fork-a-repo/).
+* Make changes to the docs using your favorite editor.
+* To update docs for the latest - i.e. unstable - release of StackStorm, base your changes off the `master` branch.
 * To update docs for a released version of StackStorm pick the appropriate version branch (v1.2 etc) and make changes.
 * Push changes to your fork.
 * Create a pull request (https://help.github.com/articles/creating-a-pull-request/) against StackStorm/st2docs repository
@@ -23,11 +23,11 @@ Product documentation for StackStorm is maintained in this repository. These doc
 
 ## Build and Run the Docs.
 
-Follows these steps to build the docs locally -
+Follows these steps to build the docs locally:
 
 ```bash
- git clone https://github.com/StackStorm/st2docs.git
- cd st2docs
+git clone https://github.com/StackStorm/st2docs.git
+cd st2docs
 make docs
 ```
 
@@ -39,7 +39,7 @@ validate changes locally prior to committing any code.
 
 ## Sphinx Tricks
 
-* If the whole section belongs Enterprise Edition, put the following note:
+* If the whole section belongs in the Enterprise Edition, put the following note:
     ```
     .. note::
 
@@ -72,7 +72,7 @@ validate changes locally prior to committing any code.
 
          .. _sensors-examples:
 
-    and point to it as from this, or from other documensts as:
+    and point to it as from this, or from other documents as:
 
            :ref:`sensors-examples`
            :ref:`My examples <sensors-examples>`

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -18,8 +18,8 @@ implemented as actions:
 * run nagios check
 
 Actions can be executed when a :doc:`Rule </rules>` with a matching criteria is triggered.
-Multiple Actions can be stringed together into a :doc:`Workflow </workflows>`. And each action can
-be executed directly from the clients via CLI, API, or UI.
+Multiple Actions can be strung together into a :doc:`Workflow </workflows>`. Actions can
+also be executed directly from the clients via CLI, API, or UI.
 
 Managing and Running Actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ Currently the system provides the following runners:
    :doc:`CloudSlang </cloudslang>` section of documentation.
 
    Note: This runner is currently in an experimental phase which means that there might be
-   bugs and the external user facing API might change.
+   bugs and the external user-facing API might change.
 
 Runners come with their own set of input parameters and when an action
 picks a runner\_type it also inherits the runner parameters.
@@ -130,7 +130,7 @@ language, as long as it follows some simple conventions described below:
 
 1. Script should exit with ``0`` status code on success and non-zero on error
    (e.g. ``1``)
-2. All the log messages should be printed to standard error
+2. All log messages should be printed to standard error
 
 Action metadata
 ~~~~~~~~~~~~~~~

--- a/docs/source/chatops/aliases.rst
+++ b/docs/source/chatops/aliases.rst
@@ -109,7 +109,7 @@ Using example -
       - "google {{query=StackStorm}}"
 
 In this case the query has a default value assigned which will be used if not value is provided by user.
-Therefore,  simple ``google`` instead of ``google StackStorm`` would still result in assumption of the
+Therefore, simple ``google`` instead of ``google StackStorm`` would still result in assumption of the
 default value much like how an Action default parameter values are interpretted.
 
 Regular expressions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'StackStorm'
-copyright = u'2014, StackStorm Inc'
+copyright = u'2016, StackStorm Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/install/__pam_auth_backend_requirements.rst
+++ b/docs/source/install/__pam_auth_backend_requirements.rst
@@ -1,8 +1,8 @@
 .. note::
 
     When using ``pam`` authentication backend you need to make sure that
-    ``st2auth`` process runs as ``root`` system user otherwise the
+    the ``st2auth`` process runs as ``root`` system user otherwise the
     authentication will fail. For security reasons ``st2auth`` process runs
     under ``st2`` user by default. If you want to use ``pam`` auth backend and
-    change it to run as ``root``, you can do that by editing service manager
+    change it to run as ``root``, you can do that by editing the service manager
     file for the ``st2`` auth service.

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -1,9 +1,9 @@
 Ubuntu / Debian
 ===============
 
-This guide provides step-by step instructions on installing StackStorm on a single box per
-:doc:`Reference deployment </install/overview>` on a Ubuntu/Debian. A script `st2bootstrap-deb.sh
-<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-deb.sh>`_, codifies the
+This guide provides step-by step instructions for installing StackStorm on a single Ubuntu/Debian system per
+the :doc:`Reference deployment </install/overview>`. The script `st2bootstrap-deb.sh
+<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-deb.sh>`_ codifies the
 instructions below.
 
 .. contents::
@@ -12,12 +12,12 @@ Supported versions
 ------------------
 
 We support Ubuntu 14.04, and test on `Ubuntu Server 14.04 LTS (HVM) Amazon AWS AMI <https://aws.amazon.com/marketplace/pp/B00JV9TBA6/ref=srh_res_product_title?ie=UTF8&sr=0-3&qid=1457037882965>`_
-and `puppetlabs/ubuntu-14.04-64-nocm Vagrant box <https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-14.04-64-nocm>`_. Other Debian based distributions and versions will likely work with some tweaks, you are welcome to try and report success to the `community <https://stackstorm.com/community-signup>`_.
+and `puppetlabs/ubuntu-14.04-64-nocm Vagrant box <https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-14.04-64-nocm>`_. Other Debian based distributions and versions will likely work with some tweaks. You are welcome to try - please report success to the `community <https://stackstorm.com/community-signup>`_.
 
 Sizing the server
 -----------------
-While the system can operate with less equipped servers, these are recommended
-for the best experience while testing or deploying |st2|.
+While the system can operate with lower specs, these are the recommendations
+for the best experience while testing or deploying |st2|:
 
 +--------------------------------------+-----------------------------------+
 |            Testing                   |         Production                |
@@ -43,11 +43,11 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
 Setup repositories
 ~~~~~~~~~~~~~~~~~~~
 
-The following script will detect your platform and architecture and setup the repo accordingly. It'll also install the GPG key for repo signing.
+The following script will detect your platform and architecture and setup the repo accordingly. It will also install the GPG key for repo signing.
 
   .. code-block:: bash
 
-    curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.deb.sh | sudo bash
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.deb.sh | sudo bash
 
 
 Install StackStorm components
@@ -58,7 +58,7 @@ Install StackStorm components
       sudo apt-get install -y st2 st2mistral
 
 
-If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or changed defaults,
+If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or have changed defaults,
 please adjust the settings:
 
     * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
@@ -86,13 +86,13 @@ Setup Mistral Database
 Configure SSH and SUDO
 ~~~~~~~~~~~~~~~~~~~~~~
 To run local and remote shell actions, StackStorm uses a special system user (default ``stanley``).
-For remote linux actions, SSH is used. It is advised to configure identity file based SSH access on all remote hosts. We also recommend configuring SSH access to localhost for running examples and testing.
+For remote Linux actions, SSH is used. It is advised to configure identity file based SSH access on all remote hosts. We also recommend configuring SSH access to localhost for running examples and testing.
 
 * Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so that SSH-based action can be tried and tested locally. You will need elevated privileges to do this.
 
   .. code-block:: bash
 
-    # Create an SSH system user (default `stanley` user may be already created)
+    # Create an SSH system user (default `stanley` user may already exist)
     sudo useradd stanley
     sudo mkdir -p /home/stanley/.ssh
     sudo chmod 0700 /home/stanley/.ssh
@@ -100,7 +100,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
     # On StackStorm host, generate ssh keys
     sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
 
-    # Authorize key-base acces
+    # Authorize key-based access
     sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
     sudo chown -R stanley:stanley /home/stanley/.ssh
 
@@ -176,8 +176,8 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
-Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
-to configure and use PAM or LDAP autentication backends.
+The reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
+to configure and use PAM or LDAP authentication backends.
 
 .. include:: __pam_auth_backend_requirements.rst
 
@@ -251,7 +251,7 @@ certificates under ``/etc/ssl/st2``, and configure nginx with StackStorm's suppl
 
     sudo service nginx restart
 
-If you modify ports, or url paths in nginx configuration, make correspondent changes in st2web
+If you modify ports, or url paths in the nginx configuration, make the corresponding changes in st2web
 configuration at ``/opt/stackstorm/static/webui/config.js``.
 
 Use your browser to connect to ``https://${ST2_HOSTNAME}`` and login to the WebUI.
@@ -280,12 +280,12 @@ If you already run a Hubot instance, you only have to install the `hubot-stackst
 
 * Review and edit ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to your
   StackStorm installation and Chat Service you are using. By default ``st2api`` and ``st2auth``
-  are expected to be on the same host. If it's not the case, please update ``ST2_API`` and
+  are expected to be on the same host. If that is not the case, please update ``ST2_API`` and
   ``ST2_AUTH_URL`` variables or just point to correct host with ``ST2_HOSTNAME`` variable. Use
   `ST2_WEBUI_URL` if an external address of your StackStorm host is different.
 
   The example configuration uses Slack; go to Slack web admin interface, create a Bot, and copy the authentication token into ``HUBOT_SLACK_TOKEN``.
-  If you are using other Chat Service, set correspondent environment variables under
+  If you are using a different Chat Service, set corresponding environment variables under
   `Chat service adapter settings`:
   `Slack <https://github.com/slackhq/hubot-slack>`_,
   `HipChat <https://github.com/hipchat/hubot-hipchat>`_,
@@ -298,7 +298,7 @@ If you already run a Hubot instance, you only have to install the `hubot-stackst
 
       sudo service st2chatops start
 
-* That's it! Go to your Chat room and begin ChatOpsing. Read on :doc:`/chatops/index` section.
+* That's it! Go to your Chat room and begin ChatOpsing. Read more in the :doc:`/chatops/index` section.
 
 Upgrade to Enterprise Edition
 -----------------------------

--- a/docs/source/install/enterprise.rst
+++ b/docs/source/install/enterprise.rst
@@ -1,9 +1,9 @@
 Installing StackStorm Enterprise
 ================================
 
-StackStorm Community Edition is an event-driven DevOps automation platform with all the essential features, suitable for small businesses and teams. It’s free and open source under Apache 2.0 license.
+StackStorm Community Edition is an event-driven DevOps automation platform with all the essential features suitable for small businesses and teams. It’s free and open source under the Apache 2.0 license.
 
-StackStorm Enterprise Edition is installed as an addition to the Community Edition. It adds by adding priority support and enterprise tools such as fine-tuned access control, LDAP integration and Flow, the visual workflow editor.
+StackStorm Enterprise Edition is installed as an addition to the Community Edition. It adds priority support and enterprise tools such as fine-tuned access control, LDAP integration and Flow, the visual workflow editor.
 
 Learn more about StackStorm Enterprise, request a quote, or get an evaluation license at
 `stackstorm.com/product <https://stackstorm.com/product/#enterprise/>`_.
@@ -11,16 +11,6 @@ Learn more about StackStorm Enterprise, request a quote, or get an evaluation li
 To install StackStorm Enterprise, obtain your Enterprise license key and proceed to installation
 steps for :doc:`/install/deb`, :doc:`/install/rhel7`, or :doc:`/install/rhel6`.
 The last step of the instructions is ``st2enterprise``
-
-
-If you choose to use :doc:`/install/all_in_one` (recommended for evaluation on a clean box), you will be
-presented with a screen that prompts for a license key. Check the "Enable enterprise features" and
-input the license key in the field.
-
-For unattended AIO installer, place the license key in the answers.yaml file, as described in
-:ref:`all_in_one-enterprise_configuration_values` section of :doc:`/install/all_in_one`.
-
-.. figure:: /_static/images/enterprise_enter_license.png
 
 .. include:: /__engage.rst
 

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -1,7 +1,7 @@
 Overview: Single-box Reference Deployment
 ==========================================
 
-First, let's review what are the StackStorm components, what is their role, and how they are wired
+First, let's review what the main StackStorm components are, their role, and how they are wired
 together when StackStorm is deployed on a single box. As you follow the installation instructions
 in this section, this is your target "reference deployment".
 
@@ -17,24 +17,24 @@ in this section, this is your target "reference deployment".
 
 1. st2 services
 ----------------
-st2 services provide main |st2| functionality. They are located at ``/opt/stackstorm/st2``,
-share a dedicated Python virtualenv, and configured by /etc/st2/st2.conf.
+st2 services provide the main |st2| functionality. They are located at ``/opt/stackstorm/st2``,
+share a dedicated Python virtualenv, and are configured by /etc/st2/st2.conf.
 
-    * **st2sensorcontainer** runs sensor from ``/opt/stackstorm/packs``. It manages the sensors to
-      be run on a node. It will start, stop and restart based on policy sensor running on a node.
-    * **st2rulesengine** its main function is to evaluate rules when it sees TriggerInstances and
-      decide if an ActionExecution is to be requested. It needs access to MongoDB to locate rules
-      and RabbitMQ to listen for TriggerInstances and request ActionExecutions. The auxiliary purpose
-      of this process is to run all the defined timers.
+    * **st2sensorcontainer** runs sensors from ``/opt/stackstorm/packs``. It manages the sensors to
+      be run on a node. It will start, stop and restart based on policy the sensors running on a node.
+    * **st2rulesengine** evaluates rules when it sees TriggerInstances and decides if an ActionExecution
+      is to be requested. It needs access to MongoDB to locate rules and RabbitMQ to listen for 
+      TriggerInstances and request ActionExecutions. The auxiliary purpose of this process is to 
+      run all the defined timers.
     * **st2actionrunners** run actions from packs under ``/opt/stackstorm/packs`` via a variety of
-      :doc:`/runners`. Runners may require some runner-specific configurations: SSH needs to be
-      configured for running remote actions based on `remote-shell-runner` and `remote-command-runner`,
-      windows prerequisites must be in place to run Windows runners. See :doc:`Runners </runners>`
+      :doc:`/runners`. Runners may require some runner-specific configurations, e.g. SSH needs to be
+      configured for running remote actions based on `remote-shell-runner` and `remote-command-runner`.
+      Windows prerequisites must be in place to run Windows runners. See :doc:`Runners </runners>`
       for details.
-    * **st2resultstracker** keeps track of long-running workflow executions, calling Mistral
+    * **st2resultstracker** keeps track of long-running workflow executions, calling the Mistral
       API endpoint.
-    * **st2notifier** main function is to generate ``st2.core.actiontrigger`` and ``st2.core.notifytrigger``
-      based on the completion of ActionExecution. The auxiliary purpose is to act as a backup scheduler
+    * **st2notifier** generates ``st2.core.actiontrigger`` and ``st2.core.notifytrigger`` based 
+      on the completion of ActionExecution. The auxiliary purpose is to act as a backup scheduler
       for actions that may not have been scheduled.
     * **st2garbagecollector** is an optional service to periodically delete old execution history
       data from the database, per settings in ``/etc/st2/st2.conf``.
@@ -50,8 +50,8 @@ share a dedicated Python virtualenv, and configured by /etc/st2/st2.conf.
 2. st2client
 -------------
 
-``st2client`` is the  CLI and python bindings for StackStorm API. To configure CLI to point to the right
-API, authenticate options, suppressing insecure warnings for self-signed certificates and other
+``st2client`` is the CLI and Python bindings for StackStorm API. To configure CLI to point to the right
+API, authentication options, suppressing insecure warnings for self-signed certificates and other
 conveniences see :doc:`/cli`. ``st2client`` is packaged with ``st2``, or can be installed
 independently.
 
@@ -59,8 +59,8 @@ independently.
 --------------
 
 :doc:`/mistral` is a workflow service component that StackStorm uses for long-running workflows. It
-is packaged as ``st2mistral`` ``.deb`` or ``.rpm``, installed under ``/opt/stackstorm/mistral``,
-runs in a dedicated Python virtualenv, and configured by ``/etc/mistral/mistral.conf``. ``mistral-
+is packaged as ``st2mistral`` ``deb`` or ``rpm``, installed under ``/opt/stackstorm/mistral``,
+runs in a dedicated Python virtualenv, and is configured by ``/etc/mistral/mistral.conf``. ``mistral-
 server`` runs workflow logic and calling actions, reaching out to st2api for action execution
 requests. ``st2mistral`` is a mistral plugin with stackstorm extensions. ``mistral-api`` is an
 internal end-point accessed by ``st2actionrunner`` and ``st2notifier``. In a single-box deployment
@@ -73,7 +73,7 @@ it is restricted to localhost.
   and reverse-proxies REST API endpoints to st2* web services.
 
 * **StackStorm WebUI** (st2web, and flow, for Enterprise Edition) are installed at ``/opt/statckstorm/webui``
-  and configured via ``webui/config.js``. `st2web` comes in it's own ``deb`` and ``rpm``. `Flow` is
+  and configured via ``webui/config.js``. `st2web` comes in its own ``deb`` and ``rpm``. `Flow` is
   deployed with ``st2enterprise`` package. They are HTML5 applications, served as static HTML,
   and calling StackStorm st2auth and st2api REST API endpoints. NGINX proxies st2auth and st2api
   requests through 443 HTTPS port to ``/api`` and ``/auth``.

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -1,9 +1,9 @@
 RHEL 6 / CentOS 6
 =================
 
-This guide provides step-by step instructions on installing StackStorm on a single box per
-:doc:`Reference deployment </install/overview>` on RHEL 6/CentOS 6. A script `st2bootstrap-el6.sh
-<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el6.sh>`_, codifies the
+This guide provides step-by step instructions for installing StackStorm on a single RHEL 6/CentOS 6 system per
+the :doc:`Reference deployment </install/overview>`. The script `st2bootstrap-el6.sh
+<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el6.sh>`_ codifies the
 instructions below.
 
 .. contents::
@@ -17,8 +17,8 @@ and `puppetlabs/centos-6.6-64-nocm Vagrant box <https://atlas.hashicorp.com/pupp
 
 Sizing the server
 -----------------
-While the system can operate with less equipped servers, these are recommended
-for the best experience while testing or deploying |st2|.
+While the system can operate with lower specs, these are the recommendations
+for the best experience while testing or deploying |st2|:
 
 +--------------------------------------+-----------------------------------+
 |            Testing                   |         Production                |
@@ -38,8 +38,8 @@ Install libffi-devel package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RHEL 6 may not ship with ``libffi-devel`` which is a dependency for |st2|.
-If that is the case, set up `server-optional` repository, following instructions at https://access.redhat.com/solutions/265523. Or, find a version of libffi-devel compatible with libffi on the box,
-and install this version of ``libffi-devel```. For example:
+If that is the case, set up `server-optional` repository, following instructions at https://access.redhat.com/solutions/265523. 
+Or, find a version of libffi-devel compatible with libffi on the box, and install this version of ``libffi-devel```. For example:
 
 .. code :: bash
 
@@ -51,11 +51,11 @@ and install this version of ``libffi-devel```. For example:
 Adjust SELinux policies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-If your RHEL/CentOS box has SELinux enforced, please follow these instructions to adjust SELinux
+If your RHEL/CentOS box has SELinux in Enforcing mode, please follow these instructions to adjust SELinux
 policies. This is needed for successful installation. If you are not happy with these policies,
 you may want to tweak them according to your security practices.
 
-* Check if SELinux is enforcing
+* Check if SELinux is enforcing:
 
     .. code-block:: bash
 
@@ -119,7 +119,7 @@ The following script will detect your platform and architecture and setup the re
 
   .. code-block:: bash
 
-    curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.rpm.sh | sudo bash
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
 
 Install StackStorm components
@@ -157,7 +157,7 @@ Configure SSH and SUDO
 ~~~~~~~~~~~~~~~~~~~~~~
 
 To run local and remote shell actions, StackStorm uses a special system user (default ``stanley``).
-For remote linux actions, SSH is used. It is advised to configure identity file based SSH access on
+For remote Linux actions, SSH is used. It is advised to configure identity file based SSH access on
 all remote hosts. We also recommend configuring SSH access to localhost for running examples and
 testing.
 
@@ -174,7 +174,7 @@ testing.
     # On StackStorm host, generate ssh keys
     sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
 
-    # Authorize key-base acces
+    # Authorize key-based access
     sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
     sudo chown -R stanley:stanley /home/stanley/.ssh
 
@@ -250,8 +250,8 @@ and no money without Enterprise edition. Read on, move on!
 Configure Authentication
 ------------------------
 
-Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
-to configure and use PAM or LDAP autentication backends.
+The reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
+to configure and use PAM or LDAP authentication backends.
 
 .. include:: __pam_auth_backend_requirements.rst
 
@@ -325,7 +325,7 @@ certificates under ``/etc/ssl/st2``, and configure nginx with StackStorm's suppl
     sudo service nginx restart
     sudo chkconfig nginx on
 
-If you modify ports, or url paths in nginx configuration, make correspondent chagnes in st2web
+If you modify ports, or url paths in the nginx configuration, make the corresponding changes in st2web
 configuration at ``/opt/stackstorm/static/webui/config.js``.
 
 Use your browser to connect to ``https://${ST2_HOSTNAME}`` and login to the WebUI.
@@ -354,8 +354,8 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
 
 
 * Review and edit ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to your
-  StackStorm   installation and Chat Service you are using. By default ``st2api`` and ``st2auth``
-  are expected to be on the same host. If it's not the case, please update ``ST2_API`` and
+  |st2| installation and Chat Service you are using. By default ``st2api`` and ``st2auth``
+  are expected to be on the same host. If that is not the case, please update ``ST2_API`` and
   ``ST2_AUTH_URL`` variables or just point to correct host with ``ST2_HOSTNAME`` variable. Use
   `ST2_WEBUI_URL` if an external address of your StackStorm host is different.
 
@@ -363,8 +363,8 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
   `create and configure a Bot <https://api.slack.com/bot-users>`_, invite a Bot to the rooms,
   and copy the authentication token into ``HUBOT_SLACK_TOKEN`` variable.
 
-  If you are using other Chat Service, do appropriate bot configurations,
-  and set correspondent environment variables under
+  If you are using a different Chat Service, make the appropriate bot configurations,
+  and set corresponding environment variables under
   `Chat service adapter settings`:
   `Slack <https://github.com/slackhq/hubot-slack>`_,
   `HipChat <https://github.com/hipchat/hubot-hipchat>`_,
@@ -380,7 +380,7 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
       # Starting st2chatops on boot
       sudo chkconfig st2chatops on
 
-* That's it! Go to your Chat room and begin ChatOps-ing. Read on :doc:`/chatops/index` section.
+* That's it! Go to your Chat room and begin ChatOps-ing. Read more in the :doc:`/chatops/index` section.
 
 Upgrade to Enterprise Edition
 -----------------------------

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -1,9 +1,10 @@
 RHEL 7 / CentOS 7
 =================
 
-This guide provides step-by step instructions on installing StackStorm on a single box on RHEL 7/CentOS 7.
-A script `st2bootstrap-el7.sh <https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el7.sh>`_,
-codifies the instructions below.
+This guide provides step-by step instructions for installing StackStorm on a single RHEL 7/CentOS 7 system per
+the :doc:`Reference deployment </install/overview>`. The script `st2bootstrap-el7.sh 
+<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el7.sh>`_ codifies the 
+instructions below.
 
 .. contents::
 
@@ -11,12 +12,12 @@ Supported platforms
 --------------------
 
 We support RedHat 7 / CentOS 7 and test on `Red Hat Enterprise Linux (RHEL) 7.2 (HVM) Amazon AWS AMI <https://aws.amazon.com/marketplace/pp/B019NS7T5I/ref=srh_res_product_title?ie=UTF8&sr=0-2&qid=1457037671547>`_
-and `puppetlabs/centos-7.0-64-nocm Vagrant box <https://atlas.hashicorp.com/puppetlabs/boxes/centos-7.0-64-nocm>`_. Other RPM based distributions and versions will likely work with some tweaks, you are welcome to try and report successes to the `community <https://stackstorm.com/community-signup>`_.
+and `puppetlabs/centos-7.0-64-nocm Vagrant box <https://atlas.hashicorp.com/puppetlabs/boxes/centos-7.0-64-nocm>`_. Other RPM based distributions and versions will likely work with some tweaks. You are welcome to try - please report success to the `community <https://stackstorm.com/community-signup>`_.
 
 Sizing the server
 -----------------
-While the system can operate with less equipped servers, these are recommended
-for the best experience while testing or deploying |st2|.
+While the system can operate with lower specs, these are the recommendations
+for the best experience while testing or deploying |st2|:
 
 +--------------------------------------+-----------------------------------+
 |            Testing                   |         Production                |
@@ -32,11 +33,11 @@ Minimal installation
 Adjust SELinux policies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-If your RHEL/CentOS box has SELinux enforced, please follow these instructions to adjust SELinux
+If your RHEL/CentOS box has SELinux in Enforcing mode, please follow these instructions to adjust SELinux
 policies. This is needed for successful installation. If you are not happy with these policies,
 you may want to tweak them according to your security practices.
 
-* Check if SELinux is enforcing
+* Check if SELinux is enforcing:
 
     .. code-block:: bash
 
@@ -94,7 +95,7 @@ The following script will detect your platform and architecture and setup the re
 
   .. code-block:: bash
 
-    curl -s https://packagecloud.io/install/repositories/StackStorm/staging-stable/script.rpm.sh | sudo bash
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
 
 Install StackStorm components
@@ -105,7 +106,7 @@ Install StackStorm components
       sudo yum install -y st2 st2mistral
 
 
-If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or changed defaults,
+If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or changed the defaults,
 please adjust the settings:
 
     * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
@@ -131,7 +132,7 @@ Setup Mistral Database
 Configure SSH and SUDO
 ~~~~~~~~~~~~~~~~~~~~~~
 To run local and remote shell actions, StackStorm uses a special system user (default ``stanley``).
-For remote linux actions, SSH is used. It is advised to configure identity file based SSH access on all remote hosts. We also recommend configuring SSH access to localhost for running examples and testing.
+For remote Linux actions, SSH is used. It is advised to configure identity file based SSH access on all remote hosts. We also recommend configuring SSH access to localhost for running examples and testing.
 
 * Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so that SSH-based action can be tried and tested locally.
 
@@ -145,7 +146,7 @@ For remote linux actions, SSH is used. It is advised to configure identity file 
     # On StackStorm host, generate ssh keys
     sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
 
-    # Authorize key-base acces
+    # Authorize key-based access
     sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
     sudo chown -R stanley:stanley /home/stanley/.ssh
 
@@ -219,8 +220,8 @@ But there is no joy without WebUI, no security without SSL termination, no fun w
 Configure Authentication
 ------------------------
 
-Reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
-to configure and use PAM or LDAP autentication backends.
+The reference deployment uses File Based auth provider for simplicity. Refer to :doc:`/authentication`
+to configure and use PAM or LDAP authentication backends.
 
 .. include:: __pam_auth_backend_requirements.rst
 
@@ -293,7 +294,7 @@ certificates under ``/etc/ssl/st2``, and configure nginx with StackStorm's suppl
     sudo systemctl restart nginx
     sudo systemctl enable nginx
 
-If you modify ports, or url paths in nginx configuration, make correspondent chagnes in st2web
+If you modify ports, or url paths in the nginx configuration, make the corresponding changes in st2web
 configuration at ``/opt/stackstorm/static/webui/config.js``.
 
 Use your browser to connect to ``https://${ST2_HOSTNAME}`` and login to the WebUI.
@@ -330,8 +331,8 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
   `create and configure a Bot <https://api.slack.com/bot-users>`_, invite a Bot to the rooms,
   and copy the authentication token into ``HUBOT_SLACK_TOKEN`` variable.
 
-  If you are using other Chat Service, do appropriate bot configurations,
-  and set correspondent environment variables under
+  If you are using a different Chat Service, make the appropriate bot configurations,
+  and set corresponding environment variables under
   `Chat service adapter settings`:
   `Slack <https://github.com/slackhq/hubot-slack>`_,
   `HipChat <https://github.com/hipchat/hubot-hipchat>`_,
@@ -347,7 +348,7 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
       # Start st2chatops on boot
       sudo systemctl enable st2chatops
 
-* That's it! Go to your Chat room and begin ChatOps-ing. Read on :doc:`/chatops/index` section.
+* That's it! Go to your Chat room and begin ChatOps-ing. Read more in the :doc:`/chatops/index` section.
 
 Upgrade to Enterprise Edition
 -----------------------------

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -4,11 +4,11 @@ Updates and Upgrades
 
 Safe way: Migrate
 ~~~~~~~~~~~~~~~~~
-The safe and reliable way to transition |st2| to newer versions to provision a
+The safe and reliable way to transition |st2| to newer versions is to provision a
 new |st2| instance, and roll over the content. Thanks to the "Infrastructure as code" approach, all |st2| content and artifacts are simple files, and should be kept under source control.
 The recommended upgrade path to move from v1.2 to v1.3 is as follows :
 1. Install StackStorm ``VERSION_NEW`` on a brand new instance.
-2. Package all your pack from the old ``VERSION_OLD`` instance and place them under some SCM like git (you should have done it long ago).
+2. Package all your packs from the old ``VERSION_OLD`` instance and place them under some SCM like git (you should have done it long ago).
 3. Save your key-value pairs from the st2 datastore: ``st2 key list -j > kv_file.json``
 4. Grab packs from the SCM.
 5. If the SCM is git then it is possible to use st2 run packs.install packs=<pack-list> repo_url=<repo-url>

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -4,15 +4,15 @@
 About
 -------
 
-|st2| is a platform for integration and automation across services and tools. It ties together your existing infrastructure and application environment so you can more easily automate that environment -- with a particular focus on taking actions in response to events.
+|st2| is a platform for integration and automation across services and tools. It ties together your existing infrastructure and application environment so you can more easily automate that environment. It has a particular focus on taking actions in response to events.
 
 |st2| helps automate common operational patterns. Some examples are:
 
-* **Facilitated Troubleshooting** - triggering on system failures captured by Nagios, Sensu, New Relic and other monitoring, running a series of diagnostic checks on physical nodes, OpenStack or Amazon instances, and application components, and posting results to a shared communication context, like HipChat or JIRA.
-* **Automated remediation** - identifying and verifying hardware failure on OpenStack compute node, properly evacuating instances and emailing VM about potential downtime, but if anything goes wrong - freezing the workflow and calling PagerDuty to wake up a human.
-* **Continuous deployment** - build and test with Jenkins, provision a new AWS cluster, turn on some traffic with the load balancer, and roll-forth or roll-back based on NewRelic app performance data.
+* **Facilitated Troubleshooting** - triggering on system failures captured by Nagios, Sensu, New Relic and other monitoring systems, running a series of diagnostic checks on physical nodes, OpenStack or Amazon instances, and application components, and posting results to a shared communication context, like HipChat or JIRA.
+* **Automated remediation** - identifying and verifying hardware failure on OpenStack compute node, properly evacuating instances and emailing admins about potential downtime, but if anything goes wrong - freezing the workflow and calling PagerDuty to wake up a human.
+* **Continuous deployment** - build and test with Jenkins, provision a new AWS cluster, turn on some traffic with the load balancer, and roll-forward or roll-back, based on NewRelic app performance data.
 
-|st2| helps you compose these and other operational patterns as rules and workflows or actions; and these rules and workflows - the content within the |st2| platform - are stored *as code* which means they support the same approach to collaboration that you use today for code development and can be shared with the broader open source community via |st2|.com/community for example.
+|st2| helps you compose these and other operational patterns as rules and workflows or actions. These rules and workflows - the content within the |st2| platform - are stored *as code* which means they support the same approach to collaboration that you use today for code development. They can be shared with the broader open source community, for example via the `StackStorm community <http://www.stackstorm.com/community/>`_.
 
 How it works
 -------------
@@ -22,24 +22,24 @@ How it works
 
     StackStorm architecture diagram
 
-|st2| plugs into the environment via the extensible set of adapters: sensors and actions.
+|st2| plugs into the environment via the extensible set of adapters containing sensors and actions.
 
-* **Sensors** are python plugins for either inbound or outbound integration that receives or watches for events respectively. When an event from external systems occurs and is processed by a sensor, a |st2| trigger will be emitted into the system.
+* **Sensors** are Python plugins for either inbound or outbound integration that receives or watches for events respectively. When an event from external systems occurs and is processed by a sensor, a |st2| trigger will be emitted into the system.
 
 * **Triggers** are |st2| representations of external events. There are generic triggers (e.g. timers, webhooks) and integration triggers (e.g. Sensu alert, JIRA issue updated). A new trigger type can be defined by writing a sensor plugin.
 
-* **Actions** are |st2| outbound integrations. There are generic actions (ssh, REST call), integrations (OpenStack, Docker, Puppet), or custom actions. Actions are either python plugins, or any scripts, consumed into |st2| by adding a few lines of metadata. Actions can be invoked directly by user via CLI or API, or used and called as part of  automations - rules and workflows.
+* **Actions** are |st2| outbound integrations. There are generic actions (ssh, REST call), integrations (OpenStack, Docker, Puppet), or custom actions. Actions are either Python plugins, or any scripts, consumed into |st2| by adding a few lines of metadata. Actions can be invoked directly by user via CLI or API, or used and called as part of rules and workflows.
 
-* **Rules** map triggers to actions (or to workflows), applying matching criterias and mapping trigger payload to action inputs.
+* **Rules** map triggers to actions (or to workflows), applying matching criteria and mapping trigger payload to action inputs.
 
-* **Workflows** stitch actions together into “uber-actions”, defining the order, transition conditions, and passing the data. Most automations are more than one-step and thus need more than one action. Workflows, just like “atomic” actions, are available in action library, can be invoked manually or triggered by rules.
+* **Workflows** stitch actions together into “uber-actions”, defining the order, transition conditions, and passing the data. Most automations are more than one-step and thus need more than one action. Workflows, just like “atomic” actions, are available in the Action library, can be invoked manually or triggered by rules.
 
-* **Packs** are the units of content deployment. They simplify the management and sharing of |st2| pluggable content by grouping integrations (triggers and actions) and automations (rules and workflows). A growing number of packs is available on |st2| community. User can create their own packs,  share them on Github, or submit to |st2| community repo.
+* **Packs** are the units of content deployment. They simplify the management and sharing of |st2| pluggable content by grouping integrations (triggers and actions) and automations (rules and workflows). A growing number of packs are available on |st2| community. User can create their own packs, share them on Github, or submit to |st2| community repo.
 
-* **Audit trail** of action executions, manual or automated, is recorded and stored with full details of triggering context and execution results. It is is also captured in audit logs for integrating with external logging and analytical tools: LogStash, Splunk, statsd, syslog.
+* **Audit trail** of action executions, manual or automated, is recorded and stored with full details of triggering context and execution results. It is also captured in audit logs for integrating with external logging and analytical tools: LogStash, Splunk, statsd, syslog.
 
 
-|st2| is a service with modular architecture. It comprises loosely coupled  service components that communicate over the message bus, and scales horizontally to deliver automation at scale. |st2| has a full REST API, CLI client for admins and users to operate it locally or remotely, and Python client bindings for developer’s convenience. Web UI is coming soon.
+|st2| is a service with modular architecture. It comprises loosely coupled service components that communicate over the message bus, and scales horizontally to deliver automation at scale. |st2| has a full REST API, CLI client for admins and users to operate it locally or remotely, and Python client bindings for developer’s convenience. Web UI is coming soon.
 
 StackStorm is new and under active development. We are opening it early to engage community, get feedback, and refine directions, and welcome contributions.
 
@@ -49,7 +49,7 @@ What's Next?
 * Learn how to use StackStorm - watch :doc:`/video`
 * Build a simple automation - follow :doc:`/start` Guide
 * Help us with directions - comment on the :doc:`/roadmap`
-* Explore the `StackStorm community <http:://www.stackstorm.com/community/>`__
+* Explore the `StackStorm community <http://www.stackstorm.com/community/>`__
 
 
 .. include:: __engage.rst

--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -24,7 +24,7 @@ Components
 
 st2api
 ^^^^^^
-This process host the REST API endpoints that serve requests from  WebUI, CLI and ChatOps. It maintains
+This process host the REST API endpoints that serve requests from WebUI, CLI and ChatOps. It maintains
 connections to MongoDB to store and retrieve information. It also connects to RabbitMQ to push various
 kind of messages onto the message bus. It is a Python WSGI app running under gunicorn managed process
 which by default listens on port ``9101`` and is front-ended by Nginx acting as a reverse proxy.

--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -1,7 +1,7 @@
 Roadmap
 =======
 
-StackStorm is still under active development. We welcome community feedback to  refine directions, and encourage contributions. Below are key next items we see as top priorities.
+StackStorm is still under active development. We welcome community feedback to refine directions, and encourage contributions. Below are key next items we see as top priorities.
 
 * **Complete DEB/RPM for st2 components:** Build self-sustaining RPM/DEB packages for all the StackStorm components, Mistral, Hubot and the other dependencies for a fast and reliable installation.
 * **Docker based installer:** Complete the vision of OS independent, layered docker-based installer, to increase reliability, modularity, and speed of deployment.


### PR DESCRIPTION
Same set of typos as for master. 
Also set copyright date to 2016, and removed AIO reference from Installing Enterprise