### PR TITLE
Cross-reference for Mongo/Rabbit HA. Fixes #466

### DIFF
--- a/docs/source/install/config/config.rst
+++ b/docs/source/install/config/config.rst
@@ -27,6 +27,8 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
 
 The ``username`` and ``password`` properties are optional.
 
+.. _ref-mongo-ha-config:
+
 |st2| also supports `MongoDB replica sets <https://docs.mongodb.com/v3.2/core/replication-introduction/>`_
 using `MongoDB URI string <https://docs.mongodb.com/v3.2/reference/connection-string/>`_.
 
@@ -82,6 +84,8 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
     url = <amqp://#RMQ_USER:#RMQ_PASSWD@#RMQ_HOST:#RMQ_PORT/#RMQ_VHOST>
 
 The ``#RMQ_VHOST`` property is optional and can be left blank.
+
+.. _ref-rabbitmq-cluster-config:
 
 |st2| also supports `RabbitMQ cluster <https://www.rabbitmq.com/clustering.html>`_.
 

--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -155,7 +155,8 @@ MongoDB
 |st2| uses this to cache Actions, Rules and Sensor metadata which already live in the filesystem. All the content should
 ideally be source-control managed, preferably in a git repository. |st2| also stores operational data like ActionExecution,
 TriggerInstance etc. MongoDB supports `replica set high-availability <https://docs.mongodb.org/v2.4/core/replica-set-high-availability/>`__
-which we recommend to provide a safe failover.
+which we recommend to provide a safe failover. See :ref:`here<ref-mongo-ha-config>` for how to configure |st2| to
+connect to MongoDB replica sets.
 
 Loss of connectivity to a MongoDB cluster will cause downtime for |st2|. However, once a replica MongoDB is brought back it
 should be quite possible to bring |st2| back to operational state by simply loading the content. Easy access to old
@@ -175,6 +176,8 @@ RabbitMQ is the communication hub for |st2| to co-ordinate and distribute work. 
 `RabbitMQ documentation <https://www.rabbitmq.com/ha.html>`__ to understand HA deployment strategies.
 
 Our recommendation is to mirror all the Queues and Exchanges so that the loss of one server does not affect functionality.
+
+See :ref:`here<ref-rabbitmq-cluster-config>` for how to configure |st2| to connect to a RabbitMQ cluster.
 
 Zookeeper/Redis
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add cross-reference from HA doc to MongoDB & RabbitMQ configuration to show how to configure ST2 to connect to a MongoDB replica set/RabbitMQ cluster.

Fixes #466 