### PR TITLE
upgrade pip version;fix make distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ bwclocallivedocs: bwclocaldocs .livedocs
 	rm -rf $(DOC_BUILD_DIR)
 
 .PHONY: distclean
-distclean: clean
+distclean:
 	@echo
 	@echo "==================== distclean ===================="
 	@echo
@@ -151,7 +151,7 @@ requirements: virtualenv
 	@echo
 
 	# Make sure we use latest version of pip
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip<8.0.0"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=8.1.2,<8.2"
 
 	# Install requirements
 	#


### PR DESCRIPTION
We upgraded st2 to use newer pip version last August. But we didn't update the st2docs/Makefile. This change will make st2docs use the same pip version. 

I also fixed the `make distclean` target. Previously it would fail with errors like this:
```
(virtualenv) st2docs lhill$ make distclean
make: *** No rule to make target `clean', needed by `distclean'.  Stop.
``` 