### PR TITLE
Adding `solutions/*` to toctree

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -377,6 +377,3 @@ texinfo_documents = info.texinfo_documents
 intersphinx_mapping = {'http://docs.python.org/': None}
 
 autoclass_content = 'both'
-
-# A config variable that checks if StackStorm or BWC is being built.
-bwc = info.bwc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -377,3 +377,6 @@ texinfo_documents = info.texinfo_documents
 intersphinx_mapping = {'http://docs.python.org/': None}
 
 autoclass_content = 'both'
+
+# A config variable that checks if StackStorm or BWC is being built.
+bwc = info.bwc

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,4 +36,4 @@ Contents:
     upgrade_notes
     roadmap
 
-..include:: solutions/toc.rst
+..include:: _includes/bwc_toc.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,4 +39,5 @@ Contents:
 .. toctree::
     :maxdepth: 3
     :glob:
+    
     solutions/*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,10 +36,4 @@ Contents:
     upgrade_notes
     roadmap
 
-..ifconfig:: bwc === True
-
-    .. toctree::
-        :maxdepth: 3
-        :glob:
-
-        solutions/*
+..include:: solutions/toc.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,3 +35,4 @@ Contents:
     changelog
     upgrade_notes
     roadmap
+    solutions/*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,8 +36,10 @@ Contents:
     upgrade_notes
     roadmap
 
-.. toctree::
-    :maxdepth: 3
-    :glob:
-    
-    solutions/*
+..ifconfig:: bwc === True
+
+    .. toctree::
+        :maxdepth: 3
+        :glob:
+
+        solutions/*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,4 +35,8 @@ Contents:
     changelog
     upgrade_notes
     roadmap
+
+.. toctree::
+    :maxdepth: 3
+    :glob:
     solutions/*

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -32,5 +32,3 @@ github_repo = 'StackStorm/st2docs'
 github_version = 'master'
 
 theme_base_url = u'http://docs.stackstorm.com/'
-
-bwc = False

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -32,3 +32,5 @@ github_repo = 'StackStorm/st2docs'
 github_version = 'master'
 
 theme_base_url = u'http://docs.stackstorm.com/'
+
+bwc = False


### PR DESCRIPTION
Adding `solutions/*` to toctree to list all the BWC solutions in BWC docs.