### PR TITLE
Add more example for YAQL expressions

### DIFF
--- a/docs/source/mistral_yaql.rst
+++ b/docs/source/mistral_yaql.rst
@@ -193,6 +193,7 @@ The following YAQL expressions are some sample queries that YAQL is capable of:
 * ``<% $.vms.select($.region).distinct() %>`` returns the distinct list of regions ``['us-east', 'us-west']``.
 * ``<% $.vms.where($.region = 'us-east').select($.name) %>`` selects only the VMs in us-east ``['vmweb1', 'vmdb1']``.
 * ``<% $.vms.where($.region = 'us-east' and $.role = 'web').select($.name) %>`` selects only the web server in us-east ``['vmweb1']``.
+* ``<% let(myregion => 'us-east', myrole => 'web') -> $.vms.where($.region = $myregion and $.role = $myrole).select($.name) %>`` selects only the web server in us-east ``['vmweb1']``.
 
 List to Dictionary
 ++++++++++++++++++


### PR DESCRIPTION
Use context and pass variables to the yaql expression, useful in defining yaql expression in the same task.