### PR TITLE
Adding package dependencies for st2docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Product documentation for StackStorm is maintained in this repository. These doc
 Follows these steps to build the docs locally:
 
 Install the dependencies:
+
 For Debian/Ubuntu: ``sudo apt-get install libpython-dev libssl-dev``
-For RHEL/CentOS: `` sudo yum install libpython-dev libssl-dev`` 
+
+For RHEL/CentOS: `` sudo yum install libpython-dev libssl-dev``
 
 ```bash
 git clone https://github.com/StackStorm/st2docs.git

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Product documentation for StackStorm is maintained in this repository. These doc
 #### Build locally on Linux
 Follows these steps to build the docs locally:
 
+Install the dependencies:
+For Debian/Ubuntu: ``sudo apt-get install libpython-dev libssl-dev``
+For RHEL/CentOS: `` sudo yum install libpython-dev libssl-dev`` 
+
 ```bash
 git clone https://github.com/StackStorm/st2docs.git
 cd st2docs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install the dependencies:
 
 For Debian/Ubuntu: ``sudo apt-get install libpython-dev libssl-dev``
 
-For RHEL/CentOS: `` sudo yum install libpython-dev libssl-dev``
+For RHEL/CentOS: `` sudo yum install python-devel openssl-devel gcc``
 
 ```bash
 git clone https://github.com/StackStorm/st2docs.git


### PR DESCRIPTION
Fixing issue https://github.com/StackStorm/st2docs/issues/438

The mentioned packages are required on the linux host where st2docs are being built and run. Without these, the build fails. 