### PR TITLE
Fix installation docs - add apt-get update after adding new apt repo

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -55,6 +55,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
     sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.2.list
     deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse
     EOT"
+    sudo apt-get update
 
     sudo apt-get install -y mongodb-org
     sudo apt-get install -y rabbitmq-server


### PR DESCRIPTION
We need to run apt-get update after adding a new repo.

Will cherry pick into v1.6.