### PR TITLE
Add Nginx instructions

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -232,7 +232,19 @@ To set it up, install `st2web` and `nginx`, generate certificates or place your 
 certificates under ``/etc/ssl/st2``, and configure nginx with StackStorm's supplied
 :github_st2:`site config file st2.conf<conf/nginx/st2.conf>`.
 
+StackStorm depends on Nginx version >=1.7.5; since Ubuntu 14 has an older version
+in the package repositories at the time of writing, you will have to include
+the official Nginx repository into the source list:
+
   .. code-block:: bash
+
+    # Add key and repo for the latest stable nginx
+    sudo apt-key adv --fetch-keys http://nginx.org/keys/nginx_signing.key
+    sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/nginx.list
+    deb http://nginx.org/packages/ubuntu/ trusty nginx
+    deb-src http://nginx.org/packages/ubuntu/ trusty nginx
+    EOT"
+    sudo apt-get update
 
     # Install st2web and nginx
     sudo apt-get install -y st2web nginx

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -38,7 +38,7 @@ Install libffi-devel package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RHEL 6 may not ship with ``libffi-devel`` which is a dependency for |st2|.
-If that is the case, set up `server-optional` repository, following instructions at https://access.redhat.com/solutions/265523. 
+If that is the case, set up `server-optional` repository, following instructions at https://access.redhat.com/solutions/265523.
 Or, find a version of libffi-devel compatible with libffi on the box, and install this version of ``libffi-devel```. For example:
 
 .. code :: bash
@@ -304,7 +304,21 @@ To set it up: install `st2web` and `nginx`, generate certificates or place your 
 certificates under ``/etc/ssl/st2``, and configure nginx with StackStorm's supplied
 :github_st2:`site config file st2.conf<conf/nginx/st2.conf>`.
 
+StackStorm depends on Nginx version >=1.7.5; since RHEL6 has an older version
+in the package repositories at the time of writing, you will have to include
+the official Nginx repository into the list:
+
   .. code-block:: bash
+
+    # Add key and repo for the latest stable nginx
+    sudo rpm --import http://nginx.org/keys/nginx_signing.key
+    sudo sh -c "cat <<EOT > /etc/yum.repos.d/nginx.repo
+    [nginx]
+    name=nginx repo
+    baseurl=http://nginx.org/packages/rhel/6/x86_64/
+    gpgcheck=1
+    enabled=1
+    EOT"
 
     # Install st2web and nginx
     sudo yum -y install st2web nginx

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -2,8 +2,8 @@ RHEL 7 / CentOS 7
 =================
 
 This guide provides step-by step instructions for installing StackStorm on a single RHEL 7/CentOS 7 system per
-the :doc:`Reference deployment </install/overview>`. The script `st2bootstrap-el7.sh 
-<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el7.sh>`_ codifies the 
+the :doc:`Reference deployment </install/overview>`. The script `st2bootstrap-el7.sh
+<https://github.com/StackStorm/st2-packages/blob/master/scripts/st2bootstrap-el7.sh>`_ codifies the
 instructions below.
 
 .. contents::
@@ -274,7 +274,21 @@ To set it up: install `st2web` and `nginx`, generate certificates or place your 
 certificates under ``/etc/ssl/st2``, and configure nginx with StackStorm's supplied
 :github_st2:`site config file st2.conf<conf/nginx/st2.conf>`.
 
+StackStorm depends on Nginx version >=1.7.5; since RHEL7 has an older version
+in the package repositories at the time of writing, you will have to include
+the official Nginx repository into the list:
+
   .. code-block:: bash
+
+    # Add key and repo for the latest stable nginx
+    sudo rpm --import http://nginx.org/keys/nginx_signing.key
+    sudo sh -c "cat <<EOT > /etc/yum.repos.d/nginx.repo
+    [nginx]
+    name=nginx repo
+    baseurl=http://nginx.org/packages/rhel/7/x86_64/
+    gpgcheck=1
+    enabled=1
+    EOT"
 
     # Install st2web and nginx
     sudo yum install -y st2web nginx

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -9,7 +9,7 @@ instructions below.
 .. contents::
 
 Supported platforms
---------------------
+-------------------
 
 We support RedHat 7 / CentOS 7 and test on `Red Hat Enterprise Linux (RHEL) 7.2 (HVM) Amazon AWS AMI <https://aws.amazon.com/marketplace/pp/B019NS7T5I/ref=srh_res_product_title?ie=UTF8&sr=0-2&qid=1457037671547>`_
 and `puppetlabs/centos-7.0-64-nocm Vagrant box <https://atlas.hashicorp.com/puppetlabs/boxes/centos-7.0-64-nocm>`_. Other RPM based distributions and versions will likely work with some tweaks. You are welcome to try - please report success to the `community <https://stackstorm.com/community-signup>`_.


### PR DESCRIPTION
Instructions for installing the latest Nginx stable. Need to have it there because people have issues with 1.7.5 not yet being in the package repos.