### PR TITLE
Update upgrade section to clarify Mistral database upgrade

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -50,7 +50,7 @@ Upgrade Procedure
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
 
-.. note::
+.. warning::
 
     The mistral and mistral-api services must be stopped at time of upgrade. If the services are
     restarted before the mistral-db-manage commands are run, then the
@@ -88,7 +88,7 @@ v2.2
   executions_v2, either use psql or install an older version of the python-mistralclient in a
   separate python virtual environment.
 
-.. note::
+.. warning::
 
     Please be sure to follow the general steps listed above to do the database upgrade.
 

--- a/docs/source/troubleshooting/index.rst
+++ b/docs/source/troubleshooting/index.rst
@@ -10,6 +10,7 @@ This section includes common problems you might encounter while using the platfo
     basic_chatops_troubleshooting
     rules
     sensors
+    mistral
     ssh
     database
     rest_api_access

--- a/docs/source/troubleshooting/mistral.rst
+++ b/docs/source/troubleshooting/mistral.rst
@@ -1,0 +1,19 @@
+Mistral Issues
+==============
+
+This section contains information on how to troubleshoot Mistral related issues.
+
+Troubleshooting Mistral database upgrade
+----------------------------------------
+
+The mistral and mistral-api services must be stopped at time of upgrading the st2mistral package
+and the mistral database schema. If the st2mistral package has been upgraded and the services are
+started before the ``mistral-db-manage upgrade head`` command is run, then the
+``mistral-db-manage upgrade head`` command may fail. When the mistral and mistral-api services run,
+SQLAlchemy automatically creates tables, relationships, and indices that do not exist. In the case
+where there are new database objects in the upgraded database schema, the 
+``mistral-db-manage upgrade head`` command will fail because the actual schema in the database is
+now different than its spec and it no longer can create the new database objects. When that happens,
+the new database tables, relationships, and indices must be deleted before the
+``mistral-db-manage upgrade head`` command can be re-run. For more details, review the specific
+section for the version being upgraded in :doc:`/install/upgrades`.


### PR DESCRIPTION
If mistral services are restarted before the mistral-db-manage commands are run, the mistral database upgrade will fail. Update appropriate section to highlight precaution.