### PR TITLE
Refer YAQL Standard Library, and add a pro tip.

### DIFF
--- a/docs/source/mistral_yaql.rst
+++ b/docs/source/mistral_yaql.rst
@@ -235,9 +235,10 @@ function ``<% len(foobar) %>`` to get the length of the string ``foobar`` return
 documentation and git repo to explore more options.
 
 **Built-in**
-
+For the full list of build-in functinos, see `Standard Library section in YAQL docs <https://yaql.readthedocs.io/en/latest/standard_library.html>`_. Some noticable examples:
 * ``float(value)`` converts value to float.
 * ``int(value)`` converts value to integer.
+* ``str(number)`` converts number to a string.
 * ``len(list)`` and ``len(string)`` returns the length of the list and string respectively.
 * ``max(a, b)`` returns the larger value between a and b.
 * ``min(a, b)`` returns the smaller value between a and b.
@@ -246,6 +247,7 @@ documentation and git repo to explore more options.
 * ``'some string'.toUpper()`` converts the string to all upper cases.
 * ``'some string'.toLower()`` converts the string to all lower cases.
 * ``['some', 'list'].contains(value)`` returns True if list contains value.
+* ``"one, two, three, four".split(',').select(str($).trim())`` turns comma separated string to array, trimming each element.
 
 **Mistral**
 

--- a/docs/source/mistral_yaql.rst
+++ b/docs/source/mistral_yaql.rst
@@ -235,7 +235,7 @@ function ``<% len(foobar) %>`` to get the length of the string ``foobar`` return
 documentation and git repo to explore more options.
 
 **Built-in**
-For the full list of build-in functinos, see `Standard Library section in YAQL docs <https://yaql.readthedocs.io/en/latest/standard_library.html>`_. Some noticable examples:
+For the full list of built-in functinos, see `Standard Library section in YAQL docs <https://yaql.readthedocs.io/en/latest/standard_library.html>`_. Some noticeable examples:
 * ``float(value)`` converts value to float.
 * ``int(value)`` converts value to integer.
 * ``str(number)`` converts number to a string.
@@ -247,7 +247,7 @@ For the full list of build-in functinos, see `Standard Library section in YAQL d
 * ``'some string'.toUpper()`` converts the string to all upper cases.
 * ``'some string'.toLower()`` converts the string to all lower cases.
 * ``['some', 'list'].contains(value)`` returns True if list contains value.
-* ``"one, two, three, four".split(',').select(str($).trim())`` turns comma separated string to array, trimming each element.
+* ``"one, two, three, four".split(',').select(str($).trim())`` converts a comma separated string to an array, trimming each element.
 
 **Mistral**
 

--- a/docs/source/mistral_yaql.rst
+++ b/docs/source/mistral_yaql.rst
@@ -235,7 +235,7 @@ function ``<% len(foobar) %>`` to get the length of the string ``foobar`` return
 documentation and git repo to explore more options.
 
 **Built-in**
-For the full list of built-in functinos, see `Standard Library section in YAQL docs <https://yaql.readthedocs.io/en/latest/standard_library.html>`_. Some noticeable examples:
+For the full list of built-in functions, see `Standard Library section in YAQL docs <https://yaql.readthedocs.io/en/latest/standard_library.html>`_. Some noticeable examples:
 * ``float(value)`` converts value to float.
 * ``int(value)`` converts value to integer.
 * ``str(number)`` converts number to a string.


### PR DESCRIPTION
Based on the question: 

> is there a way to convert a string into an array? I'm pulling information from excel and it's coming in as a string, but the parameter I want to pass the variables too is type array.