### PR TITLE
Wrap passwords in single quotes

### DIFF
--- a/docs/source/__auth_usage.rst
+++ b/docs/source/__auth_usage.rst
@@ -9,6 +9,11 @@ response. ::
     st2 auth yourusename
     Password:
 
+.. note::
+
+    If your password contains special characters such as ``$``, they may be interpreted by the shell.
+    Wrap your password in single quotes (``'``) as above.
+
 The following is a sample API call via curl using the token. ::
 
     curl -H "X-Auth-Token: 4d76e023841a4a91a9c66aa4541156fe" https://myhost.example.com/api/v1/actions

--- a/docs/source/__auth_usage.rst
+++ b/docs/source/__auth_usage.rst
@@ -3,7 +3,7 @@ then ``st2 auth`` will prompt for the password. If successful, a token is return
 response. ::
 
     # with password
-    st2 auth yourusername -p yourpassword
+    st2 auth yourusername -p 'yourpassword'
 
     # without password
     st2 auth yourusename
@@ -29,7 +29,7 @@ for 10 minutes, use the following:
 ::
 
     # with TTL and password
-    st2 auth yourusername -p yourpassword -l 600
+    st2 auth yourusername -p 'yourpassword' -l 600
 
 Note that if the TTL requested is greater than maximum allowed TTL in st2 configuration, you'd get an error.
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -174,10 +174,10 @@ Run the following curl commands to test.
     curl -X POST -k https://myhost.example.com/auth/v1/tokens
 
     # The following will succeed and return a valid token. Please note that this is executed with "-k" to skip SSL cert verification.
-    curl -X POST -k -u yourusername:yourpassword https://myhost.example.com/auth/v1/tokens
+    curl -X POST -k -u yourusername:'yourpassword' https://myhost.example.com/auth/v1/tokens
 
     # The following will verify the SSL cert, succeed, and return a valid token.
-    curl -X POST --cacert /path/to/cacert.pem -u yourusername:yourpassword https://myhost.example.com/auth/v1/tokens
+    curl -X POST --cacert /path/to/cacert.pem -u yourusername:'yourpassword' https://myhost.example.com/auth/v1/tokens
 
 .. note:: Until version 1.2 of |st2|, auth APIs were served from its own port. If your version is 1.1.1 or below, replace '/api' with ':9100'.
 

--- a/docs/source/install/__on_complete.rst
+++ b/docs/source/install/__on_complete.rst
@@ -7,8 +7,8 @@ Check that |st2| installation works OK: ::
 
     # If AUTH enabled: authenticate and export the token env variable
     # so you don't need to pass it as parameter on every command.
-    st2 auth testu -p testp
-    export ST2_AUTH_TOKEN=`st2 auth -t -p testp testu`
+    st2 auth testu -p 'testp'
+    export ST2_AUTH_TOKEN=`st2 auth -t -p 'testp' testu`
 
     st2 action list
     st2 run core.local uname

--- a/docs/source/install/bwc.rst
+++ b/docs/source/install/bwc.rst
@@ -15,7 +15,7 @@ with the key you received when registering for evaluation or purchasing BWC.
 .. code-block:: bash
 
   curl -sSL -O https://brocade.com/bwc/install/install.sh && chmod +x install.sh
-  ./install.sh --user=st2admin --password=Ch@ngeMe --license=${BWC_LICENSE_KEY}
+  ./install.sh --user=st2admin --password='Ch@ngeMe' --license=${BWC_LICENSE_KEY}
 
 
 To understand the details of the installation procedure,

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -141,7 +141,7 @@ To set up authentication with File Based provider:
     # Install htpasswd utility if you don't have it
     sudo apt-get install -y apache2-utils
     # Create a user record in a password file.
-    echo "Ch@ngeMe" | sudo htpasswd -i /etc/st2/htpasswd st2admin
+    echo 'Ch@ngeMe' | sudo htpasswd -i /etc/st2/htpasswd st2admin
 
 * Enable and configure auth in ``/etc/st2/st2.conf``:
 
@@ -166,7 +166,7 @@ To set up authentication with File Based provider:
     st2 auth st2admin
 
     # A shortcut to authenticate and export the token
-    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p Ch@ngeMe -t)
+    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p 'Ch@ngeMe' -t)
 
     # Check that it works
     st2 action list

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -8,7 +8,7 @@ this command:
 
 .. code-block:: bash
 
-   curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=st2admin --password=Ch@ngeMe
+   curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=st2admin --password='Ch@ngeMe'
 
 It will install and configure the stable version of StackStorm, as per the
 :doc:`single host reference deployment <./overview>`.

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -203,7 +203,7 @@ To set up authentication with File Based provider:
     # Install htpasswd utility if you don't have it
     sudo yum -y install httpd-tools
     # Create a user record in a password file.
-    sudo htpasswd -bs /etc/st2/htpasswd st2admin Ch@ngeMe
+    sudo htpasswd -bs /etc/st2/htpasswd st2admin 'Ch@ngeMe'
 
 * Enable and configure auth in ``/etc/st2/st2.conf``:
 
@@ -228,7 +228,7 @@ To set up authentication with File Based provider:
     st2 auth st2admin
 
     # A shortcut to authenticate and export the token
-    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p Ch@ngeMe -t)
+    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p 'Ch@ngeMe' -t)
 
     # Check that it works
     st2 action list

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -179,7 +179,7 @@ To set up authentication with File Based provider:
     # Install htpasswd utility if you don't have it
     sudo yum -y install httpd-tools
     # Create a user record in a password file.
-    echo "Ch@ngeMe" | sudo htpasswd -i /etc/st2/htpasswd st2admin
+    echo 'Ch@ngeMe' | sudo htpasswd -i /etc/st2/htpasswd st2admin
 
 * Enable and configure auth in ``/etc/st2/st2.conf``:
 
@@ -204,7 +204,7 @@ To set up authentication with File Based provider:
     st2 auth st2admin
 
     # A shortcut to authenticate and export the token
-    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p Ch@ngeMe -t)
+    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p 'Ch@ngeMe' -t)
 
     # Check that it works
     st2 action list

--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -323,7 +323,7 @@ Once this user is created |st2| will allow access to this user. (Optional) To va
 
 .. sourcecode:: bash
 
-    $ st2 auth rbacu1 -p <RBACU1_PASSWORD>
+    $ st2 auth rbacu1 -p '<RBACU1_PASSWORD>'
     $ export ST2_AUTH_TOKEN=<USER_SCOPED_AUTH_TOKEN>
     $ st2 action list
 
@@ -404,7 +404,7 @@ Lets take what we have achieved for a spin using the |st2| CLI.
 
 .. sourcecode:: bash
 
-    $ st2 auth rbacu1 -p <RBACU1_PASSWORD>
+    $ st2 auth rbacu1 -p '<RBACU1_PASSWORD>'
     $ export ST2_AUTH_TOKEN=<USER_SCOPED_AUTH_TOKEN>
     $ st2 action list
 

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -85,7 +85,7 @@ username and password:
 
 .. sourcecode:: bash
 
-    st2 login st2admin --password Password1!
+    st2 login st2admin --password 'Password1!'
 
 However, in addition to caching the token, this command will also modify the
 CLI configuration to include the referenced username. This way, future commands
@@ -261,7 +261,7 @@ Example command usage:
 
 .. sourcecode:: bash
 
-    st2 auth test1 -p testpassword -t
+    st2 auth test1 -p 'testpassword' -t
 
     0280826688c74bb9bd541c26631df298
 
@@ -269,7 +269,7 @@ Example usage inside a Bash script:
 
 .. sourcecode:: bash
 
-    TOKEN=$(st2 auth test1 -p testpassword -t)
+    TOKEN=$(st2 auth test1 -p 'testpassword' -t)
 
     # Now you can use the token (e.g. pass it to other commands, set an
     # environment variable, etc.)

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -20,7 +20,7 @@ The best way to explore |st2| is to use CLI. Start by firing a few commands:
     # Authenticate and export the token. Make sure ST2_AUTH_URL and
     # ST2_API_URL are set correctly (http vs https, endpoint, and etc).
     # Replace the username and password in the example below appropriately.
-    export ST2_AUTH_TOKEN=`st2 auth -t -p pass123 admin`
+    export ST2_AUTH_TOKEN=`st2 auth -t -p 'pass123' admin`
 
     # List the actions from a 'core' pack
     st2 action list --pack=core
@@ -53,7 +53,7 @@ variable ``ST2_AUTH_TOKEN``. When using environment variable, make sure that ``S
 
 .. code-block:: bash
 
-    export ST2_AUTH_TOKEN=`st2 auth -t -p pass123 admin`
+    export ST2_AUTH_TOKEN=`st2 auth -t -p 'pass123' admin`
 
 
 Work with Actions

--- a/docs/source/troubleshooting/self_verification.rst
+++ b/docs/source/troubleshooting/self_verification.rst
@@ -21,4 +21,4 @@ To run the self-verification:
 
 ::
 
-    sudo ST2_AUTH_TOKEN=$(st2 auth st2admin -p <PASSWORD> -t) /opt/stackstorm/st2/bin/st2-self-check
+    sudo ST2_AUTH_TOKEN=$(st2 auth st2admin -p '<PASSWORD>' -t) /opt/stackstorm/st2/bin/st2-self-check


### PR DESCRIPTION
Some users have been confused when they set passwords containing special chars such as `$`, as they don't seem to work using the Web UI. This is due to the shell interpreting some characters.

This change wraps all passwords in single quotes, and adds a note about it.

Addresses #390 