### PR TITLE
Remove legacy version reference

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -199,7 +199,6 @@ Run the following curl commands to test.
     # The following will verify the SSL cert, succeed, and return a valid token.
     curl -X POST --cacert /path/to/cacert.pem -u yourusername:'yourpassword' https://myhost.example.com/auth/v1/tokens
 
-.. note:: Until version 1.2 of |st2|, auth APIs were served from its own port. If your version is 1.1.1 or below, replace '/api' with ':9100'.
 
 .. _authentication-usage:
 


### PR DESCRIPTION
Saw a minor formatting issue (use of single quotes instead of backticks). Was going to fix it, but then realized that we should just get rid of references to ancient versions like that.