### PR TITLE
Add note on MongoDB being supported in StackStorm >= v2.2.0

### DIFF
--- a/docs/source/install/__mongodb_32_note.rst
+++ b/docs/source/install/__mongodb_32_note.rst
@@ -1,5 +1,0 @@
-.. note::
-
-  Since StackStorm v1.6.0, the preferred and supported version of MongoDB is 3.2. This is also the
-  version installed by the installer script. MongoDB 3.4 is `not yet <https://github.com/StackStorm/st2/issues/3100>`_ 
-  supported. Older versions of StackStorm (prior to v1.6.0) only supported MongoDB 2.x.

--- a/docs/source/install/__mongodb_note.rst
+++ b/docs/source/install/__mongodb_note.rst
@@ -1,0 +1,5 @@
+.. note::
+
+  Since StackStorm v1.6.0, the preferred and supported version of MongoDB is 3.2. This is also the
+  version installed by the installer script. MongoDB 3.4 is supported in StackStorm v2.2.0 and above.
+  Older versions of StackStorm (prior to v1.6.0) only supported MongoDB 2.x.

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -21,7 +21,7 @@ Minimal installation
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
-.. include:: __mongodb_32_note.rst
+.. include:: __mongodb_note.rst
 
 Install MongoDB, RabbitMQ, and PostgreSQL.
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -64,7 +64,7 @@ you may want to tweak them according to your security practices.
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
-.. include:: __mongodb_32_note.rst
+.. include:: __mongodb_note.rst
 
 Install MongoDB, RabbitMQ, and PostgreSQL.
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -53,7 +53,7 @@ you may want to tweak them according to your security practices.
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
-.. include:: __mongodb_32_note.rst
+.. include:: __mongodb_note.rst
 
 Install MongoDB, RabbitMQ, and PostgreSQL.
 


### PR DESCRIPTION
Documentation change for https://github.com/StackStorm/st2/pull/3185.