### PR TITLE
ST2Flow Placeholders

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,10 @@ Contents:
     datastore
     chatops/index
 
+.. include:: _includes/flow.rst
+
+.. include:: _includes/solutions.rst
+
 .. toctree::
     :maxdepth: 2
     :caption: Advanced Topics
@@ -33,10 +37,6 @@ Contents:
     reference/index
     troubleshooting/index
     development/index
-
-
-
-.. include:: _includes/solutions.rst
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Prep change for Flow Docs.

This puts placeholders in the ST2 docs, so that when https://github.com/StackStorm/ipfabric-docs/pull/64 gets merged, Flow docs will show up in bwc-docs.brocade.com, not docs.stackstorm.com