### PR TITLE
Add a note about the installation behind a proxy

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -56,6 +56,12 @@ installation, it fail. Start again with a clean system, or switch to a manual in
 If you're installing behind a proxy, just export the proxy ENV variables
 ``http_proxy``, ``https_proxy``, ``no_proxy`` before running the script.
 
+.. code-block:: bash
+
+  export http_proxy=http://proxy.server.io:port
+  export https_proxy=http://proxy.server.io:port
+  export no_proxy=localhost,127.0.0.1
+
 If you have problems accessing the Web UI on a RHEL 7/CentOS 7 system, check the
 :ref:`system firewall settings <ref-rhel7-firewall>`.
 

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -53,6 +53,9 @@ you may run into problems. In that case, you should use one of the manual instal
 The script itself is not idempotent. If you try to re-run the script on top of a failed
 installation, it fail. Start again with a clean system, or switch to a manual install.
 
+If you're installing behind a proxy, just export the proxy ENV variables
+``http_proxy``, ``https_proxy``, ``no_proxy`` before running the script.
+
 If you have problems accessing the Web UI on a RHEL 7/CentOS 7 system, check the
 :ref:`system firewall settings <ref-rhel7-firewall>`.
 


### PR DESCRIPTION
Following the https://github.com/StackStorm/st2-packages/pull/510 implementation, adding a note about installing StackStorm with `curl|bash` installer behind a proxy.

Example: 
```sh
export http_proxy=http://192.168.10.123:3128
export https_proxy=http://192.168.10.123:3128
export no_proxy=127.0.0.1,localhost

curl -sSL https://stackstorm.com/packages/install.sh |  bash -s -- --user=st2admin --password=st2admin
```
