### PR TITLE
Parallel make steps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,5 +23,5 @@ machine:
 
 test:
   override:
-    - make docs
-    - make bwcdocs
+    - case $CIRCLE_NODE_INDEX in 0) make docs ;; 1) make bwcdocs ;; esac:
+        parallel: true


### PR DESCRIPTION
Split `make docs` and `make bwcdocs` to improve test time