### PR TITLE
Update documentation for MongoDB 3.2 changes, reduce duplication / copy & paste

### DIFF
--- a/docs/source/install/__mongodb_32_note.rst
+++ b/docs/source/install/__mongodb_32_note.rst
@@ -1,0 +1,5 @@
+.. note::
+
+  Since StackStorm v1.6.0, the preferred and supported version of MongoDB is 3.2. This is also the
+  version installed by the installer script. Older versions of StackStorm (prior to v1.6.0 only
+  supported MongoDB 2.x).

--- a/docs/source/install/__mongodb_32_note.rst
+++ b/docs/source/install/__mongodb_32_note.rst
@@ -1,5 +1,5 @@
 .. note::
 
   Since StackStorm v1.6.0, the preferred and supported version of MongoDB is 3.2. This is also the
-  version installed by the installer script. Older versions of StackStorm (prior to v1.6.0 only
-  supported MongoDB 2.x).
+  version installed by the installer script. Older versions of StackStorm (prior to v1.6.0) only
+  supported MongoDB 2.x.

--- a/docs/source/install/common/configure_ssh_and_sudo.rst
+++ b/docs/source/install/common/configure_ssh_and_sudo.rst
@@ -1,0 +1,20 @@
+  .. code-block:: bash
+
+    # Create an SSH system user (default `stanley` user may already exist)
+    sudo useradd stanley
+    sudo mkdir -p /home/stanley/.ssh
+    sudo chmod 0700 /home/stanley/.ssh
+
+    # On StackStorm host, generate ssh keys
+    sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+
+    # Authorize key-based access
+    sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
+    sudo chown -R stanley:stanley /home/stanley/.ssh
+
+    # Enable passwordless sudo
+    sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
+    sudo chmod 0440 /etc/sudoers.d/st2
+
+    # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
+    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers

--- a/docs/source/install/common/configure_system_user.rst
+++ b/docs/source/install/common/configure_system_user.rst
@@ -1,0 +1,5 @@
+  .. sourcecode:: ini
+
+    [system_user]
+    user = stanley
+    ssh_key_file = /home/stanley/.ssh/stanley_rsa

--- a/docs/source/install/common/setup_mistral_database.rst
+++ b/docs/source/install/common/setup_mistral_database.rst
@@ -1,0 +1,12 @@
+  .. code-block:: bash
+
+    # Create Mistral DB in PostgreSQL
+    cat << EHD | sudo -u postgres psql
+    CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
+    CREATE DATABASE mistral OWNER mistral;
+    EHD
+
+    # Setup Mistral DB tables, etc.
+    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
+    # Register mistral actions
+    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate

--- a/docs/source/install/common/start_services.rst
+++ b/docs/source/install/common/start_services.rst
@@ -1,0 +1,7 @@
+* Start services ::
+
+    sudo st2ctl start
+
+* Register sensors and actions ::
+
+    st2ctl reload

--- a/docs/source/install/common/verify.rst
+++ b/docs/source/install/common/verify.rst
@@ -1,0 +1,24 @@
+  .. code-block:: bash
+
+    st2 --version
+
+    st2 -h
+
+    # List the actions from a 'core' pack
+    st2 action list --pack=core
+
+    # Run a local shell command
+    st2 run core.local -- date -R
+
+    # See the execution results
+    st2 execution list
+
+    # Fire a remote comand via SSH (Requires passwordless SSH)
+    st2 run core.remote hosts='localhost' -- uname -a
+
+    # Install a pack
+    st2 run packs.install packs=st2
+
+Use the supervisor script to manage |st2| services: ::
+
+    st2ctl start|stop|status|restart|restart-component|reload|clean

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -39,12 +39,24 @@ Minimal installation
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
+.. include:: __mongodb_32_note.rst
+
 Install MongoDB, RabbitMQ, and PostgreSQL.
 
   .. code-block:: bash
 
     sudo apt-get update
-    sudo apt-get install -y mongodb-server rabbitmq-server postgresql
+    sudo apt-get install -y gnupg-curl
+    sudo apt-get install -y curl
+
+    # Add key and repo for the latest stable MongoDB (3.2)
+    sudo apt-key adv --fetch-keys https://www.mongodb.org/static/pgp/server-3.2.asc
+    sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.2.list
+    deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse
+    EOT"
+
+    sudo apt-get install -y mongodb-org
+    sudo apt-get install -y rabbitmq-server
 
 Setup repositories
 ~~~~~~~~~~~~~~~~~~~
@@ -91,6 +103,7 @@ Setup Mistral Database
 
 Configure SSH and SUDO
 ~~~~~~~~~~~~~~~~~~~~~~
+
 To run local and remote shell actions, StackStorm uses a special system user (default ``stanley``).
 For remote Linux actions, SSH is used. It is advised to configure identity file based SSH access on all remote hosts. We also recommend configuring SSH access to localhost for running examples and testing.
 
@@ -131,6 +144,7 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 Start Services
 ~~~~~~~~~~~~~~
+
 * Start services ::
 
     sudo st2ctl start

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -104,11 +104,7 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 * Adjust configuration in ``/etc/st2/st2.conf`` if you are using a different user or path to the key:
 
-  .. sourcecode:: ini
-
-    [system_user]
-    user = stanley
-    ssh_key_file = /home/stanley/.ssh/stanley_rsa
+.. include:: common/configure_system_user.rst
 
 Start Services
 ~~~~~~~~~~~~~~

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -67,7 +67,6 @@ The following script will detect your platform and architecture and setup the re
 
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.deb.sh | sudo bash
 
-
 Install StackStorm components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -75,29 +74,17 @@ Install StackStorm components
 
       sudo apt-get install -y st2 st2mistral
 
-
 If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or have changed defaults,
 please adjust the settings:
 
-    * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
-    * MongoDB at ``/etc/st2/st2.conf``
-    * PostgreSQL at ``/etc/mistral/mistral.conf``
+  * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
+  * MongoDB at ``/etc/st2/st2.conf``
+  * PostgreSQL at ``/etc/mistral/mistral.conf``
 
 Setup Mistral Database
 ~~~~~~~~~~~~~~~~~~~~~~
 
-  .. code-block:: bash
-
-    # Create Mistral DB in PostgreSQL
-    cat << EHD | sudo -u postgres psql
-    CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
-    CREATE DATABASE mistral OWNER mistral;
-    EHD
-
-    # Setup Mistral DB tables, etc.
-    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
-    # Register mistral actions
-    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+.. include:: common/setup_mistral_database.rst
 
 .. _ref-config-ssh-sudo-deb:
 
@@ -109,26 +96,7 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 * Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so that SSH-based action can be tried and tested locally. You will need elevated privileges to do this.
 
-  .. code-block:: bash
-
-    # Create an SSH system user (default `stanley` user may already exist)
-    sudo useradd stanley
-    sudo mkdir -p /home/stanley/.ssh
-    sudo chmod 0700 /home/stanley/.ssh
-
-    # On StackStorm host, generate ssh keys
-    sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-
-    # Authorize key-based access
-    sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-    sudo chown -R stanley:stanley /home/stanley/.ssh
-
-    # Enable passwordless sudo
-    sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
-    sudo chmod 0440 /etc/sudoers.d/st2
-
-    # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
+.. include:: common/configure_ssh_and_sudo.rst
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.
@@ -145,42 +113,12 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 Start Services
 ~~~~~~~~~~~~~~
 
-* Start services ::
-
-    sudo st2ctl start
-
-* Register sensors and actions ::
-
-    st2ctl reload
+.. include:: common/start_services.rst
 
 Verify
 ~~~~~~
 
-  .. code-block:: bash
-
-    st2 --version
-
-    st2 -h
-
-    # List the actions from a 'core' pack
-    st2 action list --pack=core
-
-    # Run a local shell command
-    st2 run core.local -- date -R
-
-    # See the execution results
-    st2 execution list
-
-    # Fire a remote comand via SSH (Requires passwordless SSH)
-    st2 run core.remote hosts='localhost' -- uname -a
-
-    # Install a pack
-    st2 run packs.install packs=st2
-
-Use the supervisor script to manage |st2| services: ::
-
-    st2ctl start|stop|status|restart|restart-component|reload|clean
-
+.. include:: common/verify.rst
 
 -----------------
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -142,7 +142,6 @@ The following script will detect your platform and architecture and setup the re
 
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
-
 Install StackStorm components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -150,29 +149,17 @@ Install StackStorm components
 
       sudo yum install -y st2 st2mistral
 
-
 If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or changed defaults,
 please adjust the settings:
 
-    * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
-    * MongoDB at ``/etc/st2/st2.conf``
-    * PostgreSQL at ``/etc/mistral/mistral.conf``
+  * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
+  * MongoDB at ``/etc/st2/st2.conf``
+  * PostgreSQL at ``/etc/mistral/mistral.conf``
 
 Setup Mistral Database
 ~~~~~~~~~~~~~~~~~~~~~~
 
-  .. code-block:: bash
-
-    # Create Mistral DB in PostgreSQL
-    cat << EHD | sudo -u postgres psql
-    CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
-    CREATE DATABASE mistral OWNER mistral;
-    EHD
-
-    # Setup Mistral DB tables, etc.
-    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
-    # Register mistral actions
-    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+.. include:: common/setup_mistral_database.rst
 
 Configure SSH and SUDO
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -185,26 +172,7 @@ testing.
 * Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so
   that SSH-based action can be tried and tested locally. You will need elevated privileges to do this.
 
-  .. code-block:: bash
-
-    # Create an SSH system user (default `stanley` user may be already created)
-    sudo useradd stanley
-    sudo mkdir -p /home/stanley/.ssh
-    sudo chmod 0700 /home/stanley/.ssh
-
-    # On StackStorm host, generate ssh keys
-    sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-
-    # Authorize key-based access
-    sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-    sudo chown -R stanley:stanley /home/stanley/.ssh
-
-    # Enable passwordless sudo
-    sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
-    sudo chmod 0440 /etc/sudoers.d/st2
-
-    # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
+.. include:: common/configure_ssh_and_sudo.rst
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.
@@ -220,42 +188,13 @@ testing.
 
 Start Services
 ~~~~~~~~~~~~~~
-* Start services ::
 
-    sudo st2ctl start
-
-* Register sensors and actions ::
-
-    st2ctl reload
+.. include:: common/start_services.rst
 
 Verify
 ~~~~~~
 
-  .. code-block:: bash
-
-    st2 --version
-
-    st2 -h
-
-    # List the actions from a 'core' pack
-    st2 action list --pack=core
-
-    # Run a local shell command
-    st2 run core.local -- date -R
-
-    # See the execution results
-    st2 execution list
-
-    # Fire a remote comand via SSH (Requires passwordless SSH)
-    st2 run core.remote hosts='localhost' -- uname -a
-
-    # Install a pack
-    st2 run packs.install packs=st2
-
-Use the supervisor script to manage |st2| services: ::
-
-    st2ctl start|stop|status|restart|restart-component|reload|clean
-
+.. include:: common/verify.rst
 
 -----------------
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -180,11 +180,7 @@ testing.
 
 * Adjust configuration in ``/etc/st2/st2.conf`` if you are using a different user or path to the key:
 
-  .. sourcecode:: ini
-
-    [system_user]
-    user = stanley
-    ssh_key_file = /home/stanley/.ssh/stanley_rsa
+.. include:: common/configure_system_user.rst
 
 Start Services
 ~~~~~~~~~~~~~~

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -86,12 +86,27 @@ you may want to tweak them according to your security practices.
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
+.. include:: __mongodb_32_note.rst
+
 Install MongoDB, RabbitMQ, and PostgreSQL.
 
   .. code-block:: bash
 
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-    sudo yum -y install mongodb-server rabbitmq-server
+
+    # Add key and repo for the latest stable MongoDB (3.2)
+    sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
+    sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
+    [mongodb-org-3.2]
+    name=MongoDB Repository
+    baseurl=https://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.2/x86_64/
+    gpgcheck=1
+    enabled=1
+    gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+    EOT"
+
+    sudo yum -y install mongodb-org
+    sudo yum -y install rabbitmq-server
     sudo service mongod start
     sudo service rabbitmq-server start
     sudo chkconfig mongod on

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -118,7 +118,6 @@ The following script will detect your platform and architecture and setup the re
 
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
-
 Install StackStorm components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -153,11 +152,7 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 * Adjust configuration in ``/etc/st2/st2.conf`` if you are using a different user or path to the key:
 
-  .. sourcecode:: ini
-
-    [system_user]
-    user = stanley
-    ssh_key_file = /home/stanley/.ssh/stanley_rsa
+.. include:: common/configure_system_user.rst
 
 Start Services
 ~~~~~~~~~~~~~~

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -126,29 +126,17 @@ Install StackStorm components
 
       sudo yum install -y st2 st2mistral
 
-
 If you are not running RabbitMQ, MongoDB or PostgreSQL on the same box, or changed the defaults,
 please adjust the settings:
 
-    * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
-    * MongoDB at ``/etc/st2/st2.conf``
-    * PostgreSQL at ``/etc/mistral/mistral.conf``
+  * RabbitMQ connection at ``/etc/st2/st2.conf`` and ``/etc/mistral/mistral.conf``
+  * MongoDB at ``/etc/st2/st2.conf``
+  * PostgreSQL at ``/etc/mistral/mistral.conf``
 
 Setup Mistral Database
 ~~~~~~~~~~~~~~~~~~~~~~
 
-  .. code-block:: bash
-
-    # Create Mistral DB in PostgreSQL
-    cat << EHD | sudo -u postgres psql
-    CREATE ROLE mistral WITH CREATEDB LOGIN ENCRYPTED PASSWORD 'StackStorm';
-    CREATE DATABASE mistral OWNER mistral;
-    EHD
-
-    # Setup Mistral DB tables, etc.
-    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
-    # Register mistral actions
-    /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+.. include:: common/setup_mistral_database.rst
 
 Configure SSH and SUDO
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -157,26 +145,7 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 * Create StackStorm system user, enable passwordless sudo, and set up ssh access to "localhost" so that SSH-based action can be tried and tested locally.
 
-  .. code-block:: bash
-
-    # Create an SSH system user (default `stanley` user may be already created)
-    sudo useradd stanley
-    sudo mkdir -p /home/stanley/.ssh
-    sudo chmod 0700 /home/stanley/.ssh
-
-    # On StackStorm host, generate ssh keys
-    sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
-
-    # Authorize key-based access
-    sudo sh -c 'cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys'
-    sudo chown -R stanley:stanley /home/stanley/.ssh
-
-    # Enable passwordless sudo
-    sudo sh -c 'echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2'
-    sudo chmod 0440 /etc/sudoers.d/st2
-
-    # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
+.. include:: common/configure_ssh_and_sudo.rst
 
 * Configure SSH access and enable passwordless sudo on the remote hosts which StackStorm would control
   over SSH. Use the public key generated in the previous step; follow instructions at :ref:`config-configure-ssh`.
@@ -192,42 +161,13 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 Start Services
 ~~~~~~~~~~~~~~
-* Start services ::
 
-    sudo st2ctl start
-
-* Register sensors and actions ::
-
-    st2ctl reload
+.. include:: common/start_services.rst
 
 Verify
 ~~~~~~
 
-  .. code-block:: bash
-
-    st2 --version
-
-    st2 -h
-
-    # List the actions from a 'core' pack
-    st2 action list --pack=core
-
-    # Run a local shell command
-    st2 run core.local -- date -R
-
-    # See the execution results
-    st2 execution list
-
-    # Fire a remote comand via SSH (Requires passwordless SSH)
-    st2 run core.remote hosts='localhost' -- uname -a
-
-    # Install a pack
-    st2 run packs.install packs=st2
-
-Use the supervisor script to manage |st2| services: ::
-
-    st2ctl start|stop|status|restart|restart-component|reload|clean
-
+.. include:: common/verify.rst
 
 -----------------
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -71,12 +71,27 @@ you may want to tweak them according to your security practices.
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
+.. include:: __mongodb_32_note.rst
+
 Install MongoDB, RabbitMQ, and PostgreSQL.
 
   .. code-block:: bash
 
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    sudo yum -y install mongodb-server rabbitmq-server
+
+    # Add key and repo for the latest stable MongoDB (3.2)
+    sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
+    sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
+    [mongodb-org-3.2]
+    name=MongoDB Repository
+    baseurl=https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/3.2/x86_64/
+    gpgcheck=1
+    enabled=1
+    gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+    EOT"
+
+    sudo yum -y install mongodb-org
+    sudo yum -y install rabbitmq-server
     sudo systemctl start mongod rabbitmq-server
     sudo systemctl enable mongod rabbitmq-server
 


### PR DESCRIPTION
This pull request updates documentation for MongoDB 3.2 changes.

In addition to that, I have finally done some clean-up and refactoring and moved duplicated installation steps which are the same across all the platforms in shared files (something I have complained a lot about in the past).

Keep in mind though that this is just a very first step. Next step will actually be directly re-using code from bootstrap scripts. I strongly believe that documentation which is not automated and tested (like it is right now) is bad and in many cases even worse then no documentation (things get out of date, etc.)