### PR TITLE
Update migration docs

### DIFF
--- a/docs/source/install/migration.rst
+++ b/docs/source/install/migration.rst
@@ -6,12 +6,43 @@ Migration scripts to run on upgrades
 Migration scripts most often need to be run when upgrading to |st2| versions that
 include data model changes. The runbook is usually
 
-1. Stop |st2| services on the box (``sudo st2ctl stop``).
-2. Run the migration script.
-3. Upgrade |st2| packages (``st2``, ``st2web``,
-   ``st2chatops``, ``st2mistral`` and ``st2enterprise`` using distro specific tools
-   ``apt-get install --only-upgrade $PKG_NAME`` for Ubuntu and ``yum update $PKG_NAME`` for RHEL/CentOS).
-4. Start |st2| services. (``sudo st2ctl start``)
+1. Stop |st2| services on the box.
+
+.. sourcecode:: bash
+
+   sudo st2ctl stop
+
+2. Run the migration script (if any). See section below for StackStorm
+   version-specific migration scripts.
+
+3. Upgrade |st2| packages (``st2``, ``st2web``, `st2chatops``, ``st2mistral``
+   and ``st2enterprise`` using distro specific tools.
+
+Ubuntu:
+
+
+.. sourcecode:: bash
+
+   sudo apt-get install --only-upgrade $PKG_NAME
+
+RHEL / CentOS:
+
+.. sourcecode:: bash
+
+   sudo yum update $PKG_NAME
+
+4. Run Mistral database migration scripts:
+
+.. sourcecode:: bash
+
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+
+5. Start |st2| services.
+
+.. sourcecode:: bash
+
+   sudo st2ctl start
 
 We usually document :ref:`upgrade notes<upgrade_notes>` for the various versions. The upgrade
 notes section gives an idea of what major changes happened with each release. You may also want
@@ -19,8 +50,11 @@ to take a look at detailed :doc:`/changelog` for each version.
 Following sections call out the migration scripts that need to be run before upgrading to the
 respective version
 
+Version-specific migration scripts
+----------------------------------
+
 v1.5
-----
+~~~~
 
 * Datastore model migration
 


### PR DESCRIPTION
This is a temporary work-around for v1.4 to v1.5 upgrade scenario.

We can "Mistral DB migrate scripts run" step once we move this into package `postinst` phase or similar.