### PR TITLE
changed 64 bit to 64-bit

### DIFF
--- a/docs/source/install/__64bit_note.rst
+++ b/docs/source/install/__64bit_note.rst
@@ -1,3 +1,3 @@
 .. note::
 
-  Please note that only 64 bit architecture is currently supported.
+  Please note that only 64-bit architecture is currently supported.


### PR DESCRIPTION
Apparently the proper way to refer to it is "64-bit", not "64 bit"