### PR TITLE
bwclocaldocs ain't need to build no docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ bwcdocs: .clone-st2 .clone-ipfabric requirements .requirements-st2 .patch-soluti
 bwclivedocs: bwcdocs .livedocs
 
 .PHONY: bwclocaldocs
-bwclocaldocs: .clone-st2 requirements .requirements-st2 .bwcdocs .docs
+bwclocaldocs: .clone-st2 requirements .requirements-st2 .bwcdocs
 
 .PHONY: bwclocallivedocs
 bwclocallivedocs: bwclocaldocs .livedocs


### PR DESCRIPTION
I forgot to remove .docs target from bwclocaldocs. Now we build enterprise docs separately and the target for that is .enterprise-docs which is already called. 