### PR TITLE
ChatOps API Key link

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -258,11 +258,11 @@ is to use the `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
 
 * `Add NodeJS v4 repository <https://nodejs.org/en/download/package-manager/>`_: ::
 
-      curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
+      curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 
 * Install st2chatops package: ::
 
-      sudo yum install -y st2chatops
+      sudo apt-get install -y st2chatops
 
 * Review and edit the ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to
   your |st2| installation and Chat Service you are using. At a minimum, you should generate an

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -15,7 +15,7 @@ System Requirements
 
 Please check :doc:`supported versions and system requirements <system_requirements>`.
 
-Minimal installation
+Minimal Installation
 --------------------
 
 Install Dependencies
@@ -49,8 +49,8 @@ For Ubuntu ``Xenial`` you may need to enable and start MongoDB.
     sudo systemctl enable mongod
     sudo systemctl start mongod
 
-Setup repositories
-~~~~~~~~~~~~~~~~~~~
+Setup Repositories
+~~~~~~~~~~~~~~~~~~
 
 The following script will detect your platform and architecture and setup the repo accordingly. It will also install the GPG key for repo signing.
 
@@ -58,7 +58,7 @@ The following script will detect your platform and architecture and setup the re
 
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.deb.sh | sudo bash
 
-Install |st2| components
+Install |st2| Components
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   .. code-block:: bash
@@ -175,7 +175,7 @@ Check out :doc:`/reference/cli` to learn convenient ways to authenticate via CLI
 
 .. _ref-install-webui-ssl-deb:
 
-Install WebUI and setup SSL termination
+Install WebUI and Setup SSL Termination
 ---------------------------------------
 
 `NGINX <http://nginx.org/>`_ is used to serve WebUI static files, redirect HTTP to HTTPS,
@@ -244,8 +244,10 @@ For example, to see the endpoint for getting actions, invoke
 Setup ChatOps
 -------------
 
-If you already run a Hubot instance, you only have to install the `hubot-stackstorm plugin <https://github.com/StackStorm/hubot-stackstorm>`_ and configure |st2| env variables, as described below. Otherwise, the easiest way to enable
-:doc:`StackStorm ChatOps </chatops/index>` is to use the `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
+If you already run a Hubot instance, you only have to install the
+`hubot-stackstorm plugin <https://github.com/StackStorm/hubot-stackstorm>`_ and configure |st2| env
+variables, as described below. Otherwise, the easiest way to enable :doc:`StackStorm ChatOps </chatops/index>`
+is to use the `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
 
 * Validate that ``chatops`` pack is installed, and a notification rule is enabled: ::
 
@@ -256,18 +258,21 @@ If you already run a Hubot instance, you only have to install the `hubot-stackst
 
 * `Add NodeJS v4 repository <https://nodejs.org/en/download/package-manager/>`_: ::
 
-      curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+      curl -sL https://rpm.nodesource.com/setup_4.x | sudo -E bash -
 
 * Install st2chatops package: ::
 
-      sudo apt-get install -y st2chatops
+      sudo yum install -y st2chatops
 
-* Review and edit ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to your
-  |st2| installation and Chat Service you are using. By default ``st2api`` and ``st2auth``
-  are expected to be on the same host. If that is not the case, please update ``ST2_API`` and
-  ``ST2_AUTH_URL`` variables or just point to correct host with ``ST2_HOSTNAME`` variable.
+* Review and edit the ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to
+  your |st2| installation and Chat Service you are using. At a minimum, you should generate an
+  `API key <authentication-apikeys>` and set the ``ST2_API_KEY`` variable. By default ``st2api``
+  and ``st2auth`` are expected to be on the same host. If that is not the case, please update the
+  ``ST2_API`` and ``ST2_AUTH_URL`` variables or just point to the correct host with ``ST2_HOSTNAME``.
 
-  The example configuration uses Slack; go to Slack web admin interface, create a Bot, and copy the authentication token into ``HUBOT_SLACK_TOKEN``.
+  The example configuration uses Slack. To set this up, go to the Slack web admin interface, create
+  a Bot, and copy the authentication token into ``HUBOT_SLACK_TOKEN``.
+
   If you are using a different Chat Service, set corresponding environment variables under
   `Chat service adapter settings`:
   `Slack <https://github.com/slackhq/hubot-slack>`_,

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -307,8 +307,10 @@ For example, to see the endpoint for getting actions, invoke
 Setup ChatOps
 -------------
 
-If you already run Hubot instance, you only have to install the `hubot-stackstorm plugin <https://github.com/StackStorm/hubot-stackstorm>`_ and configure |st2| env variables, as described below. Otherwise, the easiest way to enable
-:doc:`StackStorm ChatOps </chatops/index>` is to use `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
+If you already run a Hubot instance, you only have to install the
+`hubot-stackstorm plugin <https://github.com/StackStorm/hubot-stackstorm>`_ and configure |st2| env
+variables, as described below. Otherwise, the easiest way to enable :doc:`StackStorm ChatOps </chatops/index>`
+is to use the `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
 
 * Validate that ``chatops`` pack is installed, and a notification rule is enabled: ::
 
@@ -325,18 +327,16 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
 
       sudo yum install -y st2chatops
 
+* Review and edit the ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to
+  your |st2| installation and Chat Service you are using. At a minimum, you should generate an
+  `API key <authentication-apikeys>` and set the ``ST2_API_KEY`` variable. By default ``st2api``
+  and ``st2auth`` are expected to be on the same host. If that is not the case, please update the
+  ``ST2_API`` and ``ST2_AUTH_URL`` variables or just point to the correct host with ``ST2_HOSTNAME``.
 
-* Review and edit ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to your
-  |st2| installation and Chat Service you are using. By default ``st2api`` and ``st2auth``
-  are expected to be on the same host. If that is not the case, please update ``ST2_API`` and
-  ``ST2_AUTH_URL`` variables or just point to correct host with ``ST2_HOSTNAME`` variable.
+  The example configuration uses Slack. To set this up, go to the Slack web admin interface, create
+  a Bot, and copy the authentication token into ``HUBOT_SLACK_TOKEN``.
 
-  The example configuration uses Slack. In case of Slack, go to Slack web admin interface,
-  `create and configure a Bot <https://api.slack.com/bot-users>`_, invite a Bot to the rooms,
-  and copy the authentication token into ``HUBOT_SLACK_TOKEN`` variable.
-
-  If you are using a different Chat Service, make the appropriate bot configurations,
-  and set corresponding environment variables under
+  If you are using a different Chat Service, set corresponding environment variables under
   `Chat service adapter settings`:
   `Slack <https://github.com/slackhq/hubot-slack>`_,
   `HipChat <https://github.com/hipchat/hubot-hipchat>`_,

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -15,10 +15,10 @@ System Requirements
 
 Please check :doc:`supported versions and system requirements <system_requirements>`.
 
-Minimal installation
+Minimal Installation
 --------------------
 
-Install libffi-devel package
+Install libffi-devel Package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RHEL 6 may not ship with ``libffi-devel`` which is a dependency for |st2|.
@@ -32,7 +32,7 @@ Or, find a version of libffi-devel compatible with libffi on the box, and instal
 
   sudo yum localinstall -y ftp://fr2.rpmfind.net/linux/centos/6/os/x86_64/Packages/libffi-devel-3.0.5-3.2.el6.x86_64.rpm
 
-Adjust SELinux policies
+Adjust SELinux Policies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If your RHEL/CentOS box has SELinux in Enforcing mode, please follow these instructions to adjust SELinux
@@ -111,7 +111,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
     sudo chkconfig postgresql-9.4 on
 
 
-Setup repositories
+Setup Repositories
 ~~~~~~~~~~~~~~~~~~
 
 The following script will detect your platform and architecture and setup the repo accordingly. It'll also install the GPG key for repo signing.
@@ -120,7 +120,7 @@ The following script will detect your platform and architecture and setup the re
 
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
-Install |st2| components
+Install |st2| Components
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   .. code-block:: bash
@@ -235,7 +235,7 @@ To set up authentication with File Based provider:
 
 Check out :doc:`/reference/cli` to learn convenient ways to authenticate via CLI.
 
-Install WebUI and setup SSL termination
+Install WebUI and Setup SSL Termination
 ---------------------------------------
 
 `NGINX <http://nginx.org/>`_ is used to serve WebUI static files, redirect HTTP to HTTPS,

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -15,10 +15,10 @@ System Requirements
 
 Please check :doc:`supported versions and system requirements <system_requirements>`.
 
-Minimal installation
+Minimal Installation
 --------------------
 
-Adjust SELinux policies
+Adjust SELinux Policies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If your RHEL/CentOS box has SELinux in Enforcing mode, please follow these instructions to adjust SELinux
@@ -91,7 +91,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
     sudo systemctl start postgresql
     sudo systemctl enable postgresql
 
-Setup repositories
+Setup Repositories
 ~~~~~~~~~~~~~~~~~~
 
 The following script will detect your platform and architecture and setup the repo accordingly. It'll also install the GPG key for repo signing.
@@ -100,7 +100,7 @@ The following script will detect your platform and architecture and setup the re
 
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
-Install |st2| components
+Install |st2| Components
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   .. code-block:: bash
@@ -211,7 +211,7 @@ To set up authentication with File Based provider:
 
 Check out :doc:`/reference/cli` to learn convenient ways to authenticate via CLI.
 
-Install WebUI and setup SSL termination
+Install WebUI and Setup SSL Termination
 ---------------------------------------
 
 `NGINX <http://nginx.org/>`_ is used to serve WebUI static files, redirect HTTP to HTTPS,

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -295,8 +295,10 @@ For example, to see the endpoint for getting actions, invoke
 Setup ChatOps
 -------------
 
-If you already run Hubot instance, you only have to install the `hubot-stackstorm <https://github.com/StackStorm/hubot-stackstorm>`_ plugin and configure |st2| env variables, as described below. Otherwise, the easiest way to enable
-:doc:`StackStorm ChatOps </chatops/index>` is to use `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
+If you already run a Hubot instance, you only have to install the
+`hubot-stackstorm plugin <https://github.com/StackStorm/hubot-stackstorm>`_ and configure |st2| env
+variables, as described below. Otherwise, the easiest way to enable :doc:`StackStorm ChatOps </chatops/index>`
+is to use the `st2chatops <https://github.com/stackstorm/st2chatops/>`_ package.
 
 * Validate that ``chatops`` pack is installed, and a notification rule is enabled: ::
 
@@ -313,17 +315,16 @@ If you already run Hubot instance, you only have to install the `hubot-stackstor
 
       sudo yum install -y st2chatops
 
-* Review and edit ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to your
-  |st2|   installation and Chat Service you are using. By default ``st2api`` and ``st2auth``
-  are expected to be on the same host. If it's not the case, please update ``ST2_API`` and
-  ``ST2_AUTH_URL`` variables or just point to correct host with ``ST2_HOSTNAME`` variable.
+* Review and edit the ``/opt/stackstorm/chatops/st2chatops.env`` configuration file to point it to
+  your |st2| installation and Chat Service you are using. At a minimum, you should generate an
+  `API key <authentication-apikeys>` and set the ``ST2_API_KEY`` variable. By default ``st2api``
+  and ``st2auth`` are expected to be on the same host. If that is not the case, please update the
+  ``ST2_API`` and ``ST2_AUTH_URL`` variables or just point to the correct host with ``ST2_HOSTNAME``.
 
-  The example configuration uses Slack. In case of Slack, go to Slack web admin interface,
-  `create and configure a Bot <https://api.slack.com/bot-users>`_, invite a Bot to the rooms,
-  and copy the authentication token into ``HUBOT_SLACK_TOKEN`` variable.
+  The example configuration uses Slack. To set this up, go to the Slack web admin interface, create
+  a Bot, and copy the authentication token into ``HUBOT_SLACK_TOKEN``.
 
-  If you are using a different Chat Service, make the appropriate bot configurations,
-  and set corresponding environment variables under
+  If you are using a different Chat Service, set corresponding environment variables under
   `Chat service adapter settings`:
   `Slack <https://github.com/slackhq/hubot-slack>`_,
   `HipChat <https://github.com/hipchat/hubot-hipchat>`_,


### PR DESCRIPTION
Add link/note to API key generation for manual install & config of ChatOps. 

Small fixes to heading capitalization & language. 

Fixes #553 

