### PR TITLE
Updating doc with working way of accessing attributes in webhook payload

### DIFF
--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -147,7 +147,7 @@ Rule:
         type: "mypack.mytrigger"
 
     criteria:
-        trigger.body.payload.attribute1:
+        trigger.attribute1:
             type: "equals"
             pattern: "value1"
 


### PR DESCRIPTION
PR for STORM-2409:
While trying out the generic webhook, it looks like that way an attribute in the payload needs to be accessed in the rule is different from what is given in the documentation.
As per doc, attribute being passed in the webhook as payload should be accessed as follows:
"trigger.body.payload.attribute1". This does not seem to work. If one uses ""trigger.attribute1" instead, it works. Updating doc to reflect the same. 
There is a possibility that ""trigger.body.payload.attribute1" is the correct expected method, and instead of doc, the ST2 code needs to be modified - will need comments/confirmation on this.