### PR TITLE
Fix the regex used to disable 'Default requiretty'

### DIFF
--- a/docs/source/install/common/configure_ssh_and_sudo.rst
+++ b/docs/source/install/common/configure_ssh_and_sudo.rst
@@ -17,4 +17,4 @@
     sudo chmod 0440 /etc/sudoers.d/st2
 
     # Make sure `Defaults requiretty` is disabled in `/etc/sudoers`
-    sudo sed -i -r "s/^Defaults\s+\+requiretty/# Defaults +requiretty/g" /etc/sudoers
+    sudo sed -i -r "s/^Defaults\s+\+?requiretty/# Defaults +requiretty/g" /etc/sudoers


### PR DESCRIPTION
As discussed on Slack, the regex won't work if it finds something like `Defaults   requiretty` (without the `+`).

@Kami ?