### PR TITLE
Minor edit in the upgrade documentation

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -28,10 +28,7 @@ Upgrade Procedure
 
    sudo st2ctl stop
 
-2. Run the migration script (if any). See section below for |st2|
-   version-specific migration scripts.
-
-3. Upgrade |st2| packages (``st2``, ``st2web``, ``st2chatops``, ``st2mistral``
+2. Upgrade |st2| packages (``st2``, ``st2web``, ``st2chatops``, ``st2mistral``
    and ``bwc-enterprise`` using distro specific tools.
 
   Ubuntu:
@@ -45,6 +42,9 @@ Upgrade Procedure
   .. sourcecode:: bash
 
      sudo yum update $PKG_NAME
+
+3. Run the migration script (if any). See section below for |st2| 
+   version-specific migration scripts.
 
 4. Upgrade Mistral database.
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -22,7 +22,7 @@ Upgrade Notes
       1. Use ``yum`` or ``apt-get`` to upgrade to the newest version.
 
       2. Update community packs to the latest version from
-         `StackStorm Exchange <https://exchange.stackstorm.org/>`__.
+         `StackStorm Exchange <https://exchange.stackstorm.org/>`__ with ``st2 pack install <pack>``.
 
       3. Reload the content with ``st2ctl reload``.
 


### PR DESCRIPTION
1. The package upgrade needs to be done first to get the migration scripts so the scripts can be executed on after package upgrade. Changing the order of the steps to reflect the same. 

2. Just adding some clarity on how an existing community pack can be updated using the new pack management CLI. If someone is following the upgrade notes without prior knowledge of pack management CLI, this would help.