### PR TITLE
Update installation instructions to install MongoDB 3.4 by default

### DIFF
--- a/docs/source/install/__mongodb_note.rst
+++ b/docs/source/install/__mongodb_note.rst
@@ -1,5 +1,5 @@
 .. note::
 
-  The currently preferred and supported version of MongoDB is 3.2. This is the version
+  The currently preferred and supported version of MongoDB is 3.4. This is the version
   installed by the installer script. MongoDB 3.4 is supported in StackStorm v2.2.0 and above.
   Older versions of StackStorm (prior to v1.6.0) only supported MongoDB 2.x.

--- a/docs/source/install/config/config.rst
+++ b/docs/source/install/config/config.rst
@@ -29,8 +29,8 @@ The ``username`` and ``password`` properties are optional.
 
 .. _ref-mongo-ha-config:
 
-|st2| also supports `MongoDB replica sets <https://docs.mongodb.com/v3.2/core/replication-introduction/>`_
-using `MongoDB URI string <https://docs.mongodb.com/v3.2/reference/connection-string/>`_.
+|st2| also supports `MongoDB replica sets <https://docs.mongodb.com/v3.4/core/replication-introduction/>`_
+using `MongoDB URI string <https://docs.mongodb.com/v3.4/reference/connection-string/>`_.
 
 In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following section :
 
@@ -39,9 +39,9 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
     [database]
     host = mongodb://<#MDB_NODE_1>,<#MDB_NODE_2>,<#MDB_NODE_3>/?replicaSet=<#MDB_REPLICA_SET_NAME>
 
-* You can also add ports, usernames and passwords, etc to your connection string - https://docs.mongodb.com/v3.2/reference/connection-string/
+* You can also add ports, usernames and passwords, etc to your connection string - https://docs.mongodb.com/v3.4/reference/connection-string/
 
-* To understand more about setting up a MongoDB replica set - https://docs.mongodb.com/v3.2/tutorial/deploy-replica-set/
+* To understand more about setting up a MongoDB replica set - https://docs.mongodb.com/v3.4/tutorial/deploy-replica-set/
 
 |st2| also supports SSL/TLS to encrypt connections. A few extra properties need be added to
 the configuration apart from the ones outlined above.

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -31,10 +31,10 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
     sudo apt-get install -y gnupg-curl
     sudo apt-get install -y curl
 
-    # Add key and repo for the latest stable MongoDB (3.2)
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-    sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.2.list
-    deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -c | awk '{print $2}')/mongodb-org/3.2 multiverse
+    # Add key and repo for the latest stable MongoDB (3.4)
+    wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key adv -
+    sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.4.list
+    deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -c | awk '{print $2}')/mongodb-org/3.4 multiverse
     EOT"
     sudo apt-get update
 

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -32,7 +32,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
     sudo apt-get install -y curl
 
     # Add key and repo for the latest stable MongoDB (3.4)
-    wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key adv -
+    wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
     sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.4.list
     deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -c | awk '{print $2}')/mongodb-org/3.4 multiverse
     EOT"

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -28,9 +28,9 @@ Or, find a version of libffi-devel compatible with libffi on the box, and instal
 .. code :: bash
 
   [ec2-user@ip-172-30-0-79 ~]$ rpm -qa libffi
-  libffi-3.0.5-3.2.el6.x86_64
+  libffi-3.0.5-3.4.el6.x86_64
 
-  sudo yum localinstall -y ftp://fr2.rpmfind.net/linux/centos/6/os/x86_64/Packages/libffi-devel-3.0.5-3.2.el6.x86_64.rpm
+  sudo yum localinstall -y ftp://fr2.rpmfind.net/linux/centos/6/os/x86_64/Packages/libffi-devel-3.0.5-3.4.el6.x86_64.rpm
 
 Adjust SELinux Policies
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,15 +72,15 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
 
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 
-    # Add key and repo for the latest stable MongoDB (3.2)
-    sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
-    sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
-    [mongodb-org-3.2]
+    # Add key and repo for the latest stable MongoDB (3.4)
+    sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
+    sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
+    [mongodb-org-3.4]
     name=MongoDB Repository
-    baseurl=https://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.2/x86_64/
+    baseurl=https://repo.mongodb.org/yum/redhat/6Server/mongodb-org/3.4/x86_64/
     gpgcheck=1
     enabled=1
-    gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+    gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
     EOT"
 
     sudo yum -y install mongodb-org

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -61,15 +61,15 @@ Install MongoDB, RabbitMQ, and PostgreSQL.
 
     sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
-    # Add key and repo for the latest stable MongoDB (3.2)
-    sudo rpm --import https://www.mongodb.org/static/pgp/server-3.2.asc
-    sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.2.repo
-    [mongodb-org-3.2]
+    # Add key and repo for the latest stable MongoDB (3.4)
+    sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
+    sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
+    [mongodb-org-3.4]
     name=MongoDB Repository
-    baseurl=https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/3.2/x86_64/
+    baseurl=https://repo.mongodb.org/yum/redhat/7Server/mongodb-org/3.4/x86_64/
     gpgcheck=1
     enabled=1
-    gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+    gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
     EOT"
 
     sudo yum -y install mongodb-org

--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -154,7 +154,7 @@ MongoDB
 ^^^^^^^
 |st2| uses this to cache Actions, Rules and Sensor metadata which already live in the filesystem. All the content should
 ideally be source-control managed, preferably in a git repository. |st2| also stores operational data like ActionExecution,
-TriggerInstance etc. MongoDB supports `replica set high-availability <https://docs.mongodb.org/v2.4/core/replica-set-high-availability/>`__
+TriggerInstance etc. MongoDB supports `replica set high-availability <https://docs.mongodb.org/v3.4/core/replica-set-high-availability/>`__
 which we recommend to provide a safe failover. See :ref:`here<ref-mongo-ha-config>` for how to configure |st2| to
 connect to MongoDB replica sets.
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -10,6 +10,11 @@ Upgrade Notes
   default. To return decrypted values, this must be explictly enabled via parameter, like so:
   ``st2kv('st2_key_id', decrypt=true)``.
 
+* Installer script now installs MongoDB 3.4 by default (previously, 3.2 was installed by default).
+  For information on how to upgrade MongoDB on existing installations, please refer to the official
+  MongoDB documentation - https://docs.mongodb.com/v3.4/release-notes/3.4-upgrade-standalone/,
+  https://docs.mongodb.com/manual/release-notes/3.4-upgrade-replica-set/.
+
 |st2| v2.3
 ----------
 
@@ -23,6 +28,7 @@ Upgrade Notes
 * The API endpoint for searching or showing packs has been updated to return an empty list
   instead of ``None`` when the pack was not found in the index. This is technically a breaking
   change, but a necessary one because returning ``None`` caused the client to throw an exception.
+
 * Notifier now consumes "ActionExecution" RabbitMQ exchange with
   queue name ``st2.notifiers.execution.work``. Notifier used to scan ``LiveAction``
   exchange with ``st2.notifiers.work`` queue name. When you upgrade from |st2| versions older than v2.3,


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2/issues/3592 change.