### PR TITLE
Document the difference between the number and integer JSON schema type

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -147,7 +147,11 @@ compatibility). These attributes can be present in the metadata file:
 * ``runner_type`` - The type of runner to execute the action.
 * ``enabled`` - Action cannot be invoked when disabled.
 * ``entry_point`` - Location of the action launch script relative to the /opt/stackstorm/packs/${pack_name}/actions/.
-* ``parameters`` - A dictionary of parameters and optional metadata describing type and default. The metadata is structured data following the `JSON Schema`_ specification draft 4. The common parameter types allowed are ``string``, ``boolean``, ``number``, ``object``, ``integer`` and ``array``. If metadata is provided, input args are validated on action execution. Otherwise, validation is skipped.
+* ``parameters`` - A dictionary of parameters and optional metadata describing type and default.
+  The metadata is structured data following the `JSON Schema`_ specification draft 4. The common parameter types
+  allowed are ``string``, ``boolean``, ``number`` (whole numbers and decimal numbers - e.g. ``1.0``, ``1``, ``3.3333``,
+  etc.), ``object``, ``integer`` (whole numbers only - ``1``, ``1000``, etc.) and ``array``. If metadata is provided,
+  input args are validated on action execution. Otherwise, validation is skipped.
 
 This is a sample metadata file for a Python action which sends an SMS via the Twilio web service:
 


### PR DESCRIPTION
We don't document it anywhere in our docs and it's not immediate obvious to the users.

https://github.com/StackStorm/st2/issues/3099