### PR TITLE
Added chatops log locations

### DIFF
--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -189,3 +189,10 @@ You should now be able to go into your chatroom, and execute the command
 .. figure:: /_static/images/chatops_command_out.png
 
 To customize the command output you can use Jinja templates as described in :doc:`aliases`.
+
+Logging
+=======
+
+ChatOps logs are written to ``/var/log/st2/st2chatops.log`` on non-systemd
+based distros. For systemd based distros you can access the logs via
+``journalctl --unit=st2chatops``

--- a/docs/source/troubleshooting/basic_chatops_troubleshooting.rst
+++ b/docs/source/troubleshooting/basic_chatops_troubleshooting.rst
@@ -72,7 +72,7 @@ listed (``pack`` and ``st2`` sets of commands should be installed by default).
 
     **Possible reasons:**
 
-    - Hubot can't connect to StackStorm API. Look in the st2chatops logs for errors: ``/var/log/st2/st2chatops.log``
+    - Hubot can't connect to StackStorm API. Look in the st2chatops logs for errors: ``/var/log/st2/st2chatops.log`` or for systemd based distros ``journalctl --unit=st2chatops``
     - Actions and/or ChatOps aliases aren't registered. Try running ``st2ctl reload --register-all``.
     - It's also possible you changed the bot's name or you have not invited your bot to a channel in the chat client.
     - If you're sending bot a private message instead of messaging it in a channel, 


### PR DESCRIPTION
Seen several questions on Slack wondering about location of ChatOps logs, to help remedy this i've done the following

1. Added a Logging section to the main ChatOps document
2. Mentioned the different log location for systemd distros