### PR TITLE
workaround corrupted cache issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ requirements: virtualenv
 
 	# Make sure we use latest version of pip
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=8.1.2,<8.2"
+	$(VIRTUALENV_DIR)/bin/pip install --no-cache-dir "osc-lib>=1.5.1"
 
 	# Install requirements
 	#


### PR DESCRIPTION
Having problems with osc-lib install on Xenial. Force install without cache.