### PR TITLE
updated dependencies; fixed search

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -162,7 +162,8 @@
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            HAS_SOURCE:  {{ has_source|lower }},
+            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
         };
     </script>
     {%- for scriptfile in script_files %}

--- a/docs/source/_themes/sphinx_rtd_theme/layout_old.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout_old.html
@@ -91,7 +91,8 @@
         VERSION:     '{{ release|e }}',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
+        HAS_SOURCE:  {{ has_source|lower }},
+        SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
       };
     </script>
     {%- for scriptfile in script_files %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -388,6 +388,6 @@ texinfo_documents = info.texinfo_documents
 # texinfo_no_detailmenu = False
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/2': None}
 
 autoclass_content = 'both'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx>=1.5.3,<1.6
 sphinx-autobuild

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==1.4.9
-git+https://github.com/StackStorm/sphinx-autobuild.git@develop
+sphinx
+sphinx-autobuild


### PR DESCRIPTION
We pinned sphinx back in https://github.com/StackStorm/st2docs/pull/345, due to broken search (https://github.com/rtfd/sphinx_rtd_theme/pull/346). 

This is fixed with changes to `layout.html` and `layout_old.html`. With these changes we don't need to pin our sphinx version anymore, and can get new features & bug fixes again.

I've also changed the sphinx-autobuild version. We were using our own fork, which pinned the livereload version. That fork is now very out of date. I would rather use the upstream version unless we still have a specific need to use the old one. That doesn't seem to apply anymore. 

With this combination of new sphinx versions & theme changes, I can search again when viewing local live docs.

I've also made a small change to `conf.py` to remove this message when building docs:
```
| loading intersphinx inventory from http://docs.python.org/objects.inv...
| intersphinx inventory has moved: http://docs.python.org/objects.inv -> https://docs.python.org/2/objects.inv
```