### PR TITLE
Fix for issue 298

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -210,7 +210,7 @@ Fire the POST, check out the file and see that it appends the payload if the nam
     sudo tail /home/stanley/st2.webhook_sample.out
 
     # And for fun, same post with st2
-    st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost/api/v1/webhooks/sample headers='x-auth-token=put_token_here;content-type=application/json' verify_ssl_cert=False
+    st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost/api/v1/webhooks/sample headers='x-auth-token=put_token_here,content-type=application/json' verify_ssl_cert=False
 
     # And for even more fun, same post with st2 using basic authentication
     st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost/api/v1/webhooks/sample headers='content-type=application/json' verify_ssl_cert=False username=user1 password=pass1


### PR DESCRIPTION
https://github.com/StackStorm/st2docs/issues/298

As tested, use of ";" does not act as delimiter for the headers. "," works instead. 

With ";":
id: 584e83dc00483973dd5bebd2
status: succeeded
parameters:
  body: '{"you": "too", "name": "st2"}'
  headers:
    x-auth-token: 335f1ad545a24bb19ac148bd67933689;content-type=application/json
  method: POST
  url: https://localhost/api/v1/webhooks/sample
  verify_ssl_cert: false

Whereas with ",":
id: 584e83fd00483973dd5bebd5
status: succeeded
parameters:
  body: '{"you": "too", "name": "st2"}'
  headers:
    content-type: application/json
    x-auth-token: 335f1ad545a24bb19ac148bd67933689
  method: POST
  url: https://localhost/api/v1/webhooks/sample
  verify_ssl_cert: false