### PR TITLE
Add documentation for new "action" attribute available to concurrency policies

### DIFF
--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -1,10 +1,6 @@
 Policies
 ========
 
-.. note::
-
-    Policy is currently an experimental feature and may be subject to bugs and design changes.
-
 To list the types of policy that are available for configuration, run the command ``st2 policy-type list``.
 
 Policy configuration files are expected to be located under the ``policies`` folder in related packs, similar to actions and rules. Policies can be loaded into |st2| via ``st2ctl reload --register-policies``. Once policies are loaded into |st2|, run the command ``st2 policy list`` to view the list of policies in effect.

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -1,6 +1,8 @@
 Policies
 ========
 
+Policies allows users to enforce different rules regarding action executions.
+
 To list the types of policy that are available for configuration, run the command
 `st2 policy-type list``.
 
@@ -13,8 +15,18 @@ Concurrency
 -----------
 
 The concurrency policy enforces the number of executions that can run simultaneously for a
-specified action. There are two forms of concurrency policy: ``action.concurrency`` and
+specified action.
+
+By default when a threshold is reached, action execution is postponed until a number concurrent
+executions of a particular actions falls below the threshold. As an alternative, user can also
+specify for execution to be canceled instead of it being delayed / postponed.
+
+
+There are two forms of concurrency policy: ``action.concurrency`` and
 ``action.concurrency.attr``.
+
+action.concurrency
+~~~~~~~~~~~~~~~~~~
 
 The ``action.concurrency`` policy limits the concurrent executions for the action. The following
 is an example of a policy file with concurrency defined for ``demo.my_action``. Please note that
@@ -31,7 +43,25 @@ execution requests above this threshold will be postponed.
     resource_ref: demo.my_action
     policy_type: action.concurrency
     parameters:
+        action: delay
         threshold: 10
+
+If you want further actions to be canceled instead of delayed, ``action`` attribute should be
+changed to ``cancel`` as shown below.
+
+.. sourcecode:: YAML
+
+    name: my_action.concurrency
+    description: Limits the concurrent executions for my action.
+    enabled: true
+    resource_ref: demo.my_action
+    policy_type: action.concurrency
+    parameters:
+        action: cancel
+        threshold: 1
+
+action.concurrency.attr
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``action.concurrency.attr`` policy limits the executions for the action by input arguments.
 Let's say ``demo.my_remote_action`` has an input argument defined called ``hostname``. This is the
@@ -48,6 +78,7 @@ given remote host.
     resource_ref: demo.my_remote_action
     policy_type: action.concurrency.attr
     parameters:
+        action:d elay
         threshold: 10
         attributes:
             - hostname

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -1,16 +1,27 @@
 Policies
 ========
 
-To list the types of policy that are available for configuration, run the command ``st2 policy-type list``.
+To list the types of policy that are available for configuration, run the command
+`st2 policy-type list``.
 
-Policy configuration files are expected to be located under the ``policies`` folder in related packs, similar to actions and rules. Policies can be loaded into |st2| via ``st2ctl reload --register-policies``. Once policies are loaded into |st2|, run the command ``st2 policy list`` to view the list of policies in effect.
+Policy configuration files are expected to be located under the ``policies`` folder in related
+packs, similar to actions and rules. Policies can be loaded into |st2| via
+``st2ctl reload --register-policies``. Once policies are loaded into |st2|, run the command
+``st2 policy list`` to view the list of policies in effect.
 
 Concurrency
 -----------
 
-The concurrency policy enforces the number of executions that can run simultaneously for a specified action. There are two forms of concurrency policy: ``action.concurrency`` and ``action.concurrency.attr``.
+The concurrency policy enforces the number of executions that can run simultaneously for a
+specified action. There are two forms of concurrency policy: ``action.concurrency`` and
+``action.concurrency.attr``.
 
-The ``action.concurrency`` policy limits the concurrent executions for the action. The following is an example of a policy file with concurrency defined for ``demo.my_action``. Please note that the resource_ref and policy_type are the fully qualified name for the action and policy type respectively. The ``threshold`` parameter defines how many concurrent instances are allowed. In this example, no more than 10 instances of ``demo.my_action`` can be run simultaneously. Any execution requests above this threshold will be postponed.
+The ``action.concurrency`` policy limits the concurrent executions for the action. The following
+is an example of a policy file with concurrency defined for ``demo.my_action``. Please note that
+the resource_ref and policy_type are the fully qualified name for the action and policy type
+respectively. The ``threshold`` parameter defines how many concurrent instances are allowed. In
+this example, no more than 10 instances of ``demo.my_action`` can be run simultaneously. Any
+execution requests above this threshold will be postponed.
 
 .. sourcecode:: YAML
 
@@ -22,7 +33,12 @@ The ``action.concurrency`` policy limits the concurrent executions for the actio
     parameters:
         threshold: 10
 
-The ``action.concurrency.attr`` policy limits the executions for the action by input arguments. Let's say ``demo.my_remote_action`` has an input argument defined called ``hostname``. This is the name of the host where the remote command or script runs. By using the policy type ``action.concurrency.attr`` and specifying ``hostname`` as one of the attributes in the policy, only a number of ``demo.my_remote_action`` up to the defined threshold can run simultaneously on a given remote host.
+The ``action.concurrency.attr`` policy limits the executions for the action by input arguments.
+Let's say ``demo.my_remote_action`` has an input argument defined called ``hostname``. This is the
+name of the host where the remote command or script runs. By using the policy type
+``action.concurrency.attr`` and specifying ``hostname`` as one of the attributes in the policy,
+only a number of ``demo.my_remote_action`` up to the defined threshold can run simultaneously on a
+given remote host.
 
 .. sourcecode:: YAML
 
@@ -38,11 +54,14 @@ The ``action.concurrency.attr`` policy limits the executions for the action by i
 
 .. note::
 
-    The concurrency policy type is not enabled by default and requires a backend service such as ZooKeeper or Redis to work.
+    The concurrency policy type is not enabled by default and requires a backend service such as
+    ZooKeeper or Redis to work.
 
-Let's assume ZooKeeper or Redis is running on the same network where |st2| is installed. To enable the concurrency policy type in |st2|, provide the url to connect to the backend service in the coordination section of ``/etc/st2/st2.conf``. The following are examples for ZooKeeper and Redis:
+Let's assume ZooKeeper or Redis is running on the same network where |st2| is installed. To enable
+the concurrency policy type in |st2|, provide the url to connect to the backend service in the
+coordination section of ``/etc/st2/st2.conf``. The following are examples for ZooKeeper and Redis:
 
-ZooKeeper: 
+ZooKeeper:
 
 ::
 
@@ -50,7 +69,7 @@ ZooKeeper:
     url = kazoo://username:password@host:port
 
 
-Redis: 
+Redis:
 
 ::
 

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -78,7 +78,7 @@ given remote host.
     resource_ref: demo.my_remote_action
     policy_type: action.concurrency.attr
     parameters:
-        action:d elay
+        action: delay
         threshold: 10
         attributes:
             - hostname


### PR DESCRIPTION
Documentation for https://github.com/StackStorm/st2/pull/2817

## TODO

- [ ] Merge st2 branch and refer to policies examples from contrib pack instead of hard cording it in the docs (same as we do for retry policy)