### PR TITLE
Docs update, related to Ansible-st2 0.7.0 release

### DIFF
--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -107,6 +107,22 @@ Below is more advanced example to customize |st2| deployment:
 
 Here is a `full list of Variables <https://github.com/stackstorm/ansible-st2#variables>`_.
 
+Installing behind a Proxy
+--------------------------
+If you are installing from behind a proxy, you can use environment variables ``http_proxy``, ``https_proxy``, and ``no_proxy`` in the play. They will be passed through during the execution.
+
+.. sourcecode:: yaml
+
+    ---
+    - name: Install st2
+      hosts: all
+      environment:
+        http_proxy: http://proxy.example.net:8080
+        https_proxy: https://proxy.example.net:8080
+        no_proxy: 127.0.0.1,localhost
+      roles:
+        - st2
+
 BWC (|st2| Enterprise)
 ---------------------------
 Example to customize |st2| enterprise (`BWC <https://bwc-docs.brocade.com/>`_) with `LDAP <https://bwc-docs.brocade.com/authentication.html#ldap>`_ auth backend and `RBAC <https://bwc-docs.brocade.com/rbac.html>`_ configuration to allow/restrict/limit different |st2| functionality to specific users:

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -116,7 +116,7 @@ Example to customize |st2| enterprise (`BWC <https://bwc-docs.brocade.com/>`_) w
     - name: Install StackStorm with all services on a single node
       hosts: all
       roles:
-        - name: Install and configure st2mistral
+        - name: Install and configure StackStorm Enterprise (BWC)
           role: bwc
           vars:
             bwc_repo: enterprise

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -110,13 +110,15 @@ Here is a `full list of Variables <https://github.com/stackstorm/ansible-st2#var
 Custom SSL Certificate for ``st2web``
 --------------------------------------
 By default we generate self-signed certificate for ``nginx`` in ``st2web`` role. It's possible to pass custom real SSL certificate instead:
-```yaml
-  - name: Configure st2web with custom certificate
-    role: st2web
-    vars:
-      st2web_ssl_certificate: "{{ lookup('file', 'local/path/to/domain-name.crt') }}"
-      st2web_ssl_certificate_key: "{{ lookup('file', 'local/path/to/domain-name.key') }}"
-```
+
+.. sourcecode:: yaml
+
+      - name: Configure st2web with custom SSL certificate
+        role: st2web
+        vars:
+          st2web_ssl_certificate: "{{ lookup('file', 'local/path/to/domain-name.crt') }}"
+          st2web_ssl_certificate_key: "{{ lookup('file', 'local/path/to/domain-name.key') }}"
+
 
 Installing behind a Proxy
 --------------------------
@@ -133,6 +135,7 @@ If you are installing from behind a proxy, you can use environment variables ``h
         no_proxy: 127.0.0.1,localhost
       roles:
         - st2
+
 
 BWC (|st2| Enterprise)
 ---------------------------

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -113,7 +113,7 @@ Here is a `full list of Variables <https://github.com/stackstorm/ansible-st2#var
 
 Custom SSL Certificate for ``st2web``
 --------------------------------------
-By default we generate self-signed certificate for ``nginx`` in ``st2web`` role. It's possible to pass custom real SSL certificate instead:
+By default we generate a self-signed certificate for ``nginx`` in ``st2web`` role. It's possible to pass an externally signed SSL certificate instead:
 
 .. sourcecode:: yaml
 
@@ -126,7 +126,7 @@ By default we generate self-signed certificate for ``nginx`` in ``st2web`` role.
 
 Installing behind a Proxy
 --------------------------
-If you are installing from behind a proxy, you can use environment variables ``http_proxy``, ``https_proxy``, and ``no_proxy`` in the play. They will be passed through during the execution.
+If you are installing from behind a proxy, you can use the environment variables ``http_proxy``, ``https_proxy``, and ``no_proxy`` in the play. They will be passed through during the execution.
 
 .. sourcecode:: yaml
 

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -107,6 +107,17 @@ Below is more advanced example to customize |st2| deployment:
 
 Here is a `full list of Variables <https://github.com/stackstorm/ansible-st2#variables>`_.
 
+Custom SSL Certificate for ``st2web``
+--------------------------------------
+By default we generate self-signed certificate for ``nginx`` in ``st2web`` role. It's possible to pass custom real SSL certificate instead:
+```yaml
+  - name: Configure st2web with custom certificate
+    role: st2web
+    vars:
+      st2web_ssl_certificate: "{{ lookup('file', 'local/path/to/domain-name.crt') }}"
+      st2web_ssl_certificate_key: "{{ lookup('file', 'local/path/to/domain-name.key') }}"
+```
+
 Installing behind a Proxy
 --------------------------
 If you are installing from behind a proxy, you can use environment variables ``http_proxy``, ``https_proxy``, and ``no_proxy`` in the play. They will be passed through during the execution.

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -65,9 +65,9 @@ Below is more advanced example to customize |st2| deployment:
         - nodejs
 
         - name: Install StackStorm Packagecloud repository
-          role: st2repos
+          role: st2repo
           vars:
-            st2_pkg_repo: stable
+            st2repo_name: stable
 
         - name: Install and configure st2
           role: st2

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -113,7 +113,7 @@ Example to customize |st2| enterprise (`BWC <https://bwc-docs.brocade.com/>`_) w
 
 .. sourcecode:: yaml
 
-    - name: Install StackStorm with all services on a single node
+    - name: Install StackStorm Enterprise
       hosts: all
       roles:
         - name: Install and configure StackStorm Enterprise (BWC)

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -81,6 +81,8 @@ Below is more advanced example to customize |st2| deployment:
             st2_save_credentials: yes
             st2_system_user: stanley
             st2_system_user_in_sudoers: yes
+            # Dict to edit https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample
+            st2_config: {}
 
         - name: Install and configure st2mistral
           role: st2mistral
@@ -89,6 +91,8 @@ Below is more advanced example to customize |st2| deployment:
             st2mistral_db: mistral
             st2mistral_db_username: mistral
             st2mistral_db_password: StackStorm
+            # Dict to edit https://github.com/StackStorm/st2-packages/blob/master/packages/st2mistral/conf/mistral.conf
+            st2mistral_config: {}
 
         - name: Install st2web
           role: st2web


### PR DESCRIPTION
Work to address https://github.com/StackStorm/ansible-st2/issues/136, - changes and new features in https://github.com/StackStorm/ansible-st2/ upcoming [`0.7.0` release](https://github.com/StackStorm/ansible-st2/milestone/6).

- [x] Breaking changes in `st2role` naming
- [x] New `st2chatops` role (already in place https://github.com/StackStorm/st2docs/pull/423)
- [x] New `bwc` enterprise role (separated `Enterprise` block) https://github.com/StackStorm/ansible-st2/pull/126
  - [x] LDAP example (from https://github.com/StackStorm/ops-infra/pull/119/files)
  - [x] RBAC example (from https://github.com/StackStorm/ops-infra/pull/119/files)
- [x] Configure `ansible-st2` to install via proxy https://github.com/StackStorm/ansible-st2/pull/123
- [x] `st2web` with custom SSL certificate https://github.com/StackStorm/ansible-st2/pull/133
- [x] Configure any `st2.conf` and `mistral.conf` setting https://github.com/StackStorm/ansible-st2/pull/121
- [ ] ~Example with external `mongo`, `rabbitmq`, `postgresql`  https://github.com/StackStorm/ansible-st2/issues/17~ (will be available in next `0.8.0`)

