### PR TITLE
Update packs.rst

### DIFF
--- a/docs/source/reference/packs.rst
+++ b/docs/source/reference/packs.rst
@@ -152,6 +152,9 @@ Copy the following content to policies/policy1.yaml
 
    # Assuming that hello-st2 is on the same machine where StackStorm is running.
    cp -R ./hello-st2 /opt/stackstorm/packs
+   
+   # Create virtual environment for hello-st2.
+   st2 run packs.setup_virtualenv packs=hello-st2
 
    # Reloads the content
    st2 run packs.load register=all


### PR DESCRIPTION
Added command to step 7: `t2 run packs.setup_virtualenv packs=hello-st2`

After following the instructions, an exception is thrown at step 7.
See `/var/log/st2/st2sensorcontainer.log` for issue:

```
2016-06-17 11:38:12,647 139709151191920 INFO manager [-] Adding sensor hello-st2.HelloSensor.
2016-06-17 11:38:12,647 139709151191920 ERROR sensor_watcher [-] Handling failed. Message body: SensorTypeDB(artifact_uri="file:///opt/stackstorm/packs/hello-st2/sensors/sensor1.py", description="Test sensor that emits triggers$
Virtual environment (/opt/stackstorm/virtualenvs/hello-st2) for pack "hello-st2" doesn't exist. If you haven't
installed a pack using "packs.install" command, you can create a new virtual environment using
"st2 run packs.setup_virtualenv packs=hello-st2" command'
Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/services/sensor_watcher.py", line 82, in process_task
    handler(body)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/manager.py", line 120, in _handle_create_sensor
    self._sensor_container.add_sensor(sensor=self._to_sensor_object(sensor))
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/process_container.py", line 215, in add_sensor
    self._spawn_sensor_process(sensor=sensor)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/process_container.py", line 268, in _spawn_sensor_process
    raise Exception(msg)
Exception:
Virtual environment (/opt/stackstorm/virtualenvs/hello-st2) for pack "hello-st2" doesn't exist. If you haven't
installed a pack using "packs.install" command, you can create a new virtual environment using
"st2 run packs.setup_virtualenv packs=hello-st2" command'
```