### PR TITLE
Add note about how sensors are run

### DIFF
--- a/docs/source/sensors.rst
+++ b/docs/source/sensors.rst
@@ -77,7 +77,7 @@ How Sensors are Run
 Each sensor runs as a separate process. The st2sensorcontainer (see
 :doc:`Overview </install/overview>`) starts ``sensor_wrapper.py`` which wraps
 your Sensor class (such as ``SampleSensor`` or ``SamplePollingSensor`` above) in
-a :py:class:`st2reactor.container.sensor_wrapper.SensorWrapper`.
+a :ref:`st2reactor.container.sensor_wrapper.SensorWrapper<ref-sensors-authoring-a-sensor>`.
 
 Sensor Service
 --------------
@@ -212,6 +212,8 @@ is not found this method will return ``False``, ``True`` otherwise.
 .. code:: python
 
     self.sensor_service.delete_value(name='my_key')
+
+.. _ref-sensors-api-docs:
 
 API Docs
 ~~~~~~~~

--- a/docs/source/sensors.rst
+++ b/docs/source/sensors.rst
@@ -71,6 +71,14 @@ would use a PollingSensor instead of Sensor as the base class.
 For a complete implementation of a sensor that actually injects triggers
 into the system, look at the `examples <#examples>`__ section.
 
+How Sensors are Run
+-------------------
+
+Each sensor runs as a separate process. The st2sensorcontainer (see
+:doc:`Overview </install/overview>`) starts ``sensor_wrapper.py`` which wraps
+your Sensor class (such as ``SampleSensor`` or ``SamplePollingSensor`` above) in
+a :py:class:`st2reactor.container.sensor_wrapper.SensorWrapper`.
+
 Sensor Service
 --------------
 


### PR DESCRIPTION
Digging through https://docs.stackstorm.com/latest/sensors.html, I didn't see anything about how sensors are run. Actions are run by action_runners with each action run by a separate st2actionrunner process (looking at the diagram on https://docs.stackstorm.com/latest/install/overview.html). But, (on the diagram) it looks like there is only one st2sensorcontainer. So, it wasn't clear whether or not sensors were run in separate processes, or if they might have side effects on other sensors.

This PR clarifies that, yes, the sensors are run in separate processes as @armab pointed out in #community posting this systemctl screenshot (which shows that each sensor runs via sensor_wrapper.py):
```
● st2sensorcontainer.service - StackStorm service st2sensorcontainer
   Loaded: loaded (/lib/systemd/system/st2sensorcontainer.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2017-05-23 17:36:26 UTC; 1 weeks 2 days ago
 Main PID: 18326 (st2sensorcontai)
    Tasks: 4
   Memory: 161.4M
      CPU: 1h 57min 33.710s
   CGroup: /system.slice/st2sensorcontainer.service
           ├─ 4237 /opt/stackstorm/virtualenvs/twitter/bin/python /opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/sensor_wrapper.py --pack=twitter --file-path=/opt/stackstorm/packs/twitter/sensors/twitter_search_sensor.py --class-name=TwitterSearchSensor --trigger-type-refs=twitter.matched_tweet --parent-args=["--config-file", "/etc/st2/st2.conf"] --poll-interval=30
           ├─ 4240 /opt/stackstorm/virtualenvs/twitter/bin/python /opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/sensor_wrapper.py --pack=twitter --file-path=/opt/stackstorm/packs/twitter/sensors/twitter_stream_sensor.py --class-name=TwitterStreamSensor --trigger-type-refs=twitter.stream_matched_tweet --parent-args=["--config-file", "/etc/st2/st2.conf"]
           ├─ 4242 /opt/stackstorm/virtualenvs/irc/bin/python /opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/sensor_wrapper.py --pack=irc --file-path=/opt/stackstorm/packs/irc/sensors/irc_sensor.py --class-name=IRCSensor --trigger-type-refs=irc.pubmsg,irc.privmsg,irc.join,irc.part --parent-args=["--config-file", "/etc/st2/st2.conf"]
           └─18326 /opt/stackstorm/st2/bin/python /opt/stackstorm/st2/bin/st2sensorcontainer --config-file /etc/st2/st2.conf
```

I'm not sure about where exactly to put the note, but I think this will work. Does it need to be fleshed out more than this?

~I have not built the sphinx project, so I don't know if the class ref works as expected.~ _CircleCI says the class ref failed. Bummer._