### PR TITLE
Fix commit sha for the cloudflare example

### DIFF
--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -78,7 +78,7 @@ By default, the latest version of a pack will be installed, but you can specify 
 
 .. code-block:: bash
 
-    st2 pack install cloudflare=77ee04e
+    st2 pack install cloudflare=c5b75e9
     st2 pack install cloudflare=0.1.0
     st2 pack install https://github.com/emedvedev/chatops-training=testing
 


### PR DESCRIPTION
Gitrefs changed after the clean transfer, so the cloudflare example fails; reflecting in the docs.