### PR TITLE
Added missing path and config option to 'Purging Old Operational Data"

### DIFF
--- a/docs/source/troubleshooting/purging_old_data.rst
+++ b/docs/source/troubleshooting/purging_old_data.rst
@@ -49,7 +49,7 @@ Purging Executions Older than Some Timestamp
 
 .. code-block:: bash
 
-    st2-purge-executions --timestamp="2015-11-25T21:45:00.000000Z"
+    /opt/stackstorm/st2/bin/st2-purge-executions --config-file /etc/st2/st2.conf --timestamp="2015-11-25T21:45:00.000000Z"
 
 The timestamp provided is interpreted as a UTC timestamp. Please perform all necessary timezone
 conversions and specify time in UTC.
@@ -59,7 +59,7 @@ parameter:
 
 .. code-block:: bash
 
-    st2-purge-executions --timestamp="2015-11-25T21:45:00.000000Z" --action-ref="core.localzz"
+    /opt/stackstorm/st2/bin/st2-purge-executions --config-file /etc/st2/st2.conf --timestamp="2015-11-25T21:45:00.000000Z" --action-ref="core.localzz"
 
 By default, only executions in completed state are deleted - i.e. ``succeeded``, ``failed``,
 ``canceled``, ``timeout`` and ``abandoned``. To delete all models irrespective of status, use the
@@ -67,21 +67,21 @@ By default, only executions in completed state are deleted - i.e. ``succeeded``,
 
 .. code-block:: bash
 
-    st2-purge-executions --timestamp="2015-11-25T21:45:00.000000Z" --purge-incomplete
+    /opt/stackstorm/st2/bin/st2-purge-executions --config-file /etc/st2/st2.conf --timestamp="2015-11-25T21:45:00.000000Z" --purge-incomplete
 
 This script may take some time to complete, depending on data volumes. We recommend running it
 inside a screen/tmux session. For example:
 
 .. code-block:: bash
 
-    screen -d -m -S purge-execs st2-purge-executions --timestamp="2015-11-25T21:45:00.000000Z"
+    screen -d -m -S purge-execs /opt/stackstorm/st2/bin/st2-purge-executions --config-file /etc/st2/st2.conf --timestamp="2015-11-25T21:45:00.000000Z"
 
 Purging Trigger Instances Older than Some Timestamp
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
-    st2-purge-trigger-instances --timestamp="2015-11-25T21:45:00.000000Z"
+    /opt/stackstorm/st2/bin/st2-purge-trigger-instances --config-file /etc/st2/st2.conf --timestamp="2015-11-25T21:45:00.000000Z"
 
 Again, the timestamp provided is interpreted as a UTC timestamp. Please perform all necessary
 timezone conversions and specify time in UTC.
@@ -91,4 +91,4 @@ inside a screen/tmux session. For example:
 
 .. code-block:: bash
 
-    screen -d -m -S purge-instances st2-purge-trigger-instances --timestamp="2015-11-25T21:45:00.000000Z"
+    screen -d -m -S purge-instances /opt/stackstorm/st2/bin/st2-purge-trigger-instances --config-file /etc/st2/st2.conf --timestamp="2015-11-25T21:45:00.000000Z"


### PR DESCRIPTION
Today i tried to follow "Purging Old Operational Data" and it didn't work as documented.

In order for things to work properly i needed to do the following:

* Specify the full path to the script. By default `/opt/stackstorm/st2/bin` isn't in `PATH` and the `st2-purge-*` scripts are not copied to `/usr/bin` so the command couldn't be found.
* Added the option that specifies the config path, without this option i was getting this fun (and totally non-intuitive) error:

```
2017-10-19 13:26:04,900 INFO [-] Connecting to database "st2" @ "127.0.0.1:27017" as user "None".
Traceback (most recent call last):
  File "/opt/stackstorm/st2/bin/st2-purge-executions", line 22, in <module>
    sys.exit(main())
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/cmd/purge_executions.py", line 67, in main
    common_setup(config=config, setup_db=True, register_mq_exchanges=False)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/script_setup.py", line 92, in setup
    db_setup()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/database_setup.py", line 43, in db_setup
    ssl_match_hostname=cfg.CONF.database.ssl_match_hostname)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/persistence/db_init.py", line 65, in db_setup_with_retry
    ssl_match_hostname=ssl_match_hostname)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/retrying.py", line 206, in call
    return attempt.get(self._wrap_exception)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/db/__init__.py", line 94, in db_setup
    db_ensure_indexes()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/db/__init__.py", line 129, in db_ensure_indexes
    raise e
pymongo.errors.OperationFailure: not authorized on st2 to execute command { createIndexes: "user_d_b", indexes: [ { unique: true, background: false, sparse: false, key: { name: 1 }, name: "name_1" } ], writeConcern: {} }
```