### PR TITLE
Update "coordination" of st2.conf in Policy.rst

### DIFF
--- a/docs/source/reference/policies.rst
+++ b/docs/source/reference/policies.rst
@@ -107,7 +107,7 @@ Redis:
 ::
 
     [coordination]
-    url = redis://password@host:port
+    url = redis://:password@host:port
 
 Other supported coordination backends include:
 


### PR DESCRIPTION
Need ':' before password in redis url schema.
https://redis-py.readthedocs.io/en/latest/#redis.StrictRedis.from_url
For example:
redis://[:password]@localhost:6379/0