### PR TITLE
Added Datastore Crypto Key instructions to installation

### DIFF
--- a/docs/source/install/common/datastore_crypto_key.rst
+++ b/docs/source/install/common/datastore_crypto_key.rst
@@ -1,0 +1,23 @@
+The :doc:`Key-value store </datastore>` allows users to store encrypted values (secrets).
+These are stored using symmetric encryption (AES256). To generate a crypto key, run:
+
+  .. code-block:: bash
+
+    DATASTORE_ENCRYPTION_KEYS_DIRECTORY="/etc/st2/keys"
+    DATASTORE_ENCRYPTION_KEY_PATH="${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}/datastore_key.json"
+
+    sudo mkdir -p ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+    sudo st2-generate-symmetric-crypto-key --key-path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+    # Make sure only st2 user can read the file
+    sudo usermod -a -G st2 st2
+    sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+    sudo chmod o-r ${DATASTORE_ENCRYPTION_KEYS_DIRECTORY}
+    sudo chgrp st2 ${DATASTORE_ENCRYPTION_KEY_PATH}
+    sudo chmod o-r ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+    # set path to the key file in the config
+    sudo crudini --set /etc/st2/st2.conf keyvalue encryption_key_path ${DATASTORE_ENCRYPTION_KEY_PATH}
+
+    sudo st2ctl restart-component st2api
+

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -72,6 +72,11 @@ please adjust the settings:
   * MongoDB at ``/etc/st2/st2.conf``
   * PostgreSQL at ``/etc/mistral/mistral.conf``
 
+Setup Datastore Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: common/datastore_crypto_key.rst
+
 Setup Mistral Database
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -134,6 +134,11 @@ please adjust the settings:
   * MongoDB at ``/etc/st2/st2.conf``
   * PostgreSQL at ``/etc/mistral/mistral.conf``
 
+Setup Datastore Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: common/datastore_crypto_key.rst
+
 Setup Mistral Database
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -114,6 +114,11 @@ please adjust the settings:
   * MongoDB at ``/etc/st2/st2.conf``
   * PostgreSQL at ``/etc/mistral/mistral.conf``
 
+Setup Datastore Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: common/datastore_crypto_key.rst
+
 Setup Mistral Database
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
We didn't cover datastore crypto key generation in the manual installation section, so it could have been missed by people doing manual setups. 