### PR TITLE
Fix basic auth example

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -212,8 +212,8 @@ Fire the POST, check out the file and see that it appends the payload if the nam
     # And for fun, same post with st2
     st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost/api/v1/webhooks/sample headers='x-auth-token=put_token_here,content-type=application/json' verify_ssl_cert=False
 
-    # And for even more fun, same post with st2 using basic authentication
-    st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost/api/v1/webhooks/sample headers='content-type=application/json' verify_ssl_cert=False username=user1 password=pass1
+    # And for even more fun, using basic authentication over https
+    st2 run core.http url=https://httpbin.org/basic-auth/st2/pwd username=st2 password=pwd
 
     # Check that the rule worked. By default, st2 runs as the stanley user.
     sudo tail /home/stanley/st2.webhook_sample.out


### PR DESCRIPTION
Test of this example is successful.

Per https://stackoverflow.com/questions/6509278/authentication-test-servers:

```
root@e9cdba372a08:/# st2 run core.http url=https://httpbin.org/basic-auth/st2/pwd username=st2 password=pwd     
.
id: 592482b94cd9de054c0cf171
status: succeeded
parameters: 
  password: pwd
  url: https://httpbin.org/basic-auth/st2/pwd
  username: st2
result: 
  body:
    authenticated: true
    user: st2
  headers:
    Access-Control-Allow-Credentials: 'true'
    Access-Control-Allow-Origin: '*'
    Connection: keep-alive
    Content-Length: '46'
    Content-Type: application/json
    Date: Tue, 23 May 2017 18:43:04 GMT
    Server: meinheld/0.6.1
    Via: 1.1 vegur
    X-Powered-By: Flask
    X-Processed-Time: '0.000506162643433'
  parsed: true
  status_code: 200
```