### PR TITLE
wrote the first publication year to the copyright description

### DIFF
--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -10,7 +10,7 @@ from datetime import datetime
 master_doc = 'index'
 
 project = u'StackStorm'
-copyright = u'%s, StackStorm' % (datetime.now().strftime("%Y"))
+copyright = u'2014 - %s, StackStorm' % (datetime.now().strftime("%Y"))
 author = u'Brocade Communications Inc'
 
 base_url = u'http://docs.stackstorm.com/'


### PR DESCRIPTION
This patch is the correction of copyright format which is base on [this comment](https://github.com/StackStorm/st2docs/pull/366#discussion_r99528807).

Previously, the year of first publication specification is omitted.
This patch added it.
