### PR TITLE
Build and run docs with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+virtualenv
+st2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu
+
+RUN apt-get -qq update && apt-get -q install -y \
+    git \
+    python-dev python-pip python-virtualenv \
+    libffi-dev libssl-dev
+
+ADD . /st2docs
+WORKDIR /st2docs
+RUN make .cleandocs && make docs
+
+EXPOSE 8000
+
+CMD make .livedocs
+
+#CMD  . ./virtualenv/bin/activate; \
+#    sphinx-autobuild -H 0.0.0.0 -b html ./docs/source/ ./docs/build/html

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Product documentation for StackStorm is maintained in this repository. These doc
 
 ## Build and Run the Docs.
 
+#### Build locally on Linux
 Follows these steps to build the docs locally:
 
 ```bash
@@ -37,6 +38,35 @@ all the Python dependencies which are needed to build the docs.
 `make livedocs` builds the docs and runs the doc site live at [http://localhost:8000](http://localhost:8000) to
 validate changes locally prior to committing any code.
 
+#### Run with Docker
+```bash
+git clone https://github.com/StackStorm/st2docs.git
+cd st2docs
+./scripts/docker-build.sh
+./scripts/docker-run.sh
+```
+This will build a docker image and run it in a container, serving docs live at [http://localhost:8000](http://localhost:8000).
+Edit the sources and enjoy live updates.
+
+Before pushing the PR, it's good idea to run a full build and catch any warnings which will fail the official build. Here is how:
+```
+run --rm -it -v "$PWD"/docs/source:/st2docs/docs/source st2/st2docs /bin/bash -c "make .cleandocs ; make .docs"
+```
+#### Running docs only
+
+To make docs changes, without installing full development environment (e.g., on Mac or Windows):
+
+```bash
+git clone git@github.com:StackStorm/st2docs.git
+cd st2docs
+make docs
+# make docs will fail; ignore the failure:
+# it will get st2 and set up virtualenv with sphinx/shinx-autobuild
+. virtualenv/bin/activate
+sphinx-autobuild -H 0.0.0.0 -b html ./docs/source/ ./docs/build/html
+```
+
+Edit, enjoy live updates.
 ## Sphinx Tricks
 
 * If the whole section belongs in the Enterprise Edition, put the following note:
@@ -117,22 +147,6 @@ pandoc - a super-tool to convert between formats. Sample for markdown conversion
 
   sudo apt-get install pandoc
   pandoc --from=markdown --to=rst --output=README.rst README.md
-
-## Running docs only
-
-To make docs changes, without installing full development environment (e.g., on Mac or Windows):
-
-```bash
-git clone git@github.com:StackStorm/st2docs.git
-cd st2docs
-make docs
-# make docs will fail; ignore the failure: 
-# it will get st2 and set up virtualenv with sphinx/shinx-autobuild
-. virtualenv/bin/activate
-sphinx-autobuild -H 0.0.0.0 -b html ./docs/source/ ./docs/build/html
-```
-
-Edit, enjoy live updates.
 
 ## Misc
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+pushd `dirname $0` > /dev/null
+ST2DOCSROOT="${PWD%/*}"
+popd > /dev/null
+
+docker build -t st2/st2docs -f $ST2DOCSROOT/Dockerfile $ST2DOCSROOT

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+pushd `dirname $0` > /dev/null
+ST2DOCSROOT="${PWD%/*}"
+popd > /dev/null
+
+docker run --rm -it -p 127.0.0.1:8000:8000 \
+  -v "$ST2DOCSROOT"/docs/source:/st2docs/docs/source st2/st2docs


### PR DESCRIPTION
I got worried about explaining "how to write the docs" to less-technical folks. 

Using Docker for live-editing the docs, and pushing the doc-only PRs seem to be simpler and faster. Especially for those who have no st2 dev environment. With docker coming natively on Windows and Mac, it may be even simpler setup for windows users. Let's test on PMs :)

Once Docker is installed: 
```bash
git clone https://github.com/StackStorm/st2docs.git
cd st2docs
./scripts/docker-build.sh  # Builds an image with all the dependencies, runs 10+ min, grab a coffee
./scripts/docker-run.sh # Runs the doc site live. Enjoy.
```

That's it. Edit the sources and enjoy live updates at [http://localhost:8000](http://localhost:8000)
