### PR TITLE
Cross-reference to API keys from Webhooks

### DIFF
--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -28,9 +28,9 @@ Authentication
 --------------
 
 All the requests to the /webhooks endpoints needs to be authenticated in the
-same way as other API requests. There are two possible authentication approaches - API
-keys and tokens. API keys are recommended for webhooks, as they do not expire. Tokens
-have a fixed expiry.
+same way as other API requests. There are two possible authentication approaches - 
+`API keys <authentication-apikeys>` and tokens. API keys are recommended for webhooks,
+as they do not expire. Tokens have a fixed expiry.
 
 API key-based
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #537