### PR TITLE
resultstracker is the config group

### DIFF
--- a/docs/source/troubleshooting/mistral.rst
+++ b/docs/source/troubleshooting/mistral.rst
@@ -35,7 +35,7 @@ the ``results_tracker`` section in ``/etc/st2/st2.conf``:
 
 .. sourcecode:: ini
 
-    [results_tracker]
+    [resultstracker]
     query_interval = 5 # in seconds
     thread_pool_size = 10
 


### PR DESCRIPTION
Related: https://github.com/StackStorm/st2/pull/3505

I'll open a branch against 2.3 as well. 