### PR TITLE
Added references to 'st2 login' and 'st2 whoami' commands

### DIFF
--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -111,7 +111,7 @@ to point to the new username.
 .. NOTE::
    As with many other ``st2`` commands, ``st2 login`` will not create the configuration file
    for you. Keep this in mind especially if you're leveraging the ``--config-file`` CLI option,
-   or similar
+   or similar.
 
 Note that you can still use the "old" method of supplying both username and password
 in the configuration file if you wish.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -79,12 +79,31 @@ by passing ``--skip-config`` flag to the CLI as shown below:
 Authentication and auth token caching
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you specify username and password as authentication credentials in the
-configuration file, the CLI will try to use those credentials to authenticate and
-retrieve an auth token.
+The best way to authenticate to StackStorm via the CLI is using the
+``st2 login`` command. Similar to ``st2 auth``, you must provide your
+username and password:
 
-This auth token is by default cached on the local filesystem (in the ``~/.st2/token``
+    st2 login st2admin --password Password1!
+
+However, instead of just caching the token, this command will also modify the
+CLI configuration to include the referenced username. This way, future commands
+will know which cached token to use for authentication (since tokens are cached
+using the ``token-<username>`` format).
+
+These auth tokens are by default cached on the local filesystem (in the ``~/.st2/token-<username>``
 file) and re-used for subsequent requests to the API service.
+
+You can also use the ``st2 whoami`` command for a quick look at who is the currently
+configured user.
+
+The ``st2 login`` command is a good option if you want an easy way to authenticate
+via the CLI without storing your password in plain text. Switching between users is also
+as easy as re-running the ``st2 login`` command. Other users' token cache files will remain,
+but the CLi configuration will be changed to point to the new username.
+
+However, should you choose to specify username and password as authentication
+credentials in the configuration file, the CLI will try to use those credentials
+to authenticate and retrieve an auth token.
 
 If you want to disable auth token caching and want the CLI to retrieve a new
 auth token on each invocation, you can do that by setting ``cache_token``

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -79,8 +79,8 @@ by passing ``--skip-config`` flag to the CLI as shown below:
 Authentication and auth token caching
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The best way to authenticate to StackStorm via the CLI is using the
-``st2 login`` command. Similar to ``st2 auth``, you must provide your
+If you don't wish to store your password in plain-text as shown in the previous section,
+the ``st2 login`` command offers an alternative. Similar to ``st2 auth``, you must provide your
 username and password:
 
 .. sourcecode:: bash
@@ -90,10 +90,13 @@ username and password:
 However, instead of just caching the token, this command will also modify the
 CLI configuration to include the referenced username. This way, future commands
 will know which cached token to use for authentication (since tokens are cached
-using the ``token-<username>`` format).
+using the ``token-<username>`` format), meaning the password can be omitted from
+the config file altogether.
 
-.. NOTE::
-   By default, ``st2 login`` will remove any configured password from the configuration.
+.. WARNING::
+   ``st2 login`` will overwrite the "credentials" section of the configuration.
+   By default, it will overwrite the configured username, and will remove any
+   configured password.
 
 These auth tokens are by default cached on the local filesystem (in the ``~/.st2/token-<username>``
 file) and re-used for subsequent requests to the API service.
@@ -101,10 +104,13 @@ file) and re-used for subsequent requests to the API service.
 You can also use the ``st2 whoami`` command for a quick look at who is the currently
 configured user.
 
-The ``st2 login`` command is a good option if you want an easy way to authenticate
-via the CLI without storing your password in plain text. Switching between users is also
-as easy as re-running the ``st2 login`` command. Other users' token cache files will remain,
-but the CLI configuration will be changed to point to the new username.
+The previous section showed how to authenticate to StackStorm by embedding the username and
+password in plain text in configuration file. The ``st2 login`` command is good alternative
+to this, as you only need to store your username in configuration.
+
+Switching between users is also as easy as re-running the ``st2 login`` command.
+Other users' token cache files will remain, but the CLI configuration will be changed
+to point to the new username.
 
 However, should you choose to specify username and password as authentication
 credentials in the configuration file, the CLI will try to use those credentials

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -104,17 +104,17 @@ file) and re-used for subsequent requests to the API service.
 You can also use the ``st2 whoami`` command for a quick look at who is the currently
 configured user.
 
-The previous section showed how to authenticate to StackStorm by embedding the username and
-password in plain text in configuration file. The ``st2 login`` command is good alternative
-to this, as you only need to store your username in configuration.
-
 Switching between users is also as easy as re-running the ``st2 login`` command.
 Other users' token cache files will remain, but the CLI configuration will be changed
 to point to the new username.
 
-However, should you choose to specify username and password as authentication
-credentials in the configuration file, the CLI will try to use those credentials
-to authenticate and retrieve an auth token.
+.. NOTE::
+   As with many other ``st2`` commands, ``st2 login`` will not create the configuration file
+   for you. Keep this in mind especially if you're leveraging the ``--config-file`` CLI option,
+   or similar
+
+Note that you can still use the "old" method of supplying both username and password
+in the configuration file if you wish.
 
 If you want to disable auth token caching and want the CLI to retrieve a new
 auth token on each invocation, you can do that by setting ``cache_token``

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -83,12 +83,17 @@ The best way to authenticate to StackStorm via the CLI is using the
 ``st2 login`` command. Similar to ``st2 auth``, you must provide your
 username and password:
 
+.. sourcecode:: bash
+
     st2 login st2admin --password Password1!
 
 However, instead of just caching the token, this command will also modify the
 CLI configuration to include the referenced username. This way, future commands
 will know which cached token to use for authentication (since tokens are cached
 using the ``token-<username>`` format).
+
+.. NOTE::
+   By default, ``st2 login`` will remove any configured password from the configuration.
 
 These auth tokens are by default cached on the local filesystem (in the ``~/.st2/token-<username>``
 file) and re-used for subsequent requests to the API service.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -99,7 +99,7 @@ configured user.
 The ``st2 login`` command is a good option if you want an easy way to authenticate
 via the CLI without storing your password in plain text. Switching between users is also
 as easy as re-running the ``st2 login`` command. Other users' token cache files will remain,
-but the CLi configuration will be changed to point to the new username.
+but the CLI configuration will be changed to point to the new username.
 
 However, should you choose to specify username and password as authentication
 credentials in the configuration file, the CLI will try to use those credentials

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -87,7 +87,7 @@ username and password:
 
     st2 login st2admin --password Password1!
 
-However, instead of just caching the token, this command will also modify the
+However, in addition to caching the token, this command will also modify the
 CLI configuration to include the referenced username. This way, future commands
 will know which cached token to use for authentication (since tokens are cached
 using the ``token-<username>`` format), meaning the password can be omitted from
@@ -99,7 +99,9 @@ the config file altogether.
    configured password.
 
 These auth tokens are by default cached on the local filesystem (in the ``~/.st2/token-<username>``
-file) and re-used for subsequent requests to the API service.
+file) and re-used for subsequent requests to the API service. Note that because the default behavior
+is to remove the password from the configuration, you will need to re-login once the generated token
+has expired - or make use of the ``--write-password`` flag, which writes the password to the config.
 
 You can also use the ``st2 whoami`` command for a quick look at who is the currently
 configured user.
@@ -114,7 +116,8 @@ to point to the new username.
    or similar.
 
 Note that you can still use the "old" method of supplying both username and password
-in the configuration file if you wish.
+in the configuration file if you wish. If both a username and password are present in the
+configuration, then the client will automatically try to authenticate with these credentials.
 
 If you want to disable auth token caching and want the CLI to retrieve a new
 auth token on each invocation, you can do that by setting ``cache_token``


### PR DESCRIPTION
This PR adds an explanation of the new `st2 login` and `st2 whoami` commands that were introduced in https://github.com/StackStorm/st2/pull/3123