### PR TITLE
Add missing parameter to git config

### DIFF
--- a/docs/source/reference/proxy.rst
+++ b/docs/source/reference/proxy.rst
@@ -25,7 +25,7 @@ write into the config for you.
 
 .. sourcecode:: bash
 
-    git config --global http://user:passwd@proxy.server.com:port
+    git config --global http.proxy http://user:passwd@proxy.server.com:port
 
 Configuring pip
 ---------------


### PR DESCRIPTION
key http.proxy was missing in the command.