### PR TITLE
Move StackStorm/BWC-specific values from conf.py to info.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,12 +15,12 @@
 import sys
 import os
 import glob
-import info
-
-print sys.path
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.abspath(os.path.join(BASE_DIR, '../../st2'))
+
+sys.path.append(BASE_DIR)
+import info
 
 # Include Python modules for all the st2components
 st2_components_paths = glob.glob(ROOT_DIR + '/st2*')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,9 +64,6 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
-
 # General information about the project.
 project = info.project
 copyright = info.copyright

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,9 @@ release = __version__
 # The complete list of current StackStorm versions.
 release_versions = ['1.6', '1.5', '1.4', '1.3', '1.2', '1.1', '0.13', '0.12', '0.11', '0.9', '0.8']
 
+# Some loveliness that we have to do to make this work.  Otherwise it defaults to contents.rst
+master_doc = info.master_doc
+
 
 def previous_version(ver):
     if ver.endswith('dev'):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,8 @@ import os
 import glob
 import info
 
+print sys.path
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.abspath(os.path.join(BASE_DIR, '../../st2'))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 import sys
 import os
 import glob
+import info
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.abspath(os.path.join(BASE_DIR, '../../st2'))
@@ -42,6 +43,8 @@ from st2common import __version__
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.coverage',
+    'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
     'sphinx.ext.extlinks',
@@ -63,8 +66,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'StackStorm'
-copyright = u'2016, StackStorm Inc'
+project = info.project
+copyright = info.copyright
+author = info.author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -112,6 +116,8 @@ rst_epilog = """
 .. |st2| replace:: StackStorm
 .. _st2contrib: http://www.github.com/stackstorm/st2contrib
 .. _st2incubator: http://www.github.com/stackstorm/st2incubator
+.. |bwc| replace:: Brocade Workflow Composer
+.. |ipf| replace:: IP Fabric Solution
 """
 
 # Show or hide TODOs. See http://sphinx-doc.org/ext/todo.html
@@ -184,7 +190,7 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'base_url': 'http://docs.stackstorm.com/'
+    'base_url': info.theme_base_url
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -259,33 +265,88 @@ html_static_path = ['_static']
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'StackStormDoc'
+htmlhelp_basename = info.htmlhelp_basename
 
 # Variables to be used by templates
 html_context = {
-    'github_repo': 'StackStorm/st2docs',
-    'github_version': 'master',
+    'github_repo': info.github_repo,
+    'github_version': info.github_version,
     'conf_py_path': '/docs/source/',
     'display_github': True,
     'source_suffix': source_suffix,
     'versions': [
-        ('latest', 'http://docs.stackstorm.com/latest'),
-        (version, 'http://docs.stackstorm.com/%s' % version),
-        (version_minus_1, 'http://docs.stackstorm.com/%s' % version_minus_1),
-        (version_minus_2, 'http://docs.stackstorm.com/%s' % version_minus_2),
+        ('latest', '%slatest' % info.base_url),
+        (version, '%s%s' % (info.base_url, version)),
+        (version_minus_1, '%s%s' % (info.base_url, version_minus_1)),
+        (version_minus_2, '%s%s' % (info.base_url, version_minus_2)),
     ],
     'current_version': version
 }
+
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {
+     # The paper size ('letterpaper' or 'a4paper').
+     #
+     # 'papersize': 'letterpaper',
+
+     # The font size ('10pt', '11pt' or '12pt').
+     #
+     # 'pointsize': '10pt',
+
+     # Additional stuff for the LaTeX preamble.
+     #
+     # 'preamble': '',
+
+     # Latex figure (float) alignment
+     #
+     # 'figure_align': 'htbp',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = info.latex_documents
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+#
+# latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+#
+# latex_use_parts = False
+
+# If true, show page references after internal links.
+#
+# latex_show_pagerefs = False
+
+# If true, show URL addresses after external links.
+#
+# latex_show_urls = False
+
+# Documents to append as an appendix to all manuals.
+#
+# latex_appendices = []
+
+# It false, will not define \strong, \code,     itleref, \crossref ... but only
+# \sphinxstrong, ..., \sphinxtitleref, ... To help avoid clash with user added
+# packages.
+#
+# latex_keep_old_macro_names = True
+
+# If false, no module index is generated.
+#
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'stackstorm', u'StackStorm Documentation',
-     [u'StackStorm team'], 1)
-]
+man_pages = info.man_pages
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -296,11 +357,7 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
-texinfo_documents = [
-    ('index', 'StackStorm', u'StackStorm Documentation',
-     u'StackStorm team', 'StackStorm', 'One line description of project.',
-     'Miscellaneous'),
-]
+texinfo_documents = info.texinfo_documents
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# This file contains values that differ between open-source
+# to commercial (BWC) documentation. Everything that might
+# change from one version to another in conf.py should be 
+# placed here, otherwise you WILL break the build.
+
+project = u'StackStorm'
+copyright = u'2016, StackStorm'
+author = u'Brocade Communications Inc'
+
+base_url = u'http://docs.stackstorm.com/'
+htmlhelp_basename = 'StackStormDoc'
+
+man_pages = [
+    ('index', 'stackstorm', u'StackStorm Documentation',
+     [u'StackStorm team'], 1)
+]
+latex_documents = [
+    (master_doc, 'stackstorm-docs.tex', u'StackStorm Documentation',
+     u'StackStorm team', 'manual'),
+]
+texinfo_documents = [
+    ('index', 'StackStorm', u'StackStorm Documentation',
+     u'StackStorm team', 'StackStorm', 'One line description of project.',
+     'Miscellaneous'),
+]
+
+github_repo = 'StackStorm/st2docs'
+github_version = 'master'

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -30,3 +30,5 @@ texinfo_documents = [
 
 github_repo = 'StackStorm/st2docs'
 github_version = 'master'
+
+theme_base_url = u'http://docs.stackstorm.com/'

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -5,6 +5,8 @@
 # change from one version to another in conf.py should be 
 # placed here, otherwise you WILL break the build.
 
+master_doc = 'index'
+
 project = u'StackStorm'
 copyright = u'2016, StackStorm'
 author = u'Brocade Communications Inc'


### PR DESCRIPTION
This is needed for BWC docs build: we'll just have a different `info.py` there, while `conf.py` will be a single source of truth, and there'll be no need to constantly keep a bunch of config files in sync.