### PR TITLE
Add universal version picker and version warning (#455) to v2.2

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/source/_themes/sphinx_rtd_theme/layout.html
@@ -147,6 +147,13 @@
         <div class="rst-content">
           {% include "breadcrumbs.html" %}
           <div role="main" class="document">
+            <div id="version-warning" class="admonition warning hide">
+              <p class="first admonition-title">Note</p>
+              <p class="last">
+                The documentation you're currently reading is for version {{ release|e }}.
+                Click <a href="pathto('/', 1)">here</a> to view documentation for the latest stable.
+              </p>
+            </div>
             {% block body %}{% endblock %}
           </div>
           {% include "footer.html" %}
@@ -188,6 +195,8 @@
       });
   </script>
   {% endif %}
+
+  <script type="text/javascript" src="{{ pathto('/_static/js/versions.js', 1) }}"></script>
 
   {%- block footer %} {% endblock %}
 

--- a/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
+++ b/docs/source/_themes/sphinx_rtd_theme/static/css/theme.css
@@ -4740,4 +4740,8 @@ span[id*='MathJax-Span'] {
   text-align: center;
 }
 
+.hide {
+  display: none;
+}
+
 /*# sourceMappingURL=theme.css.map */

--- a/docs/source/_themes/sphinx_rtd_theme/static/js/versions.js_t
+++ b/docs/source/_themes/sphinx_rtd_theme/static/js/versions.js_t
@@ -1,0 +1,40 @@
+(function () {
+  function renderVersionBadge(versions, currentVersion) {
+    var versionsContainer = $('<dl><dt>Versions</dt></dl>');
+    $.each(versions, function (slug, url) {
+      versionsContainer.append('<dd><a href="' + url + '">' + slug + '</a></dd>');
+    });
+
+    var otherVersions = $('<div class="rst-other-versions"></div>').append(versionsContainer);
+
+    var container = $('<div id="versions" class="rst-versions rst-badge" data-toggle="rst-versions" role="note" aria-label="versions"></div>');
+    container.append('<span class="rst-current-version" data-toggle="rst-current-version">v: ' + currentVersion + ' <span class="fa fa-caret-down"></span></span>');
+    container.append(otherVersions);
+
+    $('#versions').replaceWith(container);
+  }
+
+  function showVersionWarning() {
+    $('#version-warning').show();
+  }
+
+  $(document).ready(function () {
+    var latestVersion = "{{ current_version }}";
+
+    var versions = {
+    {%- for slug, url in versions %}
+      "{{ slug }}": "{{ url }}",
+    {%- endfor %}
+    };
+
+    var currentVersion = latestVersion;
+
+    var match = window.location.pathname.match('^/(\\d+\\.\\d+)');
+    if (match) {
+      currentVersion = match[1];
+      showVersionWarning();
+    }
+
+    renderVersionBadge(versions, currentVersion);
+  });
+})()

--- a/docs/source/_themes/sphinx_rtd_theme/versions.html
+++ b/docs/source/_themes/sphinx_rtd_theme/versions.html
@@ -1,17 +1,2 @@
 {# Add rst-badge after rst-versions for small badge style. #}
-  <div class="rst-versions rst-badge" data-toggle="rst-versions" role="note" aria-label="versions">
-    <span class="rst-current-version" data-toggle="rst-current-version">
-      v: {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
-      <dl>
-        <dt>Versions</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
-        {% endfor %}
-      </dl>
-    </div>
-  </div>
-
-
+  <div id="versions"></div>


### PR DESCRIPTION
Same as #455, but for v2.2. Once it starts getting pushed to v2.1 & v2.2, we should see if it actually works...

* Add universal version picker and version warning

* move / inside pathto

just for a good measure
