### PR TITLE
added verbiage around enterprise key

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -307,7 +307,9 @@ If you already run a Hubot instance, you only have to install the `hubot-stackst
 Upgrade to Enterprise Edition
 -----------------------------
 Enterprise Edition is deployed as an addition on top of StackStorm Community. You will need an active
-Enterprise subscription, and a license key to access StackStorm enterprise repositories.
+Enterprise subscription, and a license key to access StackStorm enterprise repositories. To add your 
+license key, replace ``${ENTERPRISE_LICENSE_KEY}`` in the command below with the key you received when 
+registering or purchasing.
 
 .. code-block:: bash
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -389,7 +389,9 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
 Upgrade to Enterprise Edition
 -----------------------------
 Enterprise Edition is deployed as an addition on top of StackStorm Community. You will need an active
-Enterprise subscription, and a license key to access StackStorm enterprise repositories.
+Enterprise subscription, and a license key to access StackStorm enterprise repositories. To add your
+license key, replace ``${ENTERPRISE_LICENSE_KEY}`` in the command below with the key you received when
+registering or purchasing.
 
 .. code-block:: bash
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -354,7 +354,9 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
 Upgrade to Enterprise Edition
 -----------------------------
 Enterprise Edition is deployed as an addition on top of StackStorm Community. You will need an active
-Enterprise subscription, and a license key to access StackStorm enterprise repositories.
+Enterprise subscription, and a license key to access StackStorm enterprise repositories. To add your
+license key, replace ``${ENTERPRISE_LICENSE_KEY}`` in the command below with the key you received when
+registering or purchasing.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Better explanation of how to use the license key, based upon feedback from @Plaporte 