### PR TITLE
redirect config page

### DIFF
--- a/docs/source/_redirects/install/config.html
+++ b/docs/source/_redirects/install/config.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=config/config.html" />
+</head>
+<body>
+<p>This page has moved to <a href="config/config.html">here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
One more redirect needed to account for docs.stackstorm.com/latest/install/config.html, which is an outdated doc.