### PR TITLE
RBAC permission sensor_all -> sensor_type_all

### DIFF
--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -440,7 +440,7 @@ following content -
             resource_uid: "pack:example"
             permission_types:
                - "pack_all"
-               - "sensor_all"
+               - "sensor_type_all"
                - "rule_all"
                - "action_all"
 


### PR DESCRIPTION
For some reason RBAC permissions for sensors are sensor_type_<blah>, unlike all the other permission types.

See https://docs.stackstorm.com/rbac.html#available-permission-types