### PR TITLE
Add openssl-devel as requirement when installing from source on Fedora

### DIFF
--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -28,7 +28,7 @@ Fedora
 
 ::
 
-    yum install python-pip python-virtualenv python-tox gcc-c++ git-all screen icu libicu libicu-devel
+    yum install python-pip python-virtualenv python-tox gcc-c++ git-all screen icu libicu libicu-devel openssl-devel
 
     yum install mongodb mongodb-server
     systemctl enable mongod


### PR DESCRIPTION
Pull request to fix #375 

I've just added 'openssl-devel' to the packages mentioned in the "Environment Prerequisites"

For me this solved the issue, that I couldn't compile on a CentOS7 machine.