### PR TITLE
disable pilcrow symbol

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -4546,18 +4546,18 @@ nav.stickynav {
   margin: auto;
   display: block;
 }
-.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink {
+.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink, .rst-content p .headerlink {
   display: none;
   visibility: hidden;
   font-size: 14px;
 }
-.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after {
+.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after, .rst-content p .headerlink:after {
   visibility: visible;
   content: "";
   font-family: FontAwesome;
   display: inline-block;
 }
-.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink {
+.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink, .rst-content p:hover .headerlink {
   display: inline-block;
 }
 .rst-content .sidebar {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,6 +203,9 @@ html_theme_options = {
     'base_url': info.theme_base_url
 }
 
+# Disables pilcrow symbol on toctree next to caption headings
+html_add_permalink = ""
+
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 html_theme_path = ["_themes", ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,9 +203,6 @@ html_theme_options = {
     'base_url': info.theme_base_url
 }
 
-# Disables pilcrow symbol on toctree next to caption headings
-html_add_permalink = ""
-
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 html_theme_path = ["_themes", ]


### PR DESCRIPTION
This disables the permalink and the pilcrow (¶) symbol on the Caption headings in the TOC.

Seems to still work for displaying permalinks in normal pages - they have a symbol that only appears on hover.