### PR TITLE
redirects for moved content

### DIFF
--- a/docs/source/_redirects/cli.html
+++ b/docs/source/_redirects/cli.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/cli.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/cli.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/history.html
+++ b/docs/source/_redirects/history.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/history.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/history.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/pack_configs.html
+++ b/docs/source/_redirects/pack_configs.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/pack_configs.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/pack_configs.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/policies.html
+++ b/docs/source/_redirects/policies.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/proxy.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/proxy.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/policies.html
+++ b/docs/source/_redirects/policies.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-<meta http-equiv="Refresh" content="0; url=reference/proxy.html" />
+<meta http-equiv="Refresh" content="0; url=reference/policies.html" />
 </head>
 <body>
-<p>This page has moved to <a href="reference/proxy.html">here</a>.</p>
+<p>This page has moved to <a href="reference/policies.html">here</a>.</p>
 </body>
 </html>

--- a/docs/source/_redirects/proxy.html
+++ b/docs/source/_redirects/proxy.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/policies.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/policies.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/proxy.html
+++ b/docs/source/_redirects/proxy.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-<meta http-equiv="Refresh" content="0; url=reference/policies.html" />
+<meta http-equiv="Refresh" content="0; url=reference/proxy.html" />
 </head>
 <body>
-<p>This page has moved to <a href="reference/policies.html">here</a>.</p>
+<p>This page has moved to <a href="reference/proxy.html">here</a>.</p>
 </body>
 </html>

--- a/docs/source/_redirects/runners.html
+++ b/docs/source/_redirects/runners.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/runners.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/runners.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/traces.html
+++ b/docs/source/_redirects/traces.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=reference/traces.html" />
+</head>
+<body>
+<p>This page has moved to <a href="reference/traces.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -236,6 +236,7 @@ html_static_path = ['_static']
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
 # html_extra_path = []
+html_extra_path = ['_redirects']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
We moved some content around over the years, particularly when we went from 1.6 -> 2.0. The problem is that the old content is left in place, and not deleted when we push new branches.

So users viewing docs.stackstorm.com/policies.html will see old content, rather than the new location at docs.stackstorm.com/reference/policies.html.

We want to put redirects in place for the old content, so Google & users get steered to the new locations.

This change uses the [html_extra_path](http://www.sphinx-doc.org/en/stable/config.html#confval-html_extra_path) directive to include files in the build directory. These are raw HTML files, rather than restructuredText. 

These are set up as basic URL redirection files. In future if we move any other pages, we just need to add a new file under _redirects, and it will also get included.

Partly addresses #403 

If this looks OK, we'll also cherry-pick to v2.2, v2.1 and v2.0.