### PR TITLE
Add additional note about using 'proxy_ca_bundle_path' in installer

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -62,6 +62,9 @@ If you're installing behind a proxy, just export the proxy ENV variables
   export https_proxy=http://proxy.server.io:port
   export no_proxy=localhost,127.0.0.1
 
+In case of MITM proxy, you may need to export additional ``proxy_ca_bundle_path``, see :ref:`packs-behind-proxy`.
+
+
 If you have problems accessing the Web UI on a RHEL 7/CentOS 7 system, check the
 :ref:`system firewall settings <ref-rhel7-firewall>`.
 

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -240,6 +240,8 @@ more secure than personal access tokens and can be configured on a per-repo basi
 Other git hosting services should also support either SSH or HTTPS auth, and would be configured
 in a similar fashion.
 
+.. _packs-behind-proxy:
+
 Installing Packs from Behind a Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add a note about using ``proxy_ca_bundle_path`` ENV variable in installer docs and cross-link to pack install details about the MITM proxy settings.