### PR TITLE
fixing install docs - start services section

### DIFF
--- a/docs/source/install/common/start_services.rst
+++ b/docs/source/install/common/start_services.rst
@@ -2,6 +2,6 @@
 
     sudo st2ctl start
 
-* Register sensors and actions ::
+* Register sensors, rules and actions ::
 
-    st2ctl reload
+    sudo st2ctl reload

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -98,14 +98,6 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 
 Start Services
 ~~~~~~~~~~~~~~
-* Start services ::
-
-    sudo st2ctl start
-
-* Register sensors, rules and actions ::
-
-    sudo st2ctl reload
-
 
 .. include:: common/start_services.rst
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -162,14 +162,6 @@ testing.
 Start Services
 ~~~~~~~~~~~~~~
 
-* Start services ::
-
-    sudo st2ctl start
-
-* Register sensors, rules and actions ::
-
-    st2ctl reload
-
 .. include:: common/start_services.rst
 
 Verify

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -138,10 +138,6 @@ For remote Linux actions, SSH is used. It is advised to configure identity file 
 Start Services
 ~~~~~~~~~~~~~~
 
-* Register sensors, rules and actions ::
-
-    st2ctl reload
-
 .. include:: common/start_services.rst
 
 


### PR DESCRIPTION
Start services commands come up in the docs twice - once is explicit mention and the other comes from common/start_services.rst. Using the later only for consistency.