### PR TITLE
Add notice on StackStorm packages creating and using purpose-build Python virtual environment

### DIFF
--- a/docs/source/_includes/__pip_virtualenv_notice.rst
+++ b/docs/source/_includes/__pip_virtualenv_notice.rst
@@ -1,0 +1,25 @@
+.. note::
+
+  When using packages to install |st2| a special Python virtual environment is
+  created in ``/opt/stackstorm/st2/`` for |st2| dependencies and components.
+
+  This means that if you want to work and manipulate StackStorm installation
+  (e.g. use ``python`` binary from that virtualenv or install new auth backend)
+  you need to work with the |st2| virtual environment.
+
+  You can do so by activating the virtual environment or running ``python`` /
+  ``pip`` binary directly from the virtual environment as shown below.
+
+  .. code-block: bash
+
+    # by activating the virtual environment
+
+    source /opt/stackstorm/st2/bin/activate
+
+    pip install foo
+
+    # or by directly invoking binaries from the virtual environment
+    /opt/stackstorm/st2/bin/python
+
+    /opt/stackstorm/st2/bin/pip install foo
+

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -59,7 +59,9 @@ run the following command on the same server where st2auth is running.
 
 .. sourcecode:: bash
 
-    pip install git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2_auth_backend_pam
+    /opt/stackstorm/st2/bin/pip install git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2_auth_backend_pam
+
+.. include:: /_includes/__pip_virtualenv_notice.rst
 
 After the backend is installed, configure the backend at ``/etc/st2/st2.conf``, and restart |st2|.
 Specific configuration details for the backend can be found in the README at the corresponding


### PR DESCRIPTION
This should help clear things up when installing new auth backend, etc.

I honestly though we already updated the docs with that, but it looks like we didn't yet (or maybe it lives in some other document, but my grep failed me).