### PR TITLE
Fix formatting of ssh-keygen commands

### DIFF
--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -80,7 +80,7 @@ Specify a user for running local and remote SSH actions. See :ref:`config-config
 Running
 ~~~~~~~
 
-Activate the virtualenv before starting the services
+Activate the virtualenv before starting the services. ::
 
     source virtualenv/bin/activate
 

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -62,7 +62,9 @@ and install required dependencies, and run tests.
 Configure System User
 ~~~~~~~~~~~~~~~~~~~~~
 
-Create a system user for executing SSH actions,
+Create a system user for executing SSH actions.
+
+::
 
     useradd -d /home/stanley stanley
     su stanley


### PR DESCRIPTION
In the current version, all commands to be executed to create a user and add a SSH key, when running from source, are displayed on a single line.

This pull requests, fixes the formatting to be inline with the other command blocks on the same page.