### PR TITLE
fixed api link rst & typo

### DIFF
--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -1,10 +1,10 @@
 REST API Reference
 ===================
 
-Check our new `API documentation <https://api.stackstorm.com>_`! It includes information
+Check our new `API documentation <https://api.stackstorm.com>`_! It includes information
 on how to use the API, references for all API options, etc.
 
-Yo can also use the ``--debug`` flag with any CLI command. It will print out the
+You can also use the ``--debug`` flag with any CLI command. It will print out the
 equivalent ``curl`` commands and responses, e.g.:
 
 .. code-block:: bash


### PR DESCRIPTION
Same as #596, for 2.4 branch