### PR TITLE
st2-self-check: remove `bc` package dependency

### DIFF
--- a/docs/source/troubleshooting/self_verification.rst
+++ b/docs/source/troubleshooting/self_verification.rst
@@ -11,24 +11,10 @@ Currently script covers the following aspects of |st2|:
 * ActionChain and Mistral Workflows
 
 To run the self-verification:
-
-1. Install pre-requisite OS packages. The only dependency right now is ``bc``. To
-   install the package, run
-
-::
-
-    sudo apt-get install bc  # Ubuntu
-
-or
-
-::
-
-    sudo yum install bc  # CentOS/RHEL
-
-2. If you don't have :ref:`encryption keys setup already<admin-setup-for-encrypted-datastore>`, do so.
+1. If you don't have :ref:`encryption keys setup already<admin-setup-for-encrypted-datastore>`, do so.
    This requires admin privileges on the box and |st2|.
 
-3. Run the self-check script. This also copies over the examples from
+2. Run the self-check script. This also copies over the examples from
    ``/usr/share/doc/st2/examples`` to ``/opt/stackstorm/packs/`` and registers the content from examples. This step pollutes your |st2| environment by downloading fixtures from `st2tests
    <https://github.com/StackStorm/st2tests/tree/master/packs/>`__.
 

--- a/docs/source/troubleshooting/self_verification.rst
+++ b/docs/source/troubleshooting/self_verification.rst
@@ -11,6 +11,7 @@ Currently script covers the following aspects of |st2|:
 * ActionChain and Mistral Workflows
 
 To run the self-verification:
+
 1. If you don't have :ref:`encryption keys setup already<admin-setup-for-encrypted-datastore>`, do so.
    This requires admin privileges on the box and |st2|.
 


### PR DESCRIPTION
See https://github.com/StackStorm/st2tests/pull/87 and https://github.com/StackStorm/st2cd/pull/231 which replaces `bc` -> `awk` that already used in the same workflow for calculation.


> Ignoring docs sometimes leads to improvements :smiley: 