### PR TITLE
Document that the installer script now generates random passwords for MongoDB and PostgreSQL

### DIFF
--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -53,7 +53,6 @@ Upgrade Notes
   services to talk to MongoDB and PostgreSQL, you can find it in ``/etc/st2/st2.conf``
   (``[database]`` section) ``/etc/mistral/mistral.conf`` (``[database]`` section) files.
 
-
 |st2| v2.1
 ----------
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,8 +3,8 @@
 Upgrade Notes
 =============
 
-|st2| in development
---------------------
+|st2| v2.2
+----------
 
 * Additional validation has been introduced for triggers.
 
@@ -38,6 +38,20 @@ Upgrade Notes
   ``user`` and ``system`` scopes are now unsuported. Please use ``{{st2kv.user.key}}`` and
   ``{{st2kv.system.key}}`` notations instead. Also, please update your |st2| content
   (actions, rules and workflows) to use the new notation.
+
+* When installing StackStorm using the installer script a random password is generated for MongoDB
+  and PostgreSQL. This means you now need to explicitly pass ``--config-file /etc/st2/st2.conf``
+  argument to all the CLI scripts (e.g. ``st2-apply-rbac-definitions``, etc.) which need access
+  to the database (MongoDB). If you don't do that, "access denied" error will be returned, because
+  it will try to use a default password when connecting to the database.
+
+  .. code-block:: bash
+
+    st2-apply-rbac-defintions --config-file /etc/st2/st2.conf
+
+  If for some reason, you need access to the plain-text version of the password used by StackStorm
+  services to talk to MongoDB and PostgreSQL, you can find it in ``/etc/st2/st2.conf``
+  (``[database]`` section) ``/etc/mistral/mistral.conf`` (``[database]`` section) files.
 
 
 |st2| v2.1

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,8 +3,8 @@
 Upgrade Notes
 =============
 
-|st2| v2.2
-----------
+|st2| in development
+--------------------
 
 * Additional validation has been introduced for triggers.
 


### PR DESCRIPTION
The title says it all.

That's the upgrade notes part of it, for v2.2.1, I think we should also do what I described here - https://github.com/StackStorm/discussions/issues/225#issuecomment-281602924 (https://github.com/StackStorm/st2/issues/3203).