### PR TITLE
Add notice to changes in retry policy for workflow actions

### DIFF
--- a/docs/source/reference/policies.rst
+++ b/docs/source/reference/policies.rst
@@ -124,6 +124,12 @@ Retry policy (``action.retry``) allows you to automatically retry (re-run) an ac
 particular failure condition is met. Right now we support retrying actions which have failed or
 timed out.
 
+.. note::
+
+    Retry policy is no longer supported for actions that are executed under a workflow as it
+    conflicts with retry mechanism within specific workflow engine. Please take advantage of
+    retry mechanism provided by the workflow engine where applicable.
+
 The example below shows how to automatically retry the ``core.http`` action up to two times if it
 times out:
 


### PR DESCRIPTION
Retry policy no longer supports actions executed under a workflow and a notice is added to the appropriate doc section.