### PR TITLE
redirects for /config/ entries

### DIFF
--- a/docs/source/_redirects/config/config.html
+++ b/docs/source/_redirects/config/config.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=../install/config/config.html" />
+</head>
+<body>
+<p>This page has moved to <a href="../install/config/config.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/config/index.html
+++ b/docs/source/_redirects/config/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=../install/config/" />
+</head>
+<body>
+<p>This page has moved to <a href="../install/config/">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/config/webui.html
+++ b/docs/source/_redirects/config/webui.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=../install/config/webui.html" />
+</head>
+<body>
+<p>This page has moved to <a href="../install/config/webui.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/_redirects/config/windows_runners.html
+++ b/docs/source/_redirects/config/windows_runners.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=../install/config/windows_runners.html" />
+</head>
+<body>
+<p>This page has moved to <a href="../install/config/windows_runners.html">here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Missed some redirects for /config. Same as #482, but for v2.2.