### PR TITLE
Pack config: removed config.yaml references, clarifications, cleanups

### DIFF
--- a/docs/source/_includes/config_yaml_deprecation_notice.rst
+++ b/docs/source/_includes/config_yaml_deprecation_notice.rst
@@ -10,5 +10,9 @@
 
     For backward compatibility, if a pack doesn't contain a config inside the
     ``/opt/stackstorm/configs/`` directory, values from config.yaml are still
-    used when running an action, but support for config.yaml files inside the
-    pack directory will be fully removed in the next major release.
+    used when running an action.
+
+    In version 2.3, |st2| will generate WARNING logs at pack registration if
+    it contains ``config.yaml``. When version 2.4 is released, it will fail
+    with an error if packs still contain ``config.yaml``. You **MUST** migrate
+    your configurations.

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -23,8 +23,8 @@ Details:
 * ``chain`` is the array property that contains tasks, which incapsulate action invocation.
 * Tasks are named action execution specifications provided in form of a list. The name is scoped to an ActionChain and is used as a reference to a task.
 * ``ref`` property of an task points to an Action registered in |st2|.
-* ``on-success`` is the link to a task to invoke next on a successful action execution. If not provided, the ActionChain will terminate with status set to `success`.
-* ``on-failure`` is an optional link to a task to invoke next on a failed action execution. If not provided, the ActionChain will terminate with the status set to `error`.
+* ``on-success`` is the link to a task to invoke next on a successful action execution. If not provided, the ActionChain will terminate with status set to ``success``.
+* ``on-failure`` is an optional link to a task to invoke next on a failed action execution. If not provided, the ActionChain will terminate with the status set to ``error``.
 * ``default`` is an optional top level property that specifies the start of an ActionChain. If ``default`` not explicitly specified, the ActionChain starts from the first action.
 
 ActionChain metadata

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -244,10 +244,10 @@ To register a new action:
 
 The actions are grouped in :doc:`packs </packs>` and located
 at ``/opt/stackstorm/packs`` (default, configured, multiple locations supported).
-For hacking one-off actions, the convention is to use `default` pack - just create your action in
-``/opt/stackstorm/packs/default/actions``.
+For hacking one-off actions, the convention is to use the ``default`` pack - just
+create your action in ``/opt/stackstorm/packs/default/actions``.
 
-Register an individual action by calling `st2 action create my_action_metadata.yaml`.
+Register an individual action by calling ``st2 action create my_action_metadata.yaml``.
 To reload all the actions, use ``st2ctl reload --register-actions``
 
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -240,7 +240,7 @@ The optional ``-m`` attribute allows metadata to be associated with the created 
 practice to assign a meaningful value like the external service which uses this key to authenticate
 with |st2|.
 
-The CLI for API keys also support `get`, `list`, `delete`, `enable` and `disable` commands.
+The CLI for API keys also support ``get``, ``list``, ``delete``, ``enable`` and ``disable`` commands.
 
 If an API Key is disabled it will disallow access until that API key is enabled again. This is a
 good way to temporarily revoke access of an external service to |st2|.

--- a/docs/source/chatops/aliases.rst
+++ b/docs/source/chatops/aliases.rst
@@ -195,7 +195,7 @@ The above alias supports the following commands:
     !list sensors from examples limit=2
 
 
-Note: formats are matched in the exact order they are specified in a YAML array, and must be ordered from the most specific (first) to the most generic (last). ``deploy {{ pack }} to {{ host }}`` should come before ``deploy {{ pack }}``, otherwise everything after `deploy` will always be mapped to `pack`, ignoring more specific format strings that come after.
+Note: formats are matched in the exact order they are specified in a YAML array, and must be ordered from the most specific (first) to the most generic (last). ``deploy {{ pack }} to {{ host }}`` should come before ``deploy {{ pack }}``, otherwise everything after ``deploy`` will always be mapped to ``pack``, ignoring more specific format strings that come after.
 
 "Display-representation" format objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +215,7 @@ In this case, instead of having a string in ``formats``, you can write an object
 This works as follows:
 
   - the ``display`` string (``run {{cmd}} on {{hosts}}``) will be exposed via the ``!help`` command.
-  - strings from the `representation` list (``(run|execute) {{cmd}}( on {{hosts=localhost}})?[!.]?`` regex, and ``run remote command {{cmd}} on {{hosts}}`` string) will be matched by Hubot.
+  - strings from the ``representation`` list (``(run|execute) {{cmd}}( on {{hosts=localhost}})?[!.]?`` regex, and ``run remote command {{cmd}} on {{hosts}}`` string) will be matched by Hubot.
 
 You can use both strings and display-representation objects in ``formats`` at the same time:
 
@@ -241,7 +241,7 @@ link to the Web UI. This message can be customized in your alias definition:
       format: "acknowledged!"
       append_url: false
 
-The ``format`` parameter will customize your message, and the ``append_url`` flag controls the Web UI link at the end. It is also possible to use Jinja in the format string, with `actionalias` and `execution` comprising the Jinja context:
+The ``format`` parameter will customize your message, and the ``append_url`` flag controls the Web UI link at the end. It is also possible to use Jinja in the format string, with ``actionalias`` and ``execution`` comprising the Jinja context:
 
 .. code-block:: yaml
 

--- a/docs/source/chatops/notifications.rst
+++ b/docs/source/chatops/notifications.rst
@@ -37,7 +37,7 @@ while registering the action. For example:
     runner_type: "local-shell-cmd"
 
 Above is the same action as a ``local-shell-cmd`` action but with notify. As you can see, there
-is a notify section with ``on-complete`` section. You can also specify `on-success`
+is a notify section with ``on-complete`` section. You can also specify ``on-success``
 and ``on-failure`` sections with different messages. These subsections are all optional but at
 least one is required for any meaningful notification. For the sake of clarity, an ``on-success`` case
 is presented below.

--- a/docs/source/development/code_structure.rst
+++ b/docs/source/development/code_structure.rst
@@ -9,8 +9,8 @@ bit.
 StackStorm/st2 Repo
 -------------------
 
-StackStorm is made up of individual services viz. `st2auth`, `st2api`, `st2rulesengine`,
-`st2sensorcontainer`, `st2actionrunner`, `st2notifier`.
+StackStorm is made up of individual services viz. ``st2auth``, ``st2api``, ``st2rulesengine``,
+``st2sensorcontainer``, ``st2actionrunner``, ``st2notifier``.
 
 Also, StackStorm has a CLI and client library. Code for all these services and components are laid
 out in different folders in the repo root.
@@ -27,7 +27,7 @@ st2api
 ------
 
 This folder contains code for API controllers in StackStorm APIs are versioned and so are controllers.
-Experimental controllers are added to `exp` folder inside st2api and when they mature, they are
+Experimental controllers are added to ``exp`` folder inside st2api and when they mature, they are
 moved to folders containing versioned controllers.
 
 st2auth

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -145,14 +145,14 @@ Additional Makefile targets
  - ``make lint`` runs lint tasks (flake8, pylint)
  - ``make docs`` compiles this documentation
  - ``make clean`` clears .pyc's and docs
- - ``make distclean`` runs `make clean` target and also drops virtualenv
+ - ``make distclean`` runs ``make clean`` target and also drops virtualenv
  - ``make requirements`` installs python requirements
  - ``make virtualenv`` creates an empty virtual environment
 
 Manual Testing
 ~~~~~~~~~~~~~~
 
-In case you only need to test specific module, it might be reasonable to call `nosetests` directly.
+In case you only need to test a specific module, it might be reasonable to call ``nosetests`` directly.
 Make sure your virtualenv is active then run:
 
 ::

--- a/docs/source/install/config/config.rst
+++ b/docs/source/install/config/config.rst
@@ -106,9 +106,9 @@ Configure SSH
 
 To run actions on remote hosts, |st2| uses SSH. It is advised to configure identity file based SSH access on all remote hosts.
 
-The |st2| ssh user and path to SSH key are set in ``/etc/st2/st2.conf``. During installation, ``st2_deploy.sh`` script configures ssh on the local box for a user `stanley`.
+The |st2| ssh user and path to SSH key are set in ``/etc/st2/st2.conf``. During installation, ``st2_deploy.sh`` script configures ssh on the local box for a user ``stanley``.
 
-Follow these steps on a remote box to setup `stanley` user on remote boxes.
+Follow these steps on a remote box to setup ``stanley`` user on remote boxes.
 
 .. code-block:: bash
 
@@ -142,7 +142,7 @@ To verify do the following from the |st2| box
 SSH Troubleshooting
 ~~~~~~~~~~~~~~~~~~~
 
-* Validate that passwordless SSH configuration works fine for the destination. Assuming default user `stanley`:
+* Validate that passwordless SSH configuration works fine for the destination. Assuming default user ``stanley``:
 
     .. code-block:: bash
 
@@ -165,7 +165,7 @@ SUDO Access
 
 |st2|'s ``shell`` actions -  ``local-shell-cmd``, ``local-shell-script``, ``remote-shell-cmd``, ``remote-shell-script``- are performed by a special user. By default, this user is named ``stanley``. This is configurable via :github_st2:`st2.conf <conf/st2.prod.conf>`.
 
-.. note:: `stanley` user requires the following access:
+.. note:: ``stanley`` user requires the following access:
 
     * Sudo access to all boxes on which script action will run.
     * SETENV option needs to be set for all the commands. This way environment variables which are

--- a/docs/source/install/config/webui.rst
+++ b/docs/source/install/config/webui.rst
@@ -30,7 +30,7 @@ Configuration
 
 For the UI to work properly, both web client and |st2| server side should be configured accordingly.
 
-On the web client side, the file ``config.js`` in the project contains the list of servers this UI can connect to. This is typically `/opt/stackstorm/static/webui/config.js`. The file consists of an array of objects, each with ``name``, ``url`` and ``auth`` properties.
+On the web client side, the file ``config.js`` in the project contains the list of servers this UI can connect to. This is typically ``/opt/stackstorm/static/webui/config.js``. The file consists of an array of objects, each with ``name``, ``url`` and ``auth`` properties.
 
 ::
 
@@ -64,9 +64,9 @@ Origin consists of scheme, hostname and port (if it isn't 80). Path (including t
 
 Please note that some of the origins are already included by default and do not require additional configuration:
 
-* http://localhost:3000 - development version of `gulp` running locally
+* http://localhost:3000 - development version of ``gulp`` running locally
 * http://localhost:9101,http://127.0.0.1:9101 - st2api pecan deployment (st2_deploy default)
-* `api_url` from [auth] section of st2.conf
+* ``api_url`` from [auth] section of ``st2.conf``
 
 Also, please note that although this is not recommended and will undermine your security, you can allow every web UI deployment to connect to your server by setting ``allow_origin = *``.
 

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -180,7 +180,7 @@ Install WebUI and setup SSL termination
 
 `NGINX <http://nginx.org/>`_ is used to serve WebUI static files, redirect HTTP to HTTPS,
 provide SSL termination for HTTPS, and reverse-proxy st2auth and st2api API endpoints.
-To set it up, install `st2web` and `nginx`, generate certificates or place your existing
+To set it up, install ``st2web`` and ``nginx``, generate certificates or place your existing
 certificates under ``/etc/ssl/st2``, and configure nginx with |st2|'s supplied
 :github_st2:`site config file st2.conf<conf/nginx/st2.conf>`.
 

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -28,7 +28,7 @@ share a dedicated Python virtualenv, and are configured by /etc/st2/st2.conf.
       run all the defined timers.
     * **st2actionrunners** run actions from packs under ``/opt/stackstorm/packs`` via a variety of
       :doc:`/reference/runners`. Runners may require some runner-specific configurations, e.g. SSH needs to be
-      configured for running remote actions based on `remote-shell-runner` and `remote-command-runner`.
+      configured for running remote actions based on ``remote-shell-runner`` and ``remote-command-runner``.
       Windows prerequisites must be in place to run Windows runners. See :doc:`Runners </reference/runners>`
       for details.
     * **st2resultstracker** keeps track of long-running workflow executions, calling the Mistral
@@ -73,7 +73,7 @@ it is restricted to localhost.
   and reverse-proxies REST API endpoints to st2* web services.
 
 * **StackStorm WebUI** (st2web, and Workflow Designer, for Brocade Workflow Composer) are installed at ``/opt/statckstorm/webui``
-  and configured via ``webui/config.js``. `st2web` comes in its own ``deb`` and ``rpm``. `Flow` is
+  and configured via ``webui/config.js``. ``st2web`` comes in its own ``deb`` and ``rpm``. ``Flow`` is
   deployed with ``bwc-enterprise`` package. They are HTML5 applications, served as static HTML,
   and calling |st2| st2auth and st2api REST API endpoints. NGINX proxies st2auth and st2api
   requests through 443 HTTPS port to ``/api`` and ``/auth``.

--- a/docs/source/install/puppet_chef_salt_ansible.rst
+++ b/docs/source/install/puppet_chef_salt_ansible.rst
@@ -116,7 +116,7 @@ Any of the module configuration settings can be set at declaration. An example o
      auth_url => 'https://st2auth.stackstorm.net',
    }
 
-When composing your own profile, you can include `Class[::st2]` into your catalog to set any variables necessary.
+When composing your own profile, you can include ``Class[::st2]`` into your catalog to set any variables necessary.
 
 Hiera Configuration
 ~~~~~~~~~~~~~~~~~~~
@@ -130,7 +130,7 @@ Likewise, module configuration can be set via Hiera. For example in a hiera data
 Pack Installation and Management
 --------------------------------
 
-|st2| packs can be installed and configured directly from Puppet. This can be done via the `st2::pack` and `st2::pack::config` defined types.
+|st2| packs can be installed and configured directly from Puppet. This can be done via the ``st2::pack`` and ``st2::pack::config`` defined types.
 
 Defined Types
 ~~~~~~~~~~~~~

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -22,7 +22,7 @@ Install libffi-devel package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RHEL 6 may not ship with ``libffi-devel`` which is a dependency for |st2|.
-If that is the case, set up `server-optional` repository, following instructions at https://access.redhat.com/solutions/265523.
+If that is the case, set up the ``server-optional`` repository, following instructions at https://access.redhat.com/solutions/265523.
 Or, find a version of libffi-devel compatible with libffi on the box, and install this version of ``libffi-devel```. For example:
 
 .. code :: bash
@@ -240,7 +240,7 @@ Install WebUI and setup SSL termination
 
 `NGINX <http://nginx.org/>`_ is used to serve WebUI static files, redirect HTTP to HTTPS,
 provide SSL termination for HTTPS, and reverse-proxy st2auth and st2api API endpoints.
-To set it up: install `st2web` and `nginx`, generate certificates or place your existing
+To set it up: install ``st2web`` and ``nginx``, generate certificates or place your existing
 certificates under ``/etc/ssl/st2``, and configure nginx with |st2|'s supplied
 :github_st2:`site config file st2.conf<conf/nginx/st2.conf>`.
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -216,7 +216,7 @@ Install WebUI and setup SSL termination
 
 `NGINX <http://nginx.org/>`_ is used to serve WebUI static files, redirect HTTP to HTTPS,
 provide SSL termination for HTTPS, and reverse-proxy st2auth and st2api API endpoints.
-To set it up: install `st2web` and `nginx`, generate certificates or place your existing
+To set it up: install ``st2web`` and ``nginx``, generate certificates or place your existing
 certificates under ``/etc/ssl/st2``, and configure nginx with |st2|'s supplied
 :github_st2:`site config file st2.conf<conf/nginx/st2.conf>`.
 

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -146,7 +146,18 @@ before saving it; it's optional, and most packs don't require more than two or t
 have to comply with Health and Safety. The generated file will be placed in
 ``/opt/stackstorm/configs/<pack>.yaml`` and loaded.
 
-There are more nice tricks on pack configuration, see :doc:`/reference/pack_configs`.
+.. warning:: 
+
+    NB: |st2| loads pack configuration into MongoDB. This is automatically loaded when you use
+    ``st2 pack config``. But if you manually edit your pack configuration, or use configuration
+    management tools to manage those files, you **must** tell |st2| to load the updated config.
+
+    You can do this with: ```sudo st2ctl reload --register-configs``. Otherwise there will be much
+    head-scratching as you wonder why |st2| seems to be completely ignoring your updated configuration.
+
+    Trust us. We've all been there.
+
+For more nice tricks on pack configuration, see :doc:`/reference/pack_configs`.
 
 Developing a Pack
 -----------------

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -146,13 +146,6 @@ before saving it; it's optional, and most packs don't require more than two or t
 have to comply with Health and Safety. The generated file will be placed in
 ``/opt/stackstorm/configs/<pack>.yaml`` and loaded.
 
-The interactive configuration works for all packs that have a ``config.schema.yaml`` file,
-that has been a standard for a while now, but some older packs might require you to edit
-a ``config.yaml`` file inside the ``/opt/stackstorm/packs/<pack>`` directory, and reload the
-pack with ``st2 pack register <pack>``. Move the config file to ``/opt/stackstorm/configs/<pack>.yaml``
-after you perform the configuration to keep the config file away from the pack source and
-ensure compatibility with future versions.
-
 There are more nice tricks on pack configuration, see :doc:`/reference/pack_configs`.
 
 Developing a Pack

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -1,9 +1,11 @@
 REST API Reference
 ===================
 
-Work in progress...
+Check our new `API documentation <https://api.stackstorm.com>`! This includes information
+on how to use the API, references for all API options, etc.
 
-Meantime, using ``--debug`` key may help: used on any CLI command, it prints `curl` and outputs raw response:
+Yo can also use the ``--debug`` flag with any CLI command. It will print out the
+equivalent ``curl`` commands and responses, e.g.:
 
 ::
 
@@ -15,5 +17,3 @@ Meantime, using ``--debug`` key may help: used on any CLI command, it prints `cu
     # -------- begin 140419231392336 response ----------
     [{"description": "Run ad-hoc ansible command (module)", "runner_type":
     ...
-
-.. todo: publish complete REST API

--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -387,7 +387,7 @@ act as the SSL termination endpoint for all the REST endpoints exposed by ``st2a
 
 .. literalinclude:: /../../st2/conf/HA/nginx/st2.conf.blueprint.sample
 
-12. To use Timer triggers with Mistral, enable them on only one server. Make this change in `/etc/st2/st2.conf`:
+12. To use Timer triggers with Mistral, enable them on only one server. Make this change in ``/etc/st2/st2.conf``:
 
     .. code-block:: yaml
 

--- a/docs/source/reference/pack_configs.rst
+++ b/docs/source/reference/pack_configs.rst
@@ -112,12 +112,12 @@ a single ``device_uuids`` attribute.
 Configuration file
 ~~~~~~~~~~~~~~~~~~
 
-Configuration file is a YAML formatted file which contains pack configuration.
-This file can contain "static" or "dynamic" values. Configuration file is named
-by a pack name (``<pack name>.yaml``) and located in ``/opt/stackstorm/configs/``
+The configuration file is a YAML formatted file which contains pack configuration.
+This file can contain "static" or "dynamic" values. The configuration file is named
+``<pack name>.yaml`` and located in ``/opt/stackstorm/configs/``
 directory.
 
-For example, for a pack named ``libcloud``, configuration file is located at
+For example, for a pack named ``libcloud``, the configuration file is located at
 ``/opt/stackstorm/configs/libcloud.yaml``.
 
 An example configuration which matches the configuration schema above is
@@ -218,19 +218,12 @@ In this case, using the CLI, the value would be set as displayed below:
 Configuration loading and dynamic value resolving
 -------------------------------------------------
 
-Configuration file is loaded and dynamic values are resolved during run-time.
-For sensors this is when sensor container spawns a subprocess for sensor
-instance and for actions that is when action is executed.
+The configuration file is loaded and dynamic values are resolved during run-time.
+For sensors this is when the sensor container spawns a subprocess for a sensor
+instance and for actions that is when the action is executed.
 
-Previous versions of |st2| supported pack-local configuration files which were
-named ``config.yaml`` and stored in a root of the pack directory. For backward
-compatibility and ease of migration, those files are still supported, but
-new-style configuration files have precedence over it. If both files are
-present, old-style configuration file is loaded first and values from new-style
-configuration file are loaded and merged in second.
-
-When resolving and loading user-scoped configuration value, authenticated user
-which triggered the action execution is used for the context when resolving the
+When resolving and loading user-scoped configuration values, the authenticated user
+who triggered the action execution is used for the context when resolving the
 value.
 
 Configuring dynamic configuration values using the CLI

--- a/docs/source/reference/pack_configs.rst
+++ b/docs/source/reference/pack_configs.rst
@@ -114,8 +114,8 @@ Configuration file
 
 The configuration file is a YAML formatted file which contains pack configuration.
 This file can contain "static" or "dynamic" values. The configuration file is named
-``<pack name>.yaml`` and located in ``/opt/stackstorm/configs/``
-directory.
+``<pack name>.yaml`` and located in the ``/opt/stackstorm/configs/`` directory. File
+ownership should be ``st2:st2``.
 
 For example, for a pack named ``libcloud``, the configuration file is located at
 ``/opt/stackstorm/configs/libcloud.yaml``.

--- a/docs/source/reference/pack_management_transition.rst
+++ b/docs/source/reference/pack_management_transition.rst
@@ -85,11 +85,7 @@ Starting from 2.1, |st2| enforces validation on ``pack.yaml``.
 If you create your own packs, please validate them against these rules:
 
 * The ``version`` value in ``pack.yaml`` must conform to `semver <http://semver.org/>`__:
-  ``0.2.5``, not ``0.2``.
-  In 2.1, the system will attempt to do automatic conversion. If the attempt fails, the pack
-  loading will error out. NOTE: there will be no implicit conversions in future releases, and
-  pack loading will fail if the version is not in the semver format. Convert the versions and
-  update your packs as soon as possible to avoid surprises.
+  ``0.2.5``, not ``0.2``. Pack loading will fail if the version is not in the semver format.
 * The ``name`` value in ``pack.yaml`` must only contain letters, digits, and underscores,
   since it is also used as a ref (UID) for the pack. You can set the ``ref`` value explicitly
   in ``pack.yaml``: in this case, ``ref`` is going to be validated against the rule above,

--- a/docs/source/reference/packs.rst
+++ b/docs/source/reference/packs.rst
@@ -19,21 +19,22 @@ Canonical pack as laid out on the file system.
     policies/                #
     tests/                   #
     etc/                     # any additional things (e.g code generators, scripts...)
-    config.schema.yaml       # configuration schema (replacing config.yaml)
+    config.schema.yaml       # configuration schema
     packname.yaml.example    # example of config, used in CI
     pack.yaml                # pack definition file
     requirements.txt         # requirements for Python packs
     requirements-tests.txt   # requirements for python tests
     icon.png                 # 64x64 .png icon
 
-Some old packs also have a configuration file at ``/opt/stackstorm/<pack_name>/config.yaml``
-that defines any shared configuration used by the actions and sensors, e.g. usernames, region names, hostnames, etc. New pack rely on :doc:`configuration schema</reference/pack_configs>` and keep their configuration files under ``/opt/stackstorm/configs```.
-
 At the topmost level are the main folders ``actions``, ``rules``, ``sensors``, ``aliases`` and ``policies`` as well as some shared files:
 
 * ``pack.yaml`` - Metadata file that describes and identifies the folder as a pack.
 * ``config.schema.yaml`` - Schema that defines configuration elements used by a pack.
 * ``requirements.txt`` - File containing a list of python dependencies.
+
+Site-specific pack configuration files are stored at ``/opt/stackstorm/configs/``. See
+:doc:`configuration schema</reference/pack_configs>` for more information.
+
 
 .. code-block:: bash
 
@@ -95,7 +96,7 @@ Creating Your First Pack
 ------------------------
 In the example below, we will create a simple pack named **hello_st2**. The full example is also available at :github_st2:`st2/contrib/hello_st2 <contrib/hello_st2>`.
 
-1. Create the pack folder structure and related files. Let's keep the metadata files such as pack.yaml, config.schema.yaml, and requirements.txt empty for now:
+1. Create the pack folder structure and related files. Let's keep the metadata files such as ``pack.yaml``, ``config.schema.yaml``, and ``requirements.txt`` empty for now:
 
   .. code-block:: bash
 

--- a/docs/source/reference/runners.rst
+++ b/docs/source/reference/runners.rst
@@ -41,7 +41,7 @@ Local script runner (local-shell-script)
 
 This is the local runner. Actions are implemented as scripts. They are executed
 on the same hosts where |st2| components are running. The last newline
-character is stripped from `stdout` and `stderr` fields in the output.
+character is stripped from ``stdout`` and ``stderr`` fields in the output.
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ Remote command runner (remote-shell-cmd)
 
 This is a remote runner. This runner executes a Linux command on one or more
 remote hosts provided by the user. The last newline character is stripped
-from `stdout` and `stderr` fields in the output.
+from ``stdout`` and ``stderr`` fields in the output.
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ Remote script runner (remote-shell-script)
 
 This is a remote runner. Actions are implemented as scripts. They run on one or
 more remote hosts provided by the user. The last newline character is stripped
-from `stdout` and `stderr` fields in the output.
+from ``stdout`` and ``stderr`` fields in the output.
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/reference/sensor_partitioning.rst
+++ b/docs/source/reference/sensor_partitioning.rst
@@ -5,7 +5,7 @@ Often it is desirable to partition sensors across multiple sensor nodes. To this
 |st2| offers a few approaches to defining partition schemes.
 
 Each sensor node is identified by a name. The sensor nodename can be provided via a config
-property `sensor_node_name` as follows:
+property ``sensor_node_name`` as follows:
 
 ::
 
@@ -21,7 +21,7 @@ In the default scheme all sensors are run on a particular node. As the name sugg
 default scheme which ships out of the box. It is useful in cases where there is a single
 sensor node.
 
-No change required in the config file but for complete-ness the config would be as follows:
+No change required in the config file but for completeness the config would be as follows:
 
 ::
 

--- a/docs/source/reference/traces.rst
+++ b/docs/source/reference/traces.rst
@@ -91,7 +91,7 @@ Both custom webhooks and generic |st2| webhooks support supplying a trace-tag vi
 
 * `Header` : ``St2-Trace-Tag``
 
-In case of a custom webhook the `curl` command will be
+In case of a custom webhook the ``curl`` command will be:
 
 .. sourcecode:: bash
 

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -39,7 +39,7 @@ listed below:
 The generic form of a rule is:
 
 * The ``name`` of the rule.
-* The ``pack`` that the rule belongs to. `default` is assumed if a pack is not specified.
+* The ``pack`` that the rule belongs to. ``default`` is assumed if a pack is not specified.
 * The ``description`` of the rule.
 * The ``enabled`` state of a rule (``true`` or ``false``).
 * The type of ``trigger`` emitted from sensors to monitor, which may consist of:
@@ -437,7 +437,7 @@ question ``Why did my rule not match the trigger that just fired?``. This means 
 ``Rule`` identifiable by its reference loaded in |st2| and similarly a TriggerInstance
 with a known id.
 
-Lets say we have rule reference `my_pack.fire_on_execution` and a trigger instance `566b4be632ed352a09cd347d`
+Lets say we have rule reference ``my_pack.fire_on_execution`` and a trigger instance ``566b4be632ed352a09cd347d``
 
 .. code-block:: bash
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -61,7 +61,7 @@ Work with Actions
 
 |st2| comes with several generic actions out of the box. The catalog of actions can be easily
 extended by getting actions from the community or consuming your existing scripts (`more on that
-later`). Browse the catalog with ``st2 action list``. Action is referred to by `ref` as
+later`). Browse the catalog with ``st2 action list``. Action is referred to by ``ref`` as
 ``pack.action_name`` (e.g. ``core.local``). Learn about an action by doing
 ``st2 action get <action>``, or, ``st2 run <action> --h (--help)``: the command shows the
 description along with action parameters so that you know how to run it from the CLI or use it
@@ -89,7 +89,7 @@ To run the action from the CLI, do
     # HTTP REST call to st2 action endpoint
     st2 run -j core.http url="https://docs.stackstorm.com" method="GET"
 
-Use ``core.remote`` action to run linux command on multiple hosts over ssh. This assumes that
+Use the ``core.remote`` action to run Linux commands on multiple hosts via SSH. This assumes that
 passwordless SSH access is configured for the hosts, as described in :ref:`config-configure-ssh`
 section.
 
@@ -133,7 +133,8 @@ Check the action execution history and details of action executions with ``st2 e
     # Get only the last 5 executions
     st2 execution list -n 5
 
-That's it. You have learned to run |st2|'s actions. Let's stitch together other automation.
+That's it. You have learned to run |st2|'s actions. Now let's stitch events and actions togethe
+with rules.
 
 
 Define a Rule

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -389,9 +389,9 @@ Upgrading from 1.1
 
 To upgrade a pre-1.2.0 StackStorm instance provisioned with the :doc:`install/all_in_one`, you will need to perform the following steps:
 
-  1. Back up `/opt/puppet/hieradata/answers.json`.
+  1. Back up ``/opt/puppet/hieradata/answers.json``.
 
-  2. Update (or insert) the following lines in `/opt/puppet/hieradata/answers.yaml`:
+  2. Update (or insert) the following lines in ``/opt/puppet/hieradata/answers.yaml``:
 
   ```
   st2::version: 1.2.0
@@ -400,11 +400,11 @@ To upgrade a pre-1.2.0 StackStorm instance provisioned with the :doc:`install/al
   hubot::docker: true
   ```
 
-  If `answers.yaml` does not exist, create it. If you changed any install parameters manually (e.g. password, ChatOps token, SSH user), put these values into `answers.yaml` as well, otherwise they'll be overwritten.
+  If ``answers.yaml`` does not exist, create it. If you changed any install parameters manually (e.g. password, ChatOps token, SSH user), put these values into ``answers.yaml`` as well, otherwise they'll be overwritten.
 
-  3. If you're running ChatOps, stop the Hubot service with `service hubot stop`.
+  3. If you're running ChatOps, stop the Hubot service with ``service hubot stop``.
 
-  4. Remove `/etc/facter/facts.d/st2web_bootstrapped.txt` and execute `update-system`:
+  4. Remove ``/etc/facter/facts.d/st2web_bootstrapped.txt`` and execute ``update-system``:
 
   ```
   sudo rm /etc/facter/facts.d/st2web_bootstrapped.txt
@@ -425,11 +425,11 @@ To verify the upgrade, please follow the link to run the :doc:`self-verification
 
 Migrating to v1
 ~~~~~~~~~~~~~~~
-The `st2_deploy scripted installer` will upgrade v0.13 to v1.1. However we encourage you to switch to :doc:`install/all_in_one`. To migrate to new All-in-one deployment from existing pre v1.1 installations:
+The ``st2_deploy scripted installer`` will upgrade v0.13 to v1.1. However we encourage you to switch to :doc:`install/all_in_one`. To migrate to new All-in-one deployment from existing pre v1.1 installations:
 
     1. Install |st2| on a new clean box with :doc:`install/all_in_one`.
-    2. Copy the content from the previous installation to `/opt/stackstorm/packs`
-       and reload it with `st2ctl reload --register-all`.
+    2. Copy the content from the previous installation to ``/opt/stackstorm/packs``
+       and reload it with ``st2ctl reload --register-all``.
     3. Adjust the content according to upgrade notes below. Test and ensure your automations work.
     4. Save the audit log files from ``/var/log/st2/*.audit.log`` for future reference.
        We do not migrate execution history to the new installation, but all the execution data is
@@ -439,9 +439,9 @@ The `st2_deploy scripted installer` will upgrade v0.13 to v1.1. However we encou
 
 Changes
 ~~~~~~~
-* Triggers now have a `ref_count` property which must be included in Trigger objects
+* Triggers now have a ``ref_count`` property which must be included in Trigger objects
   created in previous versions of |st2|. A migration script is shipped in
-  ${dist_packages}/st2common/bin/migrate_triggers_to_include_ref_count.py on installation.
+  ``${dist_packages}/st2common/bin/migrate_triggers_to_include_ref_count.py`` on installation.
   The migration script is run as part of st2_deploy.sh when you upgrade from versions >= 0.13 to
   1.1.
 * Messaging queues are now exlusive and in some cases renamed from previous versions. To
@@ -464,7 +464,7 @@ Changes
 ------------
 
 * Rules now have to be part of a pack. If you don't specify a pack,
-  pack name is assumed to be `default`. A migration script
+  pack name is assumed to be ``default``. A migration script
   (migrate_rules_to_include_pack.py) is shipped in ${dist_packages}/st2common/bin/
   on installation. The migration script
   is run as part of st2_deploy.sh when you upgrade from versions < 0.9 to 0.11.


### PR DESCRIPTION
- Cleaned up references to `config.yaml` - https://github.com/StackStorm/st2/issues/3424
- Tried to be more consistent with use of backquotes for formatting. I think we mess it up due to differences between RST & Multimarkdown.

Also Fixes #445 and Fixes #471 