### PR TITLE
switch to 'st2 pack install'

### DIFF
--- a/docs/source/install/common/verify.rst
+++ b/docs/source/install/common/verify.rst
@@ -17,7 +17,7 @@
     st2 run core.remote hosts='localhost' -- uname -a
 
     # Install a pack
-    st2 run packs.install packs=st2
+    st2 pack install st2
 
 Use the supervisor script to manage |st2| services: ::
 


### PR DESCRIPTION
Change to use of `st2 pack install` not `st2 run packs.install`

Fixes #578 