### PR TITLE
Fixed upgrade notes

### DIFF
--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -13,9 +13,6 @@ Upgrade Notes
   local path or a full source / destination which includes the server part (e.g.
   ``server.fqdn:/etc/hosts``).
 
-|st2| v2.2
-----------
-
 * The API endpoint for searching or showing packs has been updated to return an empty list
   instead of ``None`` when the pack was not found in the index. This is technically a breaking
   change, but a necessary one because returning ``None`` caused the client to throw an exception.


### PR DESCRIPTION
Additional v2.2 heading in there, same as https://github.com/StackStorm/st2docs/pull/526, for v2.3 branch