### PR TITLE
Renaming, Heading Cleanup, TOC Changes

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -78,7 +78,7 @@ actions to be run remotely (via SSH) and locally. The objective is to
 allow the Action author to concentrate only on the implementation of the
 action itself rather than setting up the environment.
 
-Available runners
+Available Runners
 ~~~~~~~~~~~~~~~~~
 
 The environment in which the action runs is specified by the runner.
@@ -122,7 +122,7 @@ picks a runner\_type it also inherits the runner parameters.
 
 .. _ref-actions-writing-custom:
 
-Writing custom actions
+Writing Custom Actions
 ^^^^^^^^^^^^^^^^^^^^^^
 
 An action is composed of two parts:
@@ -137,7 +137,7 @@ language, as long as it follows these conventions:
    (e.g. ``1``)
 2. All log messages should be printed to standard error
 
-Action metadata
+Action Metadata
 ~~~~~~~~~~~~~~~
 
 Action metadata is used to describe the action and is defined as YAML (JSON is supported for backward
@@ -188,7 +188,7 @@ In the example above, ``to_number`` parameter contains attribute ``secret``
 with value:``true``. If an attribute is marked as a secret, the value of that
 attribute will be masked in the |st2| service logs.
 
-Parameters in actions
+Parameters in Actions
 ~~~~~~~~~~~~~~~~~~~~~
 
 In the previous example, you probably noticed how you can access parameters from
@@ -288,8 +288,8 @@ Overriding attributes such as ``type`` and ``position`` are not allowed because 
 potentially break the action since the runner will not be able to consume the type of value being
 passed (e.g. runner parameter is expecting an integer but a string is passed).
 
-Common environment variables available to the actions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Environment Variables Available to Actions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, local, remote and python runner make the following environment variables available
 to the actions:
@@ -315,7 +315,7 @@ action.
 
 .. _ref-actions-converting-scripts:
 
-Converting existing scripts into actions
+Converting Existing Scripts into Actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you have an existing standalone script written in an arbitrary programming
@@ -484,7 +484,7 @@ Both of them declare a ``position`` attribute (0 for server and 1 for message),
 which means they will be passed to the action script as positional arguments so
 your script doesn't require any changes.
 
-Writing custom Python actions
+Writing Custom Python Actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In the simplest form, a Python action is a module which exposes a class which
@@ -544,7 +544,7 @@ success status flag and the result object respectively.
 For a more complex example, please refer to the `actions in the Libcloud pack in
 the contrib repository <https://github.com/StackStorm/st2contrib/tree/master/packs/libcloud/actions>`_.
 
-Configuration file
+Configuration File
 ~~~~~~~~~~~~~~~~~~
 
 .. note::
@@ -616,7 +616,7 @@ Example storing a dict as JSON:
       # Delete a value
       self.action_service.delete_value('cache')
 
-Pre-defined actions
+Pre-defined Actions
 ^^^^^^^^^^^^^^^^^^^
 
 There are several predefined actions that come out of the box when |st2|

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -179,7 +179,7 @@ Run the following curl commands to test.
     # The following will verify the SSL cert, succeed, and return a valid token.
     curl -X POST --cacert /path/to/cacert.pem -u yourusername:yourpassword https://myhost.example.com/auth/v1/tokens
 
-.. note:: Until version 1.2 of StackStorm, auth APIs were served from its own port. If your version is 1.1.1 or below, replace '/api' with ':9100'.
+.. note:: Until version 1.2 of |st2|, auth APIs were served from its own port. If your version is 1.1.1 or below, replace '/api' with ':9100'.
 
 .. _authentication-usage:
 
@@ -235,7 +235,7 @@ The following are sample API calls via curl using API Keys. ::
 
     curl https://myhost.example.com/api/v1/actions?st2-api-key=<API-KEY-VALUE>
 
-API key migration
+API Key Migration
 ^^^^^^^^^^^^^^^^^
 
 API keys can be migrated from one |st2| instance to another. This way external services that have already
@@ -257,11 +257,11 @@ On new |st2| instance load API keys from the file.
     st2 apikey load apikeys.yaml
 
 
-Sending authentication token or API key to the API
---------------------------------------------------
+Using Authentication Tokens or API Keys with the API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When authenticating against the |st2| API, authentication token or API key
-(but not both), should be provided in the HTTP request headers. The headers are
+To authenticate against the |st2| API, either an authentication token or an API key
+(but not both) should be provided in the HTTP request headers. The headers are
 named ``X-Auth-Token`` and ``St2-Api-Key`` respectively.
 
 If for some reason you can't specify auth token or API key in the headers (e.g.

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -27,8 +27,8 @@ Architecture
 
 ChatOps leverages two components within |st2| in order to provide a fluid user experience. These subsystems are the :doc:`aliases` and :doc:`notifications` subsystems. You can learn more about each of these individual components in their corresponding sub-sections.
 
-|st2| flavored ChatOps
-======================
+StackStorm-flavored ChatOps
+===========================
 
 Our goal with ChatOps is to take the patterns that are arising and make them consumable by teams of all makeups. Behind our implementation of ChatOps lies the operational scalability and stability of |st2|, allowing you to grow and unleash the latent power of your existing teams. In addition to allowing integration with a plethora of existing plugins and patterns available in the larger |st2| and ChatOps communities, we add these features to the tool-belt:
 

--- a/docs/source/datastore.rst
+++ b/docs/source/datastore.rst
@@ -11,10 +11,10 @@ python client. For rule definitions in YAML/JSON, the key value pairs are
 referenced with a specific string substitution syntax and the references
 are resolved on rule evaluation.
 
-Storing and Retrieving Key Value Pairs from CLI
------------------------------------------------
+Storing and Retrieving Key Value Pairs via CLI
+----------------------------------------------
 
-Set a value of a key value pair.
+Set the value of a key value pair:
 
 ::
 
@@ -22,7 +22,7 @@ Set a value of a key value pair.
     st2 key set aws_cfn_endpoint https://cloudformation.us-west-1.amazonaws.com
 
 Load a list of key value pairs from a JSON file. The following is the
-JSON example using the same keys from the create examples above.
+JSON example using the same keys from the create examples above:
 
 ::
 
@@ -38,14 +38,14 @@ JSON example using the same keys from the create examples above.
 The load command also allows you to directly load the output of "key list -j"
 command. This is useful if you want to migrate datastore items from a different
 cluster or if you want to version control the datastore items and load the from
-version controlled files.
+version controlled files:
 
 ::
 
     st2 key list -j > mydata.json
     st2 key load mydata.json
 
-Get individual key value pair or list all.
+Get individual key value pair or list all:
 
 ::
 
@@ -53,13 +53,13 @@ Get individual key value pair or list all.
     st2 key get os_keystone_endpoint
     st2 key get os_keystone_endpoint -j
 
-Update an existing key value pair.
+Update an existing key value pair:
 
 ::
 
     st2 key set os_keystone_endpoint http://localhost:5000/v3
 
-Delete an existing key value pair.
+Delete an existing key value pair:
 
 ::
 
@@ -67,8 +67,8 @@ Delete an existing key value pair.
 
 .. _datastore-scopes-in-key-value-store:
 
-Scoping items stored in datastore
----------------------------------
+Scoping Datastore Items
+-----------------------
 
 By default, all items stored in key value store are stored in ``system`` scope. This
 basically means every user has access to these variables. You'd typically use the
@@ -76,7 +76,7 @@ jinja expression ``{{system.key_name}}`` to refer to these variables in actions 
 workflows. Starting version 1.5 of |st2|, you can now scope variables to a specific
 user. With authentication enabled, you can now control who can read or write into those
 variables. For example, to set variable ``date_cmd`` for the currently authenticated
-user, use
+user, use:
 
 ::
 
@@ -85,19 +85,19 @@ user, use
 The name of the user is figured out from the ``X-Auth-Token`` or ``St2-Api-Key``
 header passed with the API call. Basically, from the API call authentication
 credentials, we figure out the user and assign this variable to that particular user.
-To get the key back, use
+To get the key back, use:
 
 ::
 
     st2 key get date_cmd --scope=user
 
-Remember, if you want a variable ``date_cmd`` as a system variable, you can use
+Remember, if you want a variable ``date_cmd`` as a system variable, you can use:
 
 ::
 
     st2 key set date_cmd "date +%s" --scope=system
 
-or simply
+or simply:
 
 ::
 
@@ -107,16 +107,16 @@ This variable won't clash with the user variables under same name. Also, you can
 to user variables in actions or workflows. The jinja syntax to do so is
 ``{{user.date_cmd}}``. Note that the notion of ``user`` is available only when actions
 or workflows are run manually. The notion of ``user`` is non-existent when automations
-are run (actions kicked off via rules). So use of user scoped variables is limited to
+are run (actions kicked off via rules). So the use of user scoped variables is limited to
 manual execution of actions or workflows.
 
 
-Storing and Retrieving from Python Client
------------------------------------------
+Storing and Retrieving via Python Client
+----------------------------------------
 
 Create new key value pairs. The |st2| API endpoint is set either via
 the Client init (base\_url) or from environment variable
-(ST2\_BASE\_URL). The default ports for the API servers are assumed.
+(ST2\_BASE\_URL). The default ports for the API servers are assumed:
 
 ::
 
@@ -125,7 +125,7 @@ the Client init (base\_url) or from environment variable
     >>> client = Client(base_url='http://localhost')
     >>> client.keys.update(models.KeyValuePair(name='os_keystone_endpoint', value='http://localhost:5000/v2.0'))
 
-Get individual key value pair or list all.
+Get individual key value pair or list all:
 
 ::
 
@@ -134,7 +134,7 @@ Get individual key value pair or list all.
     >>> os_keystone_endpoint.value
     u'http://localhost:5000/v2.0'
 
-Update an existing key value pair.
+Update an existing key value pair:
 
 ::
 
@@ -142,7 +142,7 @@ Update an existing key value pair.
     >>> os_keystone_endpoint.value = 'http://localhost:5000/v3'
     >>> client.keys.update(os_keystone_endpoint)
 
-Delete an existing key value pair.
+Delete an existing key value pair:
 
 ::
 
@@ -178,8 +178,8 @@ related syntax.
 
 .. _admin-setup-for-encrypted-datastore:
 
-Securing secrets in key value store (admin only)
-------------------------------------------------
+Securing Secrets (admin only)
+-----------------------------
 
 .. note::
 
@@ -188,12 +188,12 @@ Securing secrets in key value store (admin only)
     no guarantee is made w.r.t ``security`` of the credentials stored in key value store.
 
 Key value store now allows users to store encrypted values (secrets). Symmetric encryption is used
-to encrypt secrets. |st2| administrator is responsible for generating symmetric key used for
-encryption / decryption. It goes without saying that |st2| operator and administrator (or anyone
+to encrypt secrets. The |st2| administrator is responsible for generating symmetric key used for
+encryption / decryption. It goes without saying that the |st2| operator and administrator (or anyone
 else who has access to the key) can decrypt the encrypted values if they want to.
 
 To generate a symmetric crypto key (AES256 used for both encryption and decryption) as an admin,
-please run
+please run:
 
 .. code-block:: bash
 
@@ -201,10 +201,10 @@ please run
     sudo st2-generate-symmetric-crypto-key --key-path /etc/st2/keys/datastore_key.json
 
 It is recommended that the key is placed in a private location such as ``/etc/st2/keys/`` and
-permissions are appropriately modified so that only StackStorm API process owner (usually ``st2``) can
+permissions are appropriately modified so that only |st2| API process owner (usually ``st2``) can
 read and admin can read/write to that file.
 
-To make sure only ``st2`` and root can access the file on the box, run
+To make sure only ``st2`` and root can access the file on the box, run:
 
 .. code-block:: bash
 
@@ -222,13 +222,13 @@ configuration file (usually /etc/st2/st2.conf) and add the following lines:
     [keyvalue]
     encryption_key_path = /etc/st2/keys/datastore_key.json
 
-Once the config file changes are made, restart |st2| by running
+Once the config file changes are made, restart |st2|:
 
 ::
 
   sudo st2ctl restart
 
-Validate you are able to set an encrypted key value in datastore by running
+Validate you are able to set an encrypted key value in datastore:
 
 ::
 
@@ -243,10 +243,10 @@ Now as an admin, you are all set with configuring |st2| server side.
 
 .. _datastore-storing-secrets-in-key-value-store:
 
-Storing secrets in key value store
-----------------------------------
+Storing Secrets
+---------------
 
-Please note that if an admin has not setup encryption key, you will not be allowed to save
+Please note that if an admin has not setup an encryption key, you will not be allowed to save
 secrets in the key value store. Contact your |st2| admin to setup encryption keys as per the section
 above.
 
@@ -257,7 +257,7 @@ To save a secret in key value store:
     st2 key set api_token SECRET_TOKEN --encrypt
 
 By default, getting a key tagged as secret (via --encrypt) will always return encrypted values only.
-To get plain text, please run with command --decrypt flag.
+To get plain text, please run with command --decrypt flag:
 
 .. code-block:: bash
 
@@ -272,7 +272,7 @@ To get plain text, please run with command --decrypt flag.
 Security notes
 --------------
 
-|st2| wishes to discuss security details and be transparent about the implementation and limitations
+We wish to discuss security details and be transparent about the implementation and limitations
 of the security practices to attract more eyes to it and therefore build better quality into
 security implementations. For the key value store, we have settled on AES256 symmetric encryption
 for simplicity. We use python library keyczar for doing this.
@@ -288,4 +288,4 @@ to still see only encrypted secret in database. Still the onus is on |st2| admin
 access to database via network daemons only and not allow physical access to the box (or run
 databases on different boxes as st2). Note that several layers of security needs to be in place
 that is beyond the scope of this document. While we can help people with deployment questions
-on stackstorm slack community, please follow your own best security practices guide.
+on StackStorm Slack community, please follow your own best security practices guide.

--- a/docs/source/development/code_structure.rst
+++ b/docs/source/development/code_structure.rst
@@ -3,43 +3,43 @@
 Code structure
 ==============
 
-You might be tempted to contribute to |st2| by this point. Let us walk you through the code a
+You might be tempted to contribute to StackStorm by this point. Let us walk you through the code a
 bit.
 
-StackStorm/st2 repo
-===================
+StackStorm/st2 Repo
+-------------------
 
-|st2| is made up of individual services viz. `st2auth`, `st2api`, `st2rulesengine`,
+StackStorm is made up of individual services viz. `st2auth`, `st2api`, `st2rulesengine`,
 `st2sensorcontainer`, `st2actionrunner`, `st2notifier`.
 
-Also, |st2| has a CLI and client library. Code for all these services and components are laid
+Also, StackStorm has a CLI and client library. Code for all these services and components are laid
 out in different folders in the repo root.
 
 st2common
-=========
+---------
 
 Common code that contains db and api data models, utility functions and common service code
-that all of |st2| needs. Each service package (deb/rpm) has a dependency on st2common package
+that all of StackStorm needs. Each service package (deb/rpm) has a dependency on st2common package
 being available. So if you want common code that should be shared amongst components written,
 you'd add them here.
 
 st2api
-======
+------
 
-This folder contains code for API controllers in |st2|. APIs are versioned and so are controllers.
+This folder contains code for API controllers in StackStorm APIs are versioned and so are controllers.
 Experimental controllers are added to `exp` folder inside st2api and when they mature, they are
 moved to folders containing versioned controllers.
 
 st2auth
-=======
+-------
 
 Contains code for st2auth endpoint. Since this endpoint needs to deployed separately than st2api,
 it is available as a separate app.
 
 st2actions
-==========
+----------
 
-Contains code for action runners. A new runner written for |st2| would be added to
+Contains code for action runners. A new runner written for StackStorm would be added to
 st2actions/st2actions/runners. Also, this folder contains the code for worker node that scans
 rabbitmq for incoming executions.
 
@@ -50,24 +50,24 @@ a workflow is kicked off remotely and you have to hit the mistral APIs to collec
 polling fashion.
 
 st2client
-=========
+---------
 
-Contains code for both |st2| client library and |st2| cli bundled into one folder. We will
+Contains code for both StackStorm client library and StackStorm cli bundled into one folder. We will
 eventually split them out.
 
 st2debug
-========
+--------
 
 If you are familiar with ``st2-submit-debug-info`` tool, the code for that is present in this folder.
-This tool provides a way to share logs and other info with a |st2| engineer for troubleshooting.
+This tool provides a way to share logs and other info with a StackStorm engineer for troubleshooting.
 
 st2reactor
-==========
+----------
 
 Contains code for both sensor container and rules engine.
 
 st2tests
-========
+--------
 
 Shared code containing fixtures and test utilities that helps in unit and integration testing
-for all |st2| components.
+for all StackStorm components.

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -1,7 +1,7 @@
 Development
 ===========
 
-This page describes StackStorm development process and contains general
+This page describes the StackStorm development processes and contains general
 guidelines and information on how to contribute to the project.
 
 Contributing
@@ -20,7 +20,7 @@ For information on contributing an integration pack, please refer to the
 For an overview of core StackStorm code structure, please refer to
 :doc:`Code structure </development/code_structure>`.
 
-Setting up a development environment
+Setting up a Development Environment
 ------------------------------------
 
 There are multiple ways for you to set up a development environment and get
@@ -34,7 +34,7 @@ Another approach is to install StackStorm and all the dependencies from source
 on a server or VM of your liking. For more information about this approach, see
 :doc:`Installing StackStorm from sources </development/sources>`.
 
-General contribution guidelines
+General Contribution Guidelines
 -------------------------------
 
 * Any non-trivial change must contain corresponding tests. For more

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Welcome to |st2|'s documentation!
+|fullname| Documentation
 ======================================
 
 Contents:
@@ -39,7 +39,7 @@ Contents:
 .. include:: _includes/solutions.rst
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
     :caption: Release Notes
 
     changelog

--- a/docs/source/install/common/configure_ssh_and_sudo.rst
+++ b/docs/source/install/common/configure_ssh_and_sudo.rst
@@ -5,7 +5,7 @@
     sudo mkdir -p /home/stanley/.ssh
     sudo chmod 0700 /home/stanley/.ssh
 
-    # On the StackStorm host, generate ssh keys
+    # Generate ssh keys
     sudo ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
 
     # Authorize key-based access

--- a/docs/source/install/enterprise.rst
+++ b/docs/source/install/enterprise.rst
@@ -1,12 +1,12 @@
 Installing Brocade Workflow Composer
 ====================================
 
-StackStorm  is an event-driven DevOps automation platform with all the essential features suitable for small businesses and teams. It’s free and open source under the Apache 2.0 license.
+StackStorm is an event-driven DevOps automation platform with all the essential features suitable for small businesses and teams. It’s free and open source under the Apache 2.0 license.
 
-Brocade Workflow Composer (BWC) is the enterprise version of StackStorm that is built on
-top of the StackStorm. It adds priority support, enterprise tools such
-as fine-tuned access control, LDAP integration and Workflow Designer -  the visual workflow editor.
-BWC also ships with networking automation suites.
+|bwc| (BWC) is the enterprise version, built on top of StackStorm. It adds
+priority support, enterprise tools such as fine-tuned access control, LDAP
+integration and Workflow Designer -  the visual workflow editor. BWC also
+ships with networking automation suites.
 
 To learn more about Brocade Workflow Composer, request a quote or get an evaluation license,
 go to `brocade.com/network-automation/workflow-composer <http://www.brocade.com/en/products-services/network-automation/workflow-composer.html>`_.
@@ -22,6 +22,3 @@ go to `brocade.com/network-automation/workflow-composer <http://www.brocade.com/
     :doc:`/install/rhel6`. The last step of the instructions is ``BWC Enterprise``
 
     .. include:: /__engage_enterprise.rst
-
-
-

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -1,10 +1,10 @@
 Installation
 ============
 
-For a quick evaluation of |st2| and package-based installation, start from
-:doc:`Overview <./overview>`, and proceed with the guide for your Linux distribution.
+For a quick evaluation of |st2|, start from
+:doc:`Overview <./overview>`, then proceed with the guide for your Linux distribution.
 
-Please note that only 64 bit architecture is currently supported.
+Please note that only 64-bit architecture is currently supported.
 
 .. rubric:: Installations
 
@@ -18,4 +18,4 @@ Please note that only 64 bit architecture is currently supported.
     StackStorm vs BWC <enterprise>
     config/index
     Updates and Upgrades <upgrades>
-    Migration scripts <migration>
+    Migration Scripts <migration>

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -50,7 +50,7 @@ share a dedicated Python virtualenv, and are configured by /etc/st2/st2.conf.
 2. st2client
 -------------
 
-``st2client`` is the CLI and Python bindings for StackStorm API. To configure CLI to point to the right
+``st2client`` is the CLI and Python bindings for the |st2| API. To configure CLI to point to the right
 API, authentication options, suppressing insecure warnings for self-signed certificates and other
 conveniences see :doc:`/reference/cli`. ``st2client`` is packaged with ``st2``, or can be installed
 independently.

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -86,7 +86,7 @@ re-run.
 
     Rerunning workflow execution from the task(s) that failed is currently an experimental
     feature and subject to bug(s) and change(s). Please also note that rerunning a subtask nested
-    in another StackStorm action is not currently supported.
+    in another |st2| action is not currently supported.
 
 Publishing variables in Mistral workflows
 +++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -14,7 +14,7 @@ About
 
 |st2| helps you compose these and other operational patterns as rules and workflows or actions. These rules and workflows - the content within the |st2| platform - are stored *as code* which means they support the same approach to collaboration that you use today for code development. They can be shared with the broader open source community, for example via the `StackStorm community <http://www.stackstorm.com/community/>`_.
 
-How it works
+How it Works
 -------------
 
 .. figure:: /_static/images/architecture_diagram.jpg

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -8,7 +8,7 @@ Pack is the unit of deployment for integrations and automations that extend |st2
 
 It is best to view a pack as the means to extend |st2| and allow it to integrate with an external systems. See `next section` to learn more about pack management.
 
-Packs location and discovery
+Packs Location and Discovery
 ----------------------------
 
 When using |st2| and pack management actions, all the packs are by default installed into the
@@ -31,7 +31,7 @@ For example:
 Note: Directories are always searched from left to right in the order they are
 specified, with the system packs directory always searched first.
 
-Getting a pack
+Getting a Pack
 --------------
 
 Pack management is done by |st2| actions from `packs` pack, pun intended. Run ``st2 action list --pack packs`` for a list of pack management actions.
@@ -113,7 +113,7 @@ See :doc:`/reference/packs` for details on how to package your integrations and 
 * Explore existing packs for many common products and tools from `StackStorm community <http://www.stackstorm.com/community/>`__ - `st2contrib <https://github.com/StackStorm/st2contrib>`__.
 * Learn how to write a pack and contribute to the community  - :doc:`/reference/packs`.
 * Learn how to write :ref:`custom sensors <ref-sensors-authoring-a-sensor>` and :ref:`custom actions <ref-actions-writing-custom>`.
-* Check out `tutorials on stackstorm.com <http://stackstorm.com/category/tutorials/>`__ - a growing set of practical examples of automating with StackStorm.
+* Check out `tutorials on stackstorm.com <http://stackstorm.com/category/tutorials/>`__ - a growing set of practical examples of automating with |st2|.
 * For information on pack testing, please see the :doc:`Pack Testing </development/pack_testing>` page.
 
 .. include:: /__engage_community.rst

--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -22,7 +22,7 @@ efficiently utilize the RBAC system.
 User
 ~~~~
 
-A user represents an entity (person / robot) which needs to be authenticated and interacts with
+A user represents an entity (person/system) which needs to be authenticated and interacts with
 |st2| through the API.
 
 User permissions are represented as a union of permission grants which are assigned to all the user
@@ -54,11 +54,11 @@ Currently, the following system roles are available:
 * **Administrator** - All the permissions on all the resources.
 * **Observer** - ``view`` permission on all the resources.
 
-Permission grant
+Permission Grant
 ~~~~~~~~~~~~~~~~
 
 Permission grant grants a particular permission (permission type) to a particular resource. For
-example, you could grant an execute / run permission (``action_execute``) to an action
+example, you could grant an execute/run permission (``action_execute``) to an action
 ``core.local``.
 
 In general, there are five permission types available for each supported resource type:
@@ -153,7 +153,7 @@ For example:
     |                         |                         |           |                         | remotely.               |
     +-------------------------+-------------------------+-----------+-------------------------+-------------------------+
 
-How it works
+How it Works
 ------------
 
 User permissions are checked when a user performs an operation using the API. If user has the
@@ -207,7 +207,7 @@ system user (``stanley``).
 By default, ``stanley`` and ``chatops_bot`` user have ``admin`` role assignment to them, which
 means they have all the permissions.
 
-Defining roles and assignments
+Defining Roles and Assignments
 ------------------------------
 
 To follow infrastructure as code approach, roles and user role assignments are defined in YAML
@@ -252,7 +252,7 @@ In the example above we assign user with the username ``user4`` two roles -
 ``role_one`` (a custom role which needs to be defined as described above) and
 ``observer`` (system role).
 
-Applying RBAC definitions
+Applying RBAC Definitions
 -------------------------
 
 As described above, RBAC definitions are defined in YAML files located in the
@@ -287,8 +287,8 @@ For example:
 
 .. _rbac-using_rbac:
 
-Using RBAC - example
---------------------
+Using RBAC Example
+------------------
 
 **Possible scenarios :**
 
@@ -302,7 +302,8 @@ Administrator of |st2| on a box that is running |st2|.
 User creation
 ~~~~~~~~~~~~~
 
-All user and password management is kept outside of StackStorm. Documentation on :doc:`authentication <authentication>` describes how to configure StackStorm with various identity providers.
+All user and password management is kept outside of |st2|. Read the :doc:`authentication <authentication>` docs to see
+how to configure to configure |st2| with various identity providers.
 
 For sake of this example let us assume that the identity provider is managed by the OS on which |st2| runs.
 

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -148,8 +148,8 @@ variable access syntax as shown below:
 In this example we are referencing a value of a datastore item with the name
 ``current_build_number``.
 
-Critera Comparision
--------------------
+Critera Comparison
+------------------
 
 This section describes all the available operators which can be used in the criteria.
 
@@ -298,7 +298,7 @@ To undeploy a rule, run ``st2 rule delete ${RULE_NAME_OR_ID}``. For example, to 
     st2 rule delete examples.sample_rule_with_webhook
 
 
-Rule location
+Rule Location
 -------------
 
 Custom rules can be placed in any accessible folder on local system. By convention, custom rules are placed
@@ -718,9 +718,9 @@ Run action every full hour every day of the week
 
 .. rubric:: What's Next?
 
-* Explore automations on `st2contrib`_ community repo.
+* Explore automations on the `st2contrib`_ community repo.
 * Learn more about :doc:`sensors`.
-* Check out `tutorials on stackstorm.com <http://stackstorm.com/category/tutorials/>`__ - a growing set of practical examples of automating with StackStorm.
+* Check out `tutorials on stackstorm.com <http://stackstorm.com/category/tutorials/>`__ - a growing set of practical examples of automating with |st2|.
 
 
 .. include:: __engage_community.rst

--- a/docs/source/sensors.rst
+++ b/docs/source/sensors.rst
@@ -19,7 +19,7 @@ Rules are written to work with triggers. Sensors typically register triggers
 though this is not strictly the case. For example, webhook triggers are just
 registered independently. You don't have to write a sensor.
 
-Internal triggers
+Internal Triggers
 -----------------
 
 By default |st2| emits some internal triggers which you can leverage in the
@@ -32,7 +32,7 @@ A list of available triggers for each resource is included below:
 
 .. _ref-sensors-authoring-a-sensor:
 
-Creating a sensor
+Creating a Sensor
 -----------------
 
 Creating a sensor involves writing a Python file and a YAML meta file
@@ -71,7 +71,7 @@ would use a PollingSensor instead of Sensor as the base class.
 For a complete implementation of a sensor that actually injects triggers
 into the system, look at the `examples <#examples>`__ section.
 
-Sensor service
+Sensor Service
 --------------
 
 As you can see in the example above, a ``sensor_service`` is passed to each
@@ -83,7 +83,7 @@ triggers into the system.
 
 All public methods are described below.
 
-Common operations
+Common Operations
 -----------------
 
 1. dispatch(trigger, payload, trace_tag)
@@ -118,7 +118,7 @@ For example:
 
 .. _ref-sensors-datastore-management-operations:
 
-Datastore management operations
+Datastore Management Operations
 -------------------------------
 
 In addition to the trigger injection, the sensor service also provides
@@ -196,7 +196,7 @@ API Docs
 .. autoclass:: st2reactor.container.sensor_wrapper.SensorService
     :members:
 
-Running your first sensor
+Running Your First Sensor
 -------------------------
 
 Once you write your own sensor, the following steps can be used to run your sensor for the first time:
@@ -221,7 +221,7 @@ Once you like your sensor, you can promote it to a pack (if required) by creatin
 /opt/stackstorm/packs/${pack_name} and moving the sensor artifacts (YAML and Python) to
 /opt/stackstorm/packs/${pack_name}/sensors/. See :doc:`/reference/packs` for how to create a pack.
 
-Debugging a sensor from a pack
+Debugging a Sensor From a Pack
 ------------------------------
 
 If you just want to run a single sensor from a pack and the sensor is already registered, you can

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -176,8 +176,8 @@ triggers, learn what the trigger does, how to configure it, and what the payload
     # Check details on the Webhook trigger
     st2 trigger get core.st2.webhook
 
-Deploy Rule
------------
+Deploy a Rule
+-------------
 
 |st2| can be configured to auto-load the rules or rules can be deployed with API or CLI:
 

--- a/docs/source/troubleshooting/database.rst
+++ b/docs/source/troubleshooting/database.rst
@@ -1,5 +1,5 @@
-Troubleshooting Database Issues
-===============================
+Database Issues
+===============
 
 This section contains information on how to troubleshoot database (MongoDB) related issues.
 

--- a/docs/source/troubleshooting/private_networks.rst
+++ b/docs/source/troubleshooting/private_networks.rst
@@ -1,5 +1,5 @@
-Troubleshooting WebUI Access on Private Networks
-================================================
+WebUI Access on Private Networks
+================================
 
 If you are installing |st2| on a host you don't have 
 direct (or VPN) network access to (such as an AWS instance

--- a/docs/source/troubleshooting/purging_old_data.rst
+++ b/docs/source/troubleshooting/purging_old_data.rst
@@ -1,10 +1,10 @@
-Purging old operational data from database
-==========================================
+Purging Old Operational Data
+============================
 
-If your |st2| deployment is used for a sufficiently larger period of time or
-you have a lot of executions happening/triggers coming in, database fills up.
+If your |st2| deployment is used for a sufficiently long period of time or
+you have a lot of executions happening/triggers coming in, the database fills up.
 If you are looking for a way to purge old data in bulk for performance reasons
-or cleaning up the db, you have two options described below.
+or cleaning up the DB, you have two options described below.
 
 1. Automatic purging via garbage collector service
 --------------------------------------------------
@@ -13,7 +13,7 @@ or cleaning up the db, you have two options described below.
 garbage and old data (old action execution, live action and trigger instance
 database objects).
 
-The actual collection threshold is very user specific (it depends on your
+The actual collection threshold is very user-specific (it depends on your
 requirements, policies, etc.) so garbage collection of old data is disabled
 by default.
 
@@ -52,22 +52,22 @@ The timestamp provided is interpreted as UTC timestamp. Please perform all neces
 conversions and specify UTC timestamp.
 
 You can also delete executions for a particular ``action_ref`` by specifying an action_ref parameter
-to the tool.
+to the tool:
 
 ::
 
     st2-purge-executions --timestamp="2015-11-25T21:45:00.000000Z" --action-ref="core.localzz"
 
-By default, only executions in completed state viz ``succeeded``, ``failed``, ``canceled``, ``timeout``
+By default, only executions in completed state, i.e. ``succeeded``, ``failed``, ``canceled``, ``timeout``
 and ``abandoned`` are deleted. If you want to purge all models irrespective of status,
-you can pass the --purge-incomplete option to the script.
+you can pass the ``--purge-incomplete`` option to the script.
 
 ::
 
     st2-purge-executions --timestamp="2015-11-25T21:45:00.000000Z" --purge-incomplete
 
-Depending on how much data there is, the tool might be running longer. Therefore, please run it
-inside a screen/tmux session. For example,
+Depending on how much data there is, the script may take a while to run. Therefore, please run it
+inside a screen/tmux session. For example:
 
 ::
 
@@ -83,8 +83,8 @@ Purging trigger instances older than some timestamp
 Again, the timestamp provided is interpreted as UTC timestamp. Please perform all necessary timezone
 conversions and specify UTC timestamp.
 
-Depending on how much data there is, the tool might be running longer. Therefore, please run it
-inside a screen/tmux session. For example,
+Depending on how much data there is, the script may take a while to run. Therefore, please run it
+inside a screen/tmux session. For example:
 
 ::
 

--- a/docs/source/troubleshooting/rules.rst
+++ b/docs/source/troubleshooting/rules.rst
@@ -5,7 +5,7 @@ You created a rule which supposed to fire an action when a particular trigger
 is emitted, but for some reason, this action is not being called.
 
 There are multiple reasons why this could be the case. If you end up in such a situation,
-follow this debugging procedure.
+follow this debugging procedure:
 
 1. Validate if rule was enforced
 2. Validate if trigger was emitted
@@ -207,7 +207,7 @@ that is to look into the action runner service logs -
 6. Ask for help!
 ----------------
 
-You have exhausted self help directions. Contact stormers
+You have exhausted self help directions. Contact us
 using :ref:`ask for help<ref-ask-for-help>` section. Please have the output of
 ``st2 rule-enforcement list --rule=<rule_being_debugged>``,
 ``st2 trigger-instance list --trigger=<trigger>`` and rule YAML ready so

--- a/docs/source/troubleshooting/sensors.rst
+++ b/docs/source/troubleshooting/sensors.rst
@@ -1,5 +1,5 @@
-Troubleshooting Sensors
-=======================
+Sensor Troubleshooting
+======================
 
 If a particular sensor is not running or appears to not be working (e.g.
 triggers are not emitted) usually the best course of action is to follow the
@@ -10,14 +10,14 @@ steps described below.
 
 The first step is verifying that sensor is registered in the database. You can
 do that by inspecting the output of the command below and making sure your
-sensor is present there.
+sensor is present:
 
 .. sourcecode:: bash
 
     st2 sensor list
 
-If your sensor is not listed there, this means it's not registered. You can
-registered it by running the ``st2-register-content`` script as shown below.
+If your sensor is not listed, this means it's not registered. You can
+register it by running the ``st2-register-content`` script:
 
 .. sourcecode:: bash
 
@@ -27,7 +27,7 @@ This will register sensors for all the packs which are available on the file
 system. As you can see, we also use ``--register-fail-on-failure`` and ``-v``
 (verbose) flags.
 
-This will cause the register script to exit with non zero and print a failure
+This will cause the register script to exit with non-zero and print a failure
 in case registration of a particular sensor fails (e.g. typo in sensor metadata
 file, invalid YAML, etc).
 
@@ -35,13 +35,12 @@ file, invalid YAML, etc).
 ---------------------------------------------------------------------
 
 When you have confirmed that the sensor has been registered, you need to
-confirm that a virtual environment for pack to which the sensor belongs
+confirm that a virtual environment for the pack to which the sensor belongs
 exists.
 
 You can confirm that by confirming the existence of
 ``/opt/stackstorm/virtualenvs/<pack name>`` directory. If the directory and
-virtual environment doesn't exist, you can create it using the command shown
-below.
+virtual environment doesn't exist, you can create it using this command:
 
 .. sourcecode:: bash
 
@@ -60,6 +59,6 @@ messages with level DEBUG and higher will be printed directly to the console.
 
     st2sensorcontainer --config-file=/etc/st2/st2.conf --debug --sensor-ref=pack.SensorClassName
 
-Log output will usually give you a clue on what is going on. Common issues
-include typos and syntax errors in the sensor class code, uncaught exception
-being thrown which causes the sensor to exit and similar.
+The log output will usually give you a clue as to what is going on. Common issues
+include typos and syntax errors in the sensor class code, uncaught exceptions
+being thrown that causes the sensor to exit, etc.

--- a/docs/source/troubleshooting/ssh.rst
+++ b/docs/source/troubleshooting/ssh.rst
@@ -1,4 +1,4 @@
-SSH troubleshooting
+SSH Troubleshooting
 ===================
 
 Since v0.13, Paramiko runner is the default SSH runner in |st2|. Most of this

--- a/docs/source/troubleshooting/submit_debug_info.rst
+++ b/docs/source/troubleshooting/submit_debug_info.rst
@@ -105,7 +105,7 @@ After review, the archive can be uploaded to Brocade using the ``--existing-file
 
 
 Customizing the debug information gathered
-==========================================
+------------------------------------------
 
 st2-submit-debug-info can be customized for specific deployments by loading a set of overrides from
 a YAML file. The following config options are supported:

--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -6,8 +6,8 @@ webhooks. Unlike sensors which use a "pull" approach, webhooks use a "push"
 approach. This means they work by you pushing triggers directly to the |st2|
 API using HTTP POST requests.
 
-What is the difference between sensors and webhooks?
-----------------------------------------------------
+Sensors vs Webhooks
+-------------------
 
 Sensors integrate with external systems and services using a poll approach
 (sensors periodically reach out to an external system to retrieve data you are
@@ -49,7 +49,7 @@ Both methods above support providing the authentication material as a header or 
 A header is usually used with your scripts where you can control request headers while query
 parameters are used with 3rd party services such as GitHub where you can only specify a URL.
 
-Request body
+Request Body
 ------------
 
 The request body or so called trigger payload can be either JSON or URL encoded form data. The body type
@@ -59,10 +59,10 @@ is determined based on the value of the ``Content-Type`` header (``application/j
 All the examples below assume JSON and as such, provide ``application/json`` for the
 ``Content-Type`` header value.
 
-Using a generic st2 webhook
----------------------------
+Using a Generic Webhook
+-----------------------
 
-By default, a generic webhook with a name ``st2`` is already registered. This
+By default, a generic webhook with the name ``st2`` is already registered. This
 webhook allows you to push arbitrary triggers to the API.
 
 The body of this request needs to be JSON and must contain the following attributes:
@@ -98,7 +98,7 @@ Rule:
 Keep in mind that the ``trigger.type`` attribute inside the rule definition
 needs to be the same as the trigger name defined in the webhook payload body.
 
-Registering a custom webhook
+Registering a Custom Webhook
 ----------------------------
 
 |st2| also supports registering custom webhooks. You can do that by specifying
@@ -157,7 +157,7 @@ Rule:
         parameters:
     ...
 
-Listing registered webhooks
+Listing Registered Webhooks
 ---------------------------
 
 To list all registered webhooks, run:


### PR DESCRIPTION
Went through naming, explicitly using StackStorm in some locations where more appropriate, in others switching from StackStorm to |st2|

Modified some TOC depths where they were too deep - e.g. main index.html didn't really need to show an entry for every individual changelog entry. 

Updated lots of headings. Some of them changed the heading level so that we dont get unnecessary things showing up in TOCS.  Lots of capitalisation changes in headings too, to get some consistency. Not perfect yet.

Various small typo & language changes.