### PR TITLE
Add Ubuntu Xenial

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -1,5 +1,5 @@
-Ubuntu / Debian
-===============
+Ubuntu Trusty / Xenial
+======================
 
 If you're just looking for a "one-liner" installation, check the :doc:`top-level install guide </install/index>`. Otherwise, you
 can use this guide for step-by step instructions for installing |st2| on a single Ubuntu/Debian 64 bit system as per
@@ -31,15 +31,22 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
     sudo apt-get install -y curl
 
     # Add key and repo for the latest stable MongoDB (3.2)
-    sudo apt-key adv --fetch-keys https://www.mongodb.org/static/pgp/server-3.2.asc
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
     sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.2.list
-    deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse
+    deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -c | awk '{print $2}')/mongodb-org/3.2 multiverse
     EOT"
     sudo apt-get update
 
     sudo apt-get install -y mongodb-org
     sudo apt-get install -y rabbitmq-server
     sudo apt-get install -y postgresql
+
+For Ubuntu ``Xenial`` you may need to enable and start MongoDB.
+
+  .. code-block:: bash
+
+    sudo systemctl enable mongod
+    sudo systemctl start mongod
 
 Setup repositories
 ~~~~~~~~~~~~~~~~~~~
@@ -187,13 +194,12 @@ the official Nginx repository into the source list:
     # Add key and repo for the latest stable nginx
     sudo apt-key adv --fetch-keys http://nginx.org/keys/nginx_signing.key
     sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/nginx.list
-    deb http://nginx.org/packages/ubuntu/ trusty nginx
-    deb-src http://nginx.org/packages/ubuntu/ trusty nginx
+    deb http://nginx.org/packages/ubuntu/ $(lsb_release -c | awk '{print $2}') nginx
     EOT"
     sudo apt-get update
 
     # Install st2web and nginx
-    # note nginx should be > 1.4.6. To install a new version like 1.10.1 do "sudo apt-get install -y nginx=1.10.1-1~trusty"
+    # note nginx should be > 1.4.6
     sudo apt-get install -y st2web nginx
 
     # Generate self-signed certificate or place your existing certificate under /etc/ssl/st2

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -49,7 +49,7 @@ Once it completes successfully, you will see the following output:
 
     Reference Deployment Overview <overview>
     system_requirements
-    Ubuntu (Trusty) <deb>
+    Ubuntu 14.04 / 16.04 <deb>
     RHEL 7 / CentOS 7 <rhel7>
     RHEL 6 / CentOS 6 <rhel6>
     Brocade Workflow Composer <bwc>

--- a/docs/source/install/system_requirements.rst
+++ b/docs/source/install/system_requirements.rst
@@ -1,7 +1,7 @@
 System Requirements
 ===================
 
-|st2| requires Ubuntu/Debian, RHEL, or CentOS. The table below lists the supported
+|st2| requires Ubuntu, RHEL or CentOS. The table below lists the supported
 Linux versions, along with Vagrant Boxes and Amazon AWS instances we use for
 testing. Yes, using exactly the same boxes will improve your experience.
 
@@ -9,6 +9,8 @@ testing. Yes, using exactly the same boxes will improve your experience.
 | Linux (64 bit)    | Vagrant Box                                                                  | Amazon AWS AMI                                                                                                                                                    |
 +===================+==============================================================================+===================================================================================================================================================================+
 | Ubuntu 14.04      | `bento/ubuntu-14.04 <https://atlas.hashicorp.com/bento/boxes/ubuntu-14.04>`_ | `Ubuntu Server 14.04 LTS (HVM)  <https://aws.amazon.com/marketplace/pp/B00JV9TBA6/ref=srh_res_product_title?ie=UTF8&sr=0-3&qid=1457037882965>`_                   |
++-------------------+------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Ubuntu 16.04      | `bento/ubuntu-16.04 <https://atlas.hashicorp.com/bento/boxes/ubuntu-16.04>`_ | `Ubuntu 16.04 LTS - Xenial (HVM)  <https://aws.amazon.com/marketplace/pp/B01JBL2M0O/>`_                                                                           |
 +-------------------+------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | RHEL 7 / CentOS 7 | `bento/centos-7.2 <https://atlas.hashicorp.com/bento/boxes/centos-7.2>`_     | `Red Hat Enterprise Linux (RHEL) 7.2 (HVM)  <https://aws.amazon.com/marketplace/pp/B019NS7T5I/ref=srh_res_product_title?ie=UTF8&sr=0-2&qid=1457037671547>`_       |
 +-------------------+------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
A couple of changes from https://github.com/StackStorm/st2-packages/pull/348/files for `Ubuntu Xenial` Installation instructions.

Glad there is no need for a separated page.

> Will open the same PR (cherry-pick) against `v2.1` once we merge this.