### PR TITLE
Makefile update to remove solutions stuff and consolidate solutions images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ docs: .clone-st2 requirements .requirements-st2 .docs
 PHONY: .docs
 .docs: .community-docs
 
-PHONY: .remove-bwc-solutions-folders
-.remove-bwc-solutions-folders:
+PHONY: .clean-bwc-solutions-folders
+.clean-bwc-solutions-folders:
 	@echo
-	@echo "==================== Remove solution specific stuff ===================="
+	@echo "==================== Remove solution specific folders ===================="
 	@echo
 	rm -Rf docs/source/_static/images/solutions/ipfabric/*
 	rm -Rf docs/source/_includes/bwc_toc.rst
@@ -60,7 +60,7 @@ PHONY: .remove-bwc-solutions-folders
 	@echo
 
 .PHONY: .community-docs
-.community-docs: .remove-bwc-solutions-folders
+.community-docs: .clean-bwc-solutions-folders
 	@echo
 	@echo "==================== COMMUNITY DOCS ===================="
 	@echo
@@ -127,7 +127,7 @@ bwcdocs: .clone-st2 .clone-ipfabric requirements .requirements-st2 .bwcdocs
 bwclivedocs: bwcdocs .livedocs
 
 .PHONY: bwclocaldocs
-bwclocaldocs: .clone-st2 requirements .requirements-st2 .bwcdocs .remove-bwc-solutions-folders
+bwclocaldocs: .clone-st2 requirements .requirements-st2 .bwcdocs .clean-bwc-solutions-folders
 
 .PHONY: bwclocallivedocs
 bwclocallivedocs: bwclocaldocs .livedocs

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,19 @@ docs: .clone-st2 requirements .requirements-st2 .docs
 PHONY: .docs
 .docs: .community-docs
 
+PHONY: .remove-bwc-solutions-folders
+.remove-bwc-solutions-folders:
+	@echo
+	@echo "==================== Remove solution specific stuff ===================="
+	@echo
+	rm -Rf docs/source/_static/images/solutions/ipfabric/*
+	rm -Rf docs/source/_includes/bwc_toc.rst
+	rm -Rf docs/source/solutions/ipfabric
+	@echo
+	@echo
+
 .PHONY: .community-docs
-.community-docs:
+.community-docs: .remove-bwc-solutions-folders
 	@echo
 	@echo "==================== COMMUNITY DOCS ===================="
 	@echo
@@ -88,7 +99,7 @@ livedocs: docs .livedocs
 	@echo
 
 .PHONY: bwcdocs
-bwcdocs: .clone-st2 .clone-ipfabric requirements .requirements-st2 .patch-solutions .enterprise-docs .git-checkout-local-changes
+bwcdocs: .clone-st2 .clone-ipfabric requirements .requirements-st2 .bwcdocs
 
 .PHONY: .bwcdocs
 .bwcdocs: .patch-solutions .enterprise-docs .git-checkout-local-changes
@@ -116,7 +127,7 @@ bwcdocs: .clone-st2 .clone-ipfabric requirements .requirements-st2 .patch-soluti
 bwclivedocs: bwcdocs .livedocs
 
 .PHONY: bwclocaldocs
-bwclocaldocs: .clone-st2 requirements .requirements-st2 .bwcdocs
+bwclocaldocs: .clone-st2 requirements .requirements-st2 .bwcdocs .remove-bwc-solutions-folders
 
 .PHONY: bwclocallivedocs
 bwclocallivedocs: bwclocaldocs .livedocs

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ PHONY: .clean-bwc-solutions-folders
 	@echo
 	@echo "==================== Remove solution specific folders ===================="
 	@echo
-	rm -Rf docs/source/_static/images/solutions/ipfabric/*
+	rm -Rf docs/source/_static/images/solutions/*
 	rm -Rf docs/source/_includes/bwc_toc.rst
-	rm -Rf docs/source/solutions/ipfabric
+	rm -Rf docs/source/solutions/*
 	@echo
 	@echo
 


### PR DESCRIPTION
Refer: https://github.com/StackStorm/ipfabric-docs/pull/24

- All the images in the solutions should be placed under _static/images/solutions/<solution_name>/ to keep the make file in st2docs clean.
- Add `.remove-bwc-solutions-folders` target to remove any solutions docs before making `community-docs` and to clean up after `bwclocaldocs`. ( `make docs` was failing, if make targets for bwc were executed before)