### PR TITLE
Refine NodeJS dependency

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -257,10 +257,9 @@ If you already run a Hubot instance, you only have to install the `hubot-stackst
     # Create notification rule if not yet enabled
     st2 rule get chatops.notify || st2 rule create /opt/stackstorm/packs/chatops/rules/notify_hubot.yaml
 
-* `Install NodeJS v4 <https://nodejs.org/en/download/package-manager/>`_: ::
+* `Add NodeJS v4 repository <https://nodejs.org/en/download/package-manager/>`_: ::
 
       curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
-      sudo apt-get install -y nodejs
 
 * Install st2chatops package: ::
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -334,10 +334,9 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
     # Create notification rule if not yet enabled
     st2 rule get chatops.notify || st2 rule create /opt/stackstorm/packs/chatops/rules/notify_hubot.yaml
 
-* `Install NodeJS v4 <https://nodejs.org/en/download/package-manager/>`_: ::
+* `Add NodeJS v4 repository <https://nodejs.org/en/download/package-manager/>`_: ::
 
       curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
-      sudo yum install -y nodejs
 
 * Install st2chatops package: ::
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -303,10 +303,9 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
     # Create notification rule if not yet enabled
     st2 rule get chatops.notify || st2 rule create /opt/stackstorm/packs/chatops/rules/notify_hubot.yaml
 
-* `Install NodeJS v4 <https://nodejs.org/en/download/package-manager/>`_: ::
+* `Add NodeJS v4 repository <https://nodejs.org/en/download/package-manager/>`_: ::
 
       curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
-      sudo yum install -y nodejs
 
 * Install st2chatops package: ::
 


### PR DESCRIPTION
Since `nodejs >= 4.0` package is now a dependency for `st2chatops` (added in https://github.com/StackStorm/st2chatops/pull/46), there is no need to install `nodejs` package by hand, - just add a correct repository.

> Reflected in https://github.com/StackStorm/st2-packages/pull/331