### PR TITLE
Enable wrapping for table cells

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -293,7 +293,10 @@ html_context = {
         (version_minus_1, '%s%s' % (info.base_url, version_minus_1)),
         (version_minus_2, '%s%s' % (info.base_url, version_minus_2)),
     ],
-    'current_version': version
+    'current_version': version,
+    'css_files': [
+        '_static/theme_overrides.css',
+        ],
 }
 
 


### PR DESCRIPTION
@enykeev what do you think of this? 

This change over-rides the `nowrap` behavior on table cell content. 

Before the change, we have a horizontal scrollbar, like this: (from docs.stackstorm.com/mistral.html)
![table_nowrap](https://cloud.githubusercontent.com/assets/3607046/22954167/c255e486-f2c9-11e6-8e24-adf6f11b68d4.png)

Afterwards, it looks like this:

![table_wrap](https://cloud.githubusercontent.com/assets/3607046/22954170/c6eb74ac-f2c9-11e6-81ae-093c574928e5.png)

I prefer the second version. From an initial look at our other tables, this change generally looks better. I haven't found any counter-examples yet.

I also have another reason for wanting this - I want to auto-generate some docs based upon action definitions, and it will use tables. If I can get the content to auto-wrap, it will be much simpler to generate my tables.

Couple of things:
1.  Min-width may not be right here - you might prefer a different value

2. This is one way to override the default CSS, but you might prefer a different approach. I have no opinion on the 'right' way to do it.