### PR TITLE
v1.6 changes - doc builds, GTM, Version Warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ requirements: virtualenv
 	@echo
 
 	# Make sure we use latest version of pip
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip<8.0.0"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=8.1.2,<8.2"
 
 	# Install requirements
 	#

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,27 @@
+# Setup in CircleCI account the following ENV variables:
+# IS_PRODUCTION (default: 0)
+# IS_ENTERPRISE (default: 0)
+# PACKAGECLOUD_ORGANIZATION (default: stackstorm)
+# PACKAGECLOUD_TOKEN
+# DOCKER_USER
+# DOCKER_EMAIL
+# DOCKER_PASSWORD
+
+# general:
+#  branches:
+#    only:
+#      - master
+#      - /v[0-9]+\.[0-9]+/
+
+# notify:
+#  webhooks:
+#    - url: https://webhooks.stackstorm.net:8531/webhooks/build/events
+
+machine:
+  environment:
+    DOCS_REPO_ROOT_DIR: ${HOME}/${CIRCLE_PROJECT_REPONAME}
+
+test:
+  override:
+    - make docs
+    - make bwcdocs

--- a/circle.yml
+++ b/circle.yml
@@ -24,4 +24,3 @@ machine:
 test:
   override:
     - make docs
-    - make bwcdocs

--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -13,6 +13,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="google-site-verification" content="ovwnX0ej2kps4UuJ9NOzNjJcLOQD8JPDLNhe-hMYTMk" />
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-NKZBMHZ');</script>
+  <!-- End Google Tag Manager -->
   {% block htmltitle %}
   <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
   {% endblock %}
@@ -73,6 +81,11 @@
 </head>
 
 <body class="wy-body-for-nav" role="document">
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NKZBMHZ"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
   <div class="wy-grid-for-nav">
 
@@ -173,33 +186,6 @@
   {% endif %}
 
   {%- block footer %} {% endblock %}
-
-<!-- Google Analytics Tracker -->
-<script>
- (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
- (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
- m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
- })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
- ga('create', 'UA-46030182-2', 'auto');
- ga('send', 'pageview');
-</script>
-
-<!-- Additional Analytics -->
-<script type="text/javascript">
-	var trackcmp_email = '';
-	var trackcmp = document.createElement("script");
-	trackcmp.async = true;
-	trackcmp.type = 'text/javascript';
-	trackcmp.src = '//trackcmp.net/visit?actid=89091034&e='+encodeURIComponent(trackcmp_email)+'&r='+encodeURIComponent(document.referrer)+'&u='+encodeURIComponent(window.location.href);
-	var trackcmp_s = document.getElementsByTagName("script");
-	if (trackcmp_s.length) {
-		trackcmp_s[0].parentNode.appendChild(trackcmp);
-	} else {
-		var trackcmp_h = document.getElementsByTagName("head");
-		trackcmp_h.length && trackcmp_h[0].appendChild(trackcmp);
-	}
-</script>  
 
 </body>
 </html>

--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -143,6 +143,13 @@
         <div class="rst-content">
           {% include "breadcrumbs.html" %}
           <div role="main" class="document">
+            <div id="version-warning" class="admonition warning hide">
+              <p class="first admonition-title">Note</p>
+              <p class="last">
+                The documentation you're currently reading is for version {{ release|e }}.
+                Click <a href="{{ pathto('/', 1) }}">here</a> to view documentation for the latest stable version.
+              </p>
+            </div>
             {% block body %}{% endblock %}
           </div>
           {% include "footer.html" %}
@@ -184,6 +191,8 @@
       });
   </script>
   {% endif %}
+
+  <script type="text/javascript" src="{{ pathto('/_static/js/versions.js', 1) }}"></script>
 
   {%- block footer %} {% endblock %}
 

--- a/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -4728,4 +4728,8 @@ span[id*='MathJax-Span'] {
   text-align: center;
 }
 
+.hide {
+  display: none;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/docs/source/_themes/sphinx_rtd_theme/static/js/versions.js_t
+++ b/docs/source/_themes/sphinx_rtd_theme/static/js/versions.js_t
@@ -1,0 +1,40 @@
+(function () {
+  function renderVersionBadge(versions, currentVersion) {
+    var versionsContainer = $('<dl><dt>Versions</dt></dl>');
+    $.each(versions, function (slug, url) {
+      versionsContainer.append('<dd><a href="' + url + '">' + slug + '</a></dd>');
+    });
+
+    var otherVersions = $('<div class="rst-other-versions"></div>').append(versionsContainer);
+
+    var container = $('<div id="versions" class="rst-versions rst-badge" data-toggle="rst-versions" role="note" aria-label="versions"></div>');
+    container.append('<span class="rst-current-version" data-toggle="rst-current-version">v: ' + currentVersion + ' <span class="fa fa-caret-down"></span></span>');
+    container.append(otherVersions);
+
+    $('#versions').replaceWith(container);
+  }
+
+  function showVersionWarning() {
+    $('#version-warning').show();
+  }
+
+  $(document).ready(function () {
+    var latestVersion = "{{ current_version }}";
+
+    var versions = {
+    {%- for slug, url in versions %}
+      "{{ slug }}": "{{ url }}",
+    {%- endfor %}
+    };
+
+    var currentVersion = latestVersion;
+
+    var match = window.location.pathname.match('^/(\\d+\\.\\d+)');
+    if (match) {
+      currentVersion = match[1];
+      showVersionWarning();
+    }
+
+    renderVersionBadge(versions, currentVersion);
+  });
+})()

--- a/docs/source/_themes/sphinx_rtd_theme/versions.html
+++ b/docs/source/_themes/sphinx_rtd_theme/versions.html
@@ -1,17 +1,2 @@
 {# Add rst-badge after rst-versions for small badge style. #}
-  <div class="rst-versions rst-badge" data-toggle="rst-versions" role="note" aria-label="versions">
-    <span class="rst-current-version" data-toggle="rst-current-version">
-      v: {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
-      <dl>
-        <dt>Versions</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
-        {% endfor %}
-      </dl>
-    </div>
-  </div>
-
-
+  <div id="versions"></div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-six==1.9.0
 sphinx
 git+https://github.com/StackStorm/sphinx-autobuild.git@develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+six==1.9.0
 sphinx
 git+https://github.com/StackStorm/sphinx-autobuild.git@develop

--- a/scripts/clone-st2.sh
+++ b/scripts/clone-st2.sh
@@ -19,3 +19,11 @@ esac
 
 echo "Cloning branch $REQUIRED_BRANCH of st2"
 git clone -b $REQUIRED_BRANCH --depth 1 https://github.com/StackStorm/st2.git st2
+
+# Ugly stuff to get old st2 versions to pass 'make requirements' steps
+sed -i 's/^ipython$/ipython<6.0.0/' st2/test-requirements.txt
+sed -i 's/six==1\.9\.0/six==1.10.0/' st2/fixed-requirements.txt
+sed -i 's/six==1\.9\.0/six==1.10.0/' st2/requirements.txt
+sed -i 's/pip>=7\.1\.2,<8\.0\.0/pip>=8.1.2,<8.2/' st2/Makefile
+sed -i 's/virtualenv>=13\.1\.2,<14\.0/virtualenv>=15.0.3,<15.1/' st2/fixed-requirements.txt
+sed -i 's/req\.project_name/name/' st2/scripts/fixate-requirements.py


### PR DESCRIPTION
Google Tag Manager changes
Changed pip versions and requirements.txt
Ugly hacks to change versions inside cloned st2 tree, so `make requirements` steps can pass
Add version warnings