### PR TITLE
added runner_type, api_key, key_value_pair API auto-gen

### DIFF
--- a/scripts/generate-available-permission-types-table.py
+++ b/scripts/generate-available-permission-types-table.py
@@ -36,7 +36,10 @@ RESOURCE_DISPLAY_ORDER = [
     ResourceType.SENSOR,
     ResourceType.ACTION,
     ResourceType.ACTION_ALIAS,
+    ResourceType.API_KEY,
+    ResourceType.KEY_VALUE_PAIR,
     ResourceType.RULE,
+    ResourceType.RUNNER,
     ResourceType.EXECUTION,
     ResourceType.WEBHOOK
 ]


### PR DESCRIPTION
Updated auto-gen script to include generation of API keys, Key-value pairs and runner_types permissions.

Needs https://github.com/StackStorm/st2/issues/3324 merged before tests will pass.

Addresses https://github.com/StackStorm/ipfabric-docs/issues/77