### PR TITLE
Fixed incorrect BWC/ST2 substitution

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -151,7 +151,7 @@ v1.5
 Content Roll-Over
 -----------------
 
-In some cases, you may need to roll over the automation from one instance of |bwc| to
+In some cases, you may need to roll over the automation from one instance of |st2| to
 another box or deployment. To do this, provision a new |st2| instance, and roll over the content.
 Thanks to the "Infrastructure as code" approach, all |st2| content and artifacts are simple files,
 and should be kept under source control.


### PR DESCRIPTION
as above. Incorrect replacement `|bwc|` vs `|st2|`, leading to unwanted BWC reference in StackStorm-branded docs. 