### PR TITLE
Updating requirements to 2GB

### DIFF
--- a/docs/source/install/system_requirements.rst
+++ b/docs/source/install/system_requirements.rst
@@ -26,7 +26,7 @@ for the best experience while testing or deploying |st2|:
 |            Testing                   |         Production                |
 +======================================+===================================+
 |  * Dual CPU system                   | * Quad core CPU system            |
-|  * 1GB RAM                           | * >16GB RAM                       |
+|  * 2GB RAM                           | * >16GB RAM                       |
 |  * 10GB storage                      | * 40GB storage                    |
 |  * Recommended EC2: **t2.medium**    | * Recommended EC2: **m4.xlarge**  |
 +--------------------------------------+-----------------------------------+


### PR DESCRIPTION
1GB is no longer enough. Need at least 2GB, otherwise good chance of getting out of memory failures during install/operation. 

CF https://github.com/StackStorm/st2vagrant/pull/17