### PR TITLE
Only use major.minor version component when checking out st2.

### DIFF
--- a/scripts/clone-ipfabric.sh
+++ b/scripts/clone-ipfabric.sh
@@ -6,7 +6,7 @@ if [ -d $IPFABRIC_DIRECTORY ]; then
     rm -rf $IPFABRIC_DIRECTORY
 fi
 
-docs_version=`cat version.txt`
+docs_version=`cat version.txt | cut -d '.' -f 1,2`
 
 case $docs_version in
     *dev*)

--- a/scripts/clone-st2.sh
+++ b/scripts/clone-st2.sh
@@ -6,7 +6,7 @@ if [ -d $ST2_DIRECTORY ]; then
     rm -rf $ST2_DIRECTORY
 fi
 
-docs_version=`cat version.txt`
+docs_version=`cat version.txt | cut -d '.' -f 1,2`
 
 case $docs_version in
     *dev*)


### PR DESCRIPTION
This change was missing.

It looks like it was committed to v2.0, but not to master and v2.1 which is not causing build failure - https://github.com/StackStorm/st2docs/commit/ccab691f8a4cc1b4c5b344c0d391e4c9e7f2c346

Will also merge it into master.