### PR TITLE
Add note to reload st2 after upgrade to v2.1

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -96,6 +96,10 @@ v2.1
 
   /opt/stackstorm/st2/bin/st2-migrate-runners.sh
 
+* Service restart ``st2ctl restart`` and reload ``st2ctl reload`` are required after upgrade
+  for the new pack management features to work properly. Some of the pack management actions
+  and workflows have changed.
+
 v1.5
 '''''
 


### PR DESCRIPTION
Pack related actions and workflows have changed.  A reload is required for new pack management features to work.