### PR TITLE
Added robots.txt

### DIFF
--- a/docs/source/_redirects/robots.txt
+++ b/docs/source/_redirects/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /0.*/
+Disallow: /1.*/
+Disallow: /2.*/
+Disallow: /3.*/
+Disallow: /4.*/
+Disallow: /5.*/


### PR DESCRIPTION
We've made several changes with canonical URLs and redirect files, to steer Google away from indexing old content. This is working pretty well - almost all searches are now returning the 'right' results.

This change adds robots.txt, so Google won't show version-specific entries below the 'right' answers.