### PR TITLE
update the copyright date

### DIFF
--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -5,10 +5,12 @@
 # change from one version to another in conf.py should be 
 # placed here, otherwise you WILL break the build.
 
+from datetime import datetime
+
 master_doc = 'index'
 
 project = u'StackStorm'
-copyright = u'2016, StackStorm'
+copyright = u'%s, StackStorm' % (datetime.now().strftime("%Y"))
 author = u'Brocade Communications Inc'
 
 base_url = u'http://docs.stackstorm.com/'


### PR DESCRIPTION
This patch update the copyright date from '2016' to 'current year' which is set automatically.

Currently, the year describing of copyright is old and it's specified statically.

By this patch, you don't need to update it for each year any more.

Thank you.