### PR TITLE
Adjust docs for 'resultstracker.query_interval' and Mistral completion latency & CPU overhead

### DIFF
--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -296,3 +296,13 @@ There are more workflow examples under :github_st2:`/usr/share/doc/st2/examples 
 Check out this step-by-step tutorial on building a workflow in |st2| https://stackstorm.com/2015/07/08/automating-with-mistral-workflow/
 
 More details about Mistral can be found at https://docs.openstack.org/mistral/latest/.
+
+
+Mistral Workflows Latency and Performance
+-----------------------------------------
+|st2| interacts with Mistral via HTTP APIs. This applies when kicking off a workflow execution
+or collecting the results for a running workflow. |st2| queries Mistral to check on workflow
+execution status and the status of individual tasks. This mechanism has a number of configuration settings.
+
+See :ref:`mistral-workflows-latency` section about how to fine-tune
+the Mistral workflows completion time opposed to CPU usage.

--- a/docs/source/troubleshooting/mistral.rst
+++ b/docs/source/troubleshooting/mistral.rst
@@ -46,13 +46,14 @@ the ``results_tracker`` section in ``/etc/st2/st2.conf``:
     thread_pool_size = 10
 
 These numbers are subject to load conditions in your infrastructure and the number of workflows
-you run. The default value for ``query_interval`` is set to ``5`` (seconds). With |st2| 2.2 and
+you run. The default value for ``query_interval`` is set to ``5`` (seconds) which is a balance
+between the workflow speed and CPU overhead. With |st2| 2.2 and
 earlier, this value was ``0.1``. We have now set the default value to ``5`` seconds to be
 conservative. This also means the time to detect a completed workflow in Mistral by |st2| could
 take as long as 5 seconds.
 
 If this is unacceptable for you, you can reduce the ``query_interval`` and also
-simultaneously check CPU usage for the ``st2resultstracker`` process. 
+simultaneously check CPU usage for the ``st2resultstracker`` process.
 
 We are reworking the design to use HTTP callbacks from Mistral to |st2|. Until then, these tunable
 knobs should help.

--- a/docs/source/troubleshooting/mistral.rst
+++ b/docs/source/troubleshooting/mistral.rst
@@ -21,6 +21,7 @@ When that happens, the new database tables, relationships, and indices must be d
 ``mistral-db-manage upgrade head`` command can be re-run. For more details, review the specific
 section for the version being upgraded in :doc:`/install/upgrades`.
 
+.. _mistral-workflows-latency:
 
 Troubleshooting Mistral Workflow Completion Latency
 ---------------------------------------------------

--- a/docs/source/troubleshooting/mistral.rst
+++ b/docs/source/troubleshooting/mistral.rst
@@ -46,10 +46,10 @@ the ``results_tracker`` section in ``/etc/st2/st2.conf``:
     thread_pool_size = 10
 
 These numbers are subject to load conditions in your infrastructure and the number of workflows
-you run. The default value for ``query_interval`` is set to ``20`` (seconds). With |st2| 2.2 and
-earlier, this value was ``0.1``. We have now set the default value to ``20`` seconds to be
+you run. The default value for ``query_interval`` is set to ``5`` (seconds). With |st2| 2.2 and
+earlier, this value was ``0.1``. We have now set the default value to ``5`` seconds to be
 conservative. This also means the time to detect a completed workflow in Mistral by |st2| could
-take as long as 20 seconds.
+take as long as 5 seconds.
 
 If this is unacceptable for you, you can reduce the ``query_interval`` and also
 simultaneously check CPU usage for the ``st2resultstracker`` process. 


### PR DESCRIPTION
Changing the `resultstracker.query_interval` doc setting from `20s` to `5s`, following the https://github.com/StackStorm/st2/pull/3776.

So seems like @lakshmi-kannan already included good explanation in `docs` about the Mistral latency troubleshooting when implemented `resultstracker.query_interval` setting.
