### PR TITLE
RBAC permission sensor_all -> sensor_type_all

### DIFF
--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -358,7 +358,7 @@ Now we setup a role. Create file `/opt/stackstorm/rbac/roles/x_pack_owner.yaml` 
             resource_uid: "pack:x"
             permission_types:
                - "pack_all"
-               - "sensor_all"
+               - "sensor_type_all"
                - "rule_all"
                - "action_all"
 


### PR DESCRIPTION
For some reason RBAC permissions for sensors are sensor_type_<blah>, unlike all the other permission types.