### PR TITLE
RFR: added |fullname| substitution

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,10 +117,10 @@ extlinks = {
 
 if tags.has('enterprise'):
     print "Building BWC docs"
-    product_replace = "\n.. |st2| replace:: BWC"
+    product_replace = "\n.. |st2| replace:: BWC\n.. |fullname| replace:: Brocade Workflow Composer"
 else:
     print "Building StackStorm docs"
-    product_replace = "\n.. |st2| replace:: StackStorm"
+    product_replace = "\n.. |st2| replace:: StackStorm\n.. |fullname| replace:: StackStorm"
 
 rst_epilog = """
 %s

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Welcome to |st2|'s documentation!
+Welcome to |fullname|'s documentation!
 ======================================
 
 Contents:


### PR DESCRIPTION
We have a substitution that maps `|st2|` to 'StackStorm' for the community docs, and to 'BWC' if the docs are built with `-t enterprise`

We also have a substitution that maps `|bwc|` to `Brocade Workflow Composer`.

But sometimes we need to map `|st2|` to either `StackStorm` or `Brocade Workflow Composer` - e.g. for /index.html, we want to say "Welcome to Brocade Workflow Composer's Documentation!"

This change is a little bit ugly. Adds a |fullname| substitution. 

Thoughts @humblearner ?