### PR TITLE
Added note for no support of 3.4 explicitly

### DIFF
--- a/docs/source/install/__mongodb_32_note.rst
+++ b/docs/source/install/__mongodb_32_note.rst
@@ -1,5 +1,5 @@
 .. note::
 
   Since StackStorm v1.6.0, the preferred and supported version of MongoDB is 3.2. This is also the
-  version installed by the installer script. Older versions of StackStorm (prior to v1.6.0) only
-  supported MongoDB 2.x.
+  version installed by the installer script. MongoDB 3.4 is `not yet <https://github.com/StackStorm/st2/issues/3100>`_ 
+  supported. Older versions of StackStorm (prior to v1.6.0) only supported MongoDB 2.x.


### PR DESCRIPTION

https://github.com/StackStorm/st2/issues/3100

Explicitly mentioning that MongoDB version 3.4 is not yet supported. Also added link to issue. 


