### PR TITLE
Updated MongoDB docs references to v3.2

### DIFF
--- a/docs/source/install/config/config.rst
+++ b/docs/source/install/config/config.rst
@@ -27,8 +27,8 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
 
 The ``username`` and ``password`` properties are optional.
 
-|st2| also supports `MongoDB replica sets <https://docs.mongodb.com/v2.4/core/replication-introduction/>`_
-using `MongoDB URI string <https://docs.mongodb.com/v2.4/reference/connection-string/>`_.
+|st2| also supports `MongoDB replica sets <https://docs.mongodb.com/v3.2/core/replication-introduction/>`_
+using `MongoDB URI string <https://docs.mongodb.com/v3.2/reference/connection-string/>`_.
 
 In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following section :
 
@@ -37,9 +37,9 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
     [database]
     host = mongodb://<#MDB_NODE_1>,<#MDB_NODE_2>,<#MDB_NODE_3>/?replicaSet=<#MDB_REPLICA_SET_NAME>
 
-* You can also add ports, usernames and passwords, etc to your connection string - https://docs.mongodb.com/v2.4/reference/connection-string/
+* You can also add ports, usernames and passwords, etc to your connection string - https://docs.mongodb.com/v3.2/reference/connection-string/
 
-* To understand more about setting up a MongoDB replica set - https://docs.mongodb.com/v2.4/tutorial/deploy-replica-set/
+* To understand more about setting up a MongoDB replica set - https://docs.mongodb.com/v3.2/tutorial/deploy-replica-set/
 
 |st2| also supports SSL/TLS to encrypt connections. A few extra properties need be added to
 the configuration apart from the ones outlined above.


### PR DESCRIPTION
Couple of MongoDB docs references were to v2.4 branch. Updated to v3.2, since that's our preferred version.