### PR TITLE
added link to mistral DB recovery procedure from upgrade notes

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -92,6 +92,8 @@ v2.2
 
     Please be sure to follow the general steps listed above to do the database upgrade.
 
+.. _mistral_db_recover:
+
 *  If you're seeing an error ``event_triggers_v2 already exists`` when running
    ``mistral-db-manage upgrade head``, this means the mistral services started before the
    mistral-db-manage commands were run. SQLAlchemy automatically creates new tables in

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -34,6 +34,10 @@ Upgrade Notes
   executions_v2, either use psql or install an older version of the python-mistralclient in a
   separate python virtual environment.
 
+* If you’re seeing an error ``event_triggers_v2 already exists`` when running ``mistral-db-manage upgrade head``,
+  this means the mistral services started before the ``mistral-db-manage`` commands were run.
+  Refer to this :ref:`procedure <mistral_db_recover>` to recover the system.
+
 * Jinja notations ``{{user.key}}`` and ``{{system.key}}`` to access datastore items under
   ``user`` and ``system`` scopes are now unsuported. Please use ``{{st2kv.user.key}}`` and
   ``{{st2kv.system.key}}`` notations instead. Also, please update your |st2| content


### PR DESCRIPTION
As per the title. Things are a bit confusing because we have /upgrade_notes.rst and /install/upgrades.rst

Will also need to cherry-pick to v2.2 branch