### PR TITLE
Include Ansible Installation method in docs

### DIFF
--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -1,0 +1,29 @@
+Ansible Playbooks
+=================
+
+Ansible playbooks to install |st2|.
+
+Allows you to deploy and further configure |st2| installation on local or remote machines with Ansible configuration management tool.
+Playbooks source code is available as GitHub repository `ansible-st2 <https://github.com/StackStorm/ansible-st2>`_.
+
+---------------------------
+
+Supported platforms
+---------------------------
+* Ubuntu Trusty (14.04)
+* Ubuntu Xenial (16.04)
+* RHEL6 / CentOS6
+* RHEL7 / CentOS7
+
+Quick Start
+---------------------------
+.. sourcecode:: bash
+
+    git clone https://github.com/StackStorm/ansible-st2.git
+    cd ansible-st2
+
+    ansible-playbook stackstorm.yml
+
+
+Please refer to https://github.com/StackStorm/ansible-st2 for updates and more detailed examples, descriptions and code.
+Additionally if you're familiar with Ansible, found a bug or would like to propose a feature, - your contributions are very welcome!

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -37,15 +37,15 @@ Roles
 Behind the scenes ``stackstorm.yml`` play composed of the following Ansible ``roles`` for a complete installation:
 
 - ``epel`` - Repository with extra packages for ``RHEL/CentOS``.
--	``mongodb`` - Main DB storage engine for |st2|.
--	``rabbitmq`` - Message broker for |st2|.
--	``postgresql`` - Main DB storage engine for |st2| Mistral.
--	``st2repos`` - Adds |st2| PackageCloud repositories.
--	``st2`` - Install and configure |st2| itself.
--	``st2mistral`` - Install and configure |st2| Mistral workflow engine.
+- ``mongodb`` - Main DB storage engine for |st2|.
+- ``rabbitmq`` - Message broker for |st2|.
+- ``postgresql`` - Main DB storage engine for |st2| Mistral.
+- ``st2repos`` - Adds |st2| PackageCloud repositories.
+- ``st2`` - Install and configure |st2| itself.
+- ``st2mistral`` - Install and configure |st2| Mistral workflow engine.
 - ``nginx`` - Dependency for ``st2web``.
 - ``st2web`` - Nice & shiny WebUI for |st2|.
--	``st2smoketests`` - Simple checks to know if |st2| really works.
+- ``st2smoketests`` - Simple checks to know if |st2| really works.
 
 Example Play
 ---------------------------

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -1,10 +1,12 @@
 Ansible Playbooks
 =================
-
-Ansible playbooks to install |st2|.
+Ansible playbooks and roles to install |st2|.
 
 Allows you to deploy and further configure |st2| installation on local or remote machines with Ansible configuration management tool.
-Playbooks source code is available as GitHub repository `ansible-st2 <https://github.com/StackStorm/ansible-st2>`_.
+
+The advantage of using this method, comparing to our demonstrational ``curl | bash`` installer are repeatable, configurable and idempotent production-friendly |st2| installations.
+
+Playbooks source code is available as GitHub repository `StackStorm/ansible-st2 <https://github.com/StackStorm/ansible-st2>`_.
 
 ---------------------------
 
@@ -15,8 +17,14 @@ Supported platforms
 * RHEL6 / CentOS6
 * RHEL7 / CentOS7
 
+Requirements
+---------------------------
+At least 2GB of memory and 3.5GB of disk space is required, since |st2| is shipped with RabbitMQ, PostgreSQL, Mongo, nginx and OpenStack Mistral.
+
 Quick Start
 ---------------------------
+Here are basic instructions to get started with a single node deployment and default configuration settings:
+
 .. sourcecode:: bash
 
     git clone https://github.com/StackStorm/ansible-st2.git
@@ -24,6 +32,69 @@ Quick Start
 
     ansible-playbook stackstorm.yml
 
+Roles
+---------------------------
+Behind the scenes ``stackstorm.yml`` play composed of the following Ansible ``roles`` for a complete installation:
 
-Please refer to https://github.com/StackStorm/ansible-st2 for updates and more detailed examples, descriptions and code.
-Additionally if you're familiar with Ansible, found a bug or would like to propose a feature, - your contributions are very welcome!
+- ``epel`` - Repository with extra packages for ``RHEL/CentOS``.
+-	``mongodb`` - Main DB storage engine for |st2|.
+-	``rabbitmq`` - Message broker for |st2|.
+-	``postgresql`` - Main DB storage engine for |st2| Mistral.
+-	``st2repos`` - Adds |st2| PackageCloud repositories.
+-	``st2`` - Install and configure |st2| itself.
+-	``st2mistral`` - Install and configure |st2| Mistral workflow engine.
+- ``nginx`` - Dependency for ``st2web``.
+- ``st2web`` - Nice & shiny WebUI for |st2|.
+-	``st2smoketests`` - Simple checks to know if |st2| really works.
+
+Example Play
+---------------------------
+Below is more advanced example to customize |st2| deployment:
+
+.. sourcecode:: yaml
+
+    - name: Install StackStorm with all services on a single node
+      hosts: all
+      roles:
+        - mongodb
+        - rabbitmq
+        - postgresql
+        - nginx
+
+        - name: Install StackStorm Packagecloud repository
+          role: st2repos
+          vars:
+            st2_pkg_repo: stable
+
+        - name: Install and configure st2
+          role: st2
+          vars:
+            st2_version: latest
+            st2_auth_enable: yes
+            st2_auth_username: demo
+            st2_auth_password: demo
+            st2_save_credentials: yes
+            st2_system_user: stanley
+            st2_system_user_in_sudoers: yes
+
+        - name: Install and configure st2mistral
+          role: st2mistral
+          vars:
+            st2mistral_version: latest
+            st2mistral_db: mistral
+            st2mistral_db_username: mistral
+            st2mistral_db_password: StackStorm
+
+        - name: Install st2web
+          role: st2web
+
+        - name: Verify StackStorm Installation
+          role: st2smoketests
+
+Here is a `full list of Variables <https://github.com/stackstorm/ansible-st2#variables>`_.
+
+
+.. note::
+
+    Please refer to https://github.com/StackStorm/ansible-st2 for updates and more detailed examples, descriptions and code.
+    Additionally if you're familiar with Ansible, found a bug, would like to propose a feature or pull request, - your contributions are very welcome!

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -54,6 +54,7 @@ Once it completes successfully, you will see the following output:
     Ubuntu 14.04 / 16.04 <deb>
     RHEL 7 / CentOS 7 <rhel7>
     RHEL 6 / CentOS 6 <rhel6>
+    Ansible Playbooks <ansible>
     Brocade Workflow Composer <bwc>
     config/index
     upgrades


### PR DESCRIPTION
We just released massive update for [`ansible-st2`](https://github.com/StackStorm/ansible-st2) `v0.6.0` https://github.com/StackStorm/ansible-st2/releases which introduces full platform support (4 platforms) and includes a lot of testing, bug-fixing and polishing.

With this update I'm confident about the quality, additionally changes are tested against [4 platforms in Travis](https://travis-ci.org/StackStorm/ansible-st2).

I think it worth to include Ansible as one of the installation methods now :100: 