### PR TITLE
WIP: Placeholders for Flow docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,10 @@ Contents:
     datastore
     chatops/index
 
+.. include:: _includes/flow.rst
+
+.. include:: _includes/solutions.rst
+
 .. toctree::
     :maxdepth: 2
     :caption: Advanced Topics
@@ -33,10 +37,6 @@ Contents:
     reference/index
     troubleshooting/index
     development/index
-
-
-
-.. include:: _includes/solutions.rst
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
I've created a WIP PR for Flow docs here: https://github.com/StackStorm/ipfabric-docs/pull/64

That relies on this change, which adds a stub entry to the index. When BWC docs get built, it will add content to _includes/flow.rst, and import the Workflow Designer doc.

This way the doc will only show up on bwc-docs.brocade.com, not on docs.stackstorm.com