### PR TITLE
Mistral Workflow Validation and Jinja Expression Testing

### DIFF
--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -182,11 +182,14 @@ of Mistral workflow YAML files.
 
 Example:
 .. code-block:: bash
-    mistral workflow-validate /path/to/workflow.yaml
+
+   mistral workflow-validate /path/to/workflow.yaml
 
 
-.. note:: These sanity checks simply provide a test against the Mistral DSL schema.
-          They do NOT test YAQL or Jinja2 expressions.
+.. note::
+
+   These sanity checks simply provide a test against the Mistral DSL schema.
+   They do NOT test YAQL or Jinja2 expressions.
 
 
 More Examples

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -182,7 +182,7 @@ of Mistral workflow YAML files.
 
 Example:
 .. code-block:: bash
-   mistral workflow-validate /path/to/workflow.yaml
+    mistral workflow-validate /path/to/workflow.yaml
 
 
 .. note:: These sanity checks simply provide a test against the Mistral DSL schema.

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -181,6 +181,7 @@ The Mistral CLI ships with the capability of performing high-level sanity checks
 of Mistral workflow YAML files.
 
 Example:
+
 .. code-block:: bash
 
    mistral workflow-validate /path/to/workflow.yaml

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -184,7 +184,11 @@ Example:
 
 .. code-block:: bash
 
+   # Validate a workflow
    mistral workflow-validate /path/to/workflow.yaml
+
+   # Validate a workbook
+   mistral workbook-validate /path/to/workbook.yaml
 
 
 .. note::

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -6,7 +6,7 @@ Mistral
 
 * Mistral workflow definition language, aka `v2 DSL <http://docs.openstack.org/developer/mistral/dsl/dsl_v2.html>`_
 * `YAQL documentation <https://yaql.readthedocs.io/en/latest/>`_ and `YAQL online evaluator <http://yaqluator.com/>`_
-* `Jinja2 template engine <http://jinja.pocoo.org>`_
+* `Jinja2 template engine documentation <http://jinja.pocoo.org>`_ and `Jinja2 online evaluator <http://jinja2test.tk/>`_
 
 .. note::
 
@@ -174,6 +174,20 @@ Since there are multiple workflows defined in this workbook, the workflow author
 .. literalinclude:: /../../st2/contrib/examples/actions/mistral-workbook-complex.yaml
 
 To test out this workflow, save the metadata file to /opt/stackstorm/packs/examples/actions/ and the workflow file to /opt/stackstorm/packs/examples/actions/workflows. Run ``st2 action create /opt/stackstorm/packs/examples/actions/mistral-workbook-complex.yaml`` to create the action and run ``st2 run examples.mistral-workbook-complex vm_name="vmtest1" -a`` to test.
+
+Validation
++++++++++++++++++++
+The Mistral CLI ships with the capability of performing high-level sanity checks
+of Mistral workflow YAML files.
+
+Example:
+.. code-block:: bash
+   mistral workflow-validate /path/to/workflow.yaml
+
+
+.. note:: These sanity checks simply provide a test against the Mistral DSL schema.
+          They do NOT test YAQL or Jinja2 expressions.
+
 
 More Examples
 +++++++++++++++++++

--- a/docs/source/mistral_jinja.rst
+++ b/docs/source/mistral_jinja.rst
@@ -171,6 +171,47 @@ A number of Mistral and |st2| specific custom functions (aka filters in Jinja) s
 
 * ``st2kv('st2_key_id')`` queries |st2|'s datastore and returns the value for the given key. For example, the expression ``{{ st2kv('system.shared_key_x') }}`` returns the value for a system scoped key named ``shared_key_x`` while the expression ``{{ st2kv('my_key_y') }}`` returns the value for the user scoped key named ``my_key_y``. The ``st2kv`` function will always decrypt the value of the key if it is encrypted when the key value pair was set. Please note that the key name should be in quotes otherwise Jinja treats key name with a dot like ``system.shared_key_x`` as a dict access.
 
+Testing Expressions
++++++++++++++++++++
+Somtimes Jinja expressions can become complex and the need to verify the expression
+outside of StackStorm is necessary. To accomplish this there are a few options:
+
+- `Jinja2 online evaluator <http://jinja2test.tk/>`_
+- Write a small test script
+  
+  .. code-block:: python
+    #!/usr/bin/env python
+    import jinja2
+    import os
+
+
+    class JinjaUtils:
+    
+        @staticmethod
+        def render_file(filename, context):
+            path, filename = os.path.split(filename)
+            env = jinja2.Environment(loader=jinja2.FileSystemLoader(path or './'))
+            tmpl = env.get_template(filename)
+            return tmpl.render(context)
+
+        @staticmethod
+        def render_str(jinja_template_str, context):
+            env = jinja2.Environment()
+            tmpl = env.from_string(jinja_template_str)
+            return tmpl.render(context)
+
+
+    if __name__ == "__main__":
+        context = {{'results': {'name': 'Stanley'}}
+        template = "Hello {{ results.name }}"
+        print JinjaUtils.render_str(template, context)
+
+.. note::
+
+    The test script does NOT include the custom StackStorm Jinja filters or functions
+    such as ``st2kv``.
+
+  
 More Examples
 +++++++++++++
 More workflow examples using Jinja expressions can be found at :github_st2:`/usr/share/doc/st2/examples </contrib/examples/actions/workflows/>`. The examples are prefixed with ``mistral-jinja``.

--- a/docs/source/mistral_jinja.rst
+++ b/docs/source/mistral_jinja.rst
@@ -180,6 +180,7 @@ outside of StackStorm is necessary. To accomplish this there are a few options:
 - Write a small test script
   
   .. code-block:: python
+
     #!/usr/bin/env python
     import jinja2
     import os
@@ -202,7 +203,7 @@ outside of StackStorm is necessary. To accomplish this there are a few options:
 
 
     if __name__ == "__main__":
-        context = {{'results': {'name': 'Stanley'}}
+        context = {'results': {'name': 'Stanley'}}
         template = "Hello {{ results.name }}"
         print JinjaUtils.render_str(template, context)
 


### PR DESCRIPTION
The documentation was lacking information about how to validate Mistral workflows outside of StackStorm.

It was also lacking some information about how to test Jinja expressions.

Comments / ideas for improvements are welcome.