### PR TITLE
cut version number to major.minor

### DIFF
--- a/scripts/clone-ipfabric.sh
+++ b/scripts/clone-ipfabric.sh
@@ -6,7 +6,7 @@ if [ -d $IPFABRIC_DIRECTORY ]; then
     rm -rf $IPFABRIC_DIRECTORY
 fi
 
-docs_version=`cat version.txt`
+docs_version=`cat version.txt | cut -d '.' -f 1,2`
 
 case $docs_version in
     *dev*)

--- a/scripts/clone-st2.sh
+++ b/scripts/clone-st2.sh
@@ -6,7 +6,7 @@ if [ -d $ST2_DIRECTORY ]; then
     rm -rf $ST2_DIRECTORY
 fi
 
-docs_version=`cat version.txt`
+docs_version=`cat version.txt | cut -d '.' -f 1,2`
 
 case $docs_version in
     *dev*)


### PR DESCRIPTION
We are currently trying to clone the branch vMAJOR.MINOR.PATCH because that is the value in version.txt.  This cuts it down to vMAJOR.MINOR to match our branching scheme.