### PR TITLE
v2.0 Canonical URLs

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -26,6 +26,10 @@
   {% endblock %}
 
   <link rel="shortcut icon" href="{{ pathto('_static/favicon.ico', 1) }}?v4"/>
+  {# CANONICAL URL #}
+  {% if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+  {% endif %}
 
   {# CSS #}
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic|Inconsolata:400,700' rel='stylesheet' type='text/css'>

--- a/docs/source/_themes/sphinx_rtd_theme/layout_old.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout_old.html
@@ -125,6 +125,9 @@
     {%- if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {%- endif %}
+    {%- if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    {%- endif %}
     {%- endif %}
 {%- block linktags %}
     {%- if hasdoc('about') %}

--- a/docs/source/_themes/sphinx_rtd_theme/theme.conf
+++ b/docs/source/_themes/sphinx_rtd_theme/theme.conf
@@ -10,3 +10,4 @@ sticky_navigation = False
 # Specify a base_url used to generate sitemap.xml links. If not specified, then
 # no sitemap will be built.
 base_url =
+canonical_url =

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -200,7 +200,8 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'base_url': info.theme_base_url
+    'base_url': info.theme_base_url,
+    'canonical_url': info.theme_base_url
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -11,7 +11,7 @@ project = u'StackStorm'
 copyright = u'2016, StackStorm'
 author = u'Brocade Communications Inc'
 
-base_url = u'http://docs.stackstorm.com/'
+base_url = u'https://docs.stackstorm.com/'
 htmlhelp_basename = 'StackStormDoc'
 
 man_pages = [

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -31,4 +31,4 @@ texinfo_documents = [
 github_repo = 'StackStorm/st2docs'
 github_version = 'master'
 
-theme_base_url = u'http://docs.stackstorm.com/'
+theme_base_url = u'https://docs.stackstorm.com/'


### PR DESCRIPTION
Steer Google towards latest docs. Partly addresses #403 