### PR TITLE
Add deprecation entry to the changelog for base Python runner Action class location

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -522,7 +522,7 @@ Writing Custom Python Actions
 -----------------------------
 
 In the simplest form, a Python action is a module which exposes a class which inherits from 
-:class:`st2actions.runners.pythonrunner.Action` and implements a ``run`` method.
+:class:`st2common.runners.base_action.Action` and implements a ``run`` method.
 
 Sample Python Action
 ~~~~~~~~~~~~~~~~~~~~
@@ -551,7 +551,7 @@ Action script file (``my_echo_action.py``):
 
     import sys
 
-    from st2actions.runners.pythonrunner import Action
+    from st2common.runners.base_action import Action
 
     class MyEchoAction(Action):
         def run(self, message):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -185,6 +185,7 @@ nitpicky = True
 # XXX: temp fix before we figure how to make autodocs work
 nitpick_ignore = [
     ('py:class', 'st2actions.runners.pythonrunner.Action'),
+    ('py:class', 'st2common.runners.base_action.Action'),
     ('py:class', 'KeyValuePair')]
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,6 +3,26 @@
 Upgrade Notes
 =============
 
+|st2| v2.6
+----------
+
+* ``st2actions.runners.pythonrunner.Action`` class path for base Python runner actions has been
+  deprecated since StackStorm v1.6.0 and will be fully removed in StackStorm v2.7.0. If you have
+  any actions still using this path you are encouraged to update them to use
+  ``st2common.runners.base_action.Action`` path.
+
+  Old code:
+
+  ..code-block:: python
+
+    from st2actions.runners.pythonrunner import Action
+
+  New code
+
+  ..code-block:: python
+
+    from st2common.runners.base_action import Action
+
 |st2| v2.5
 ----------
 


### PR DESCRIPTION
The actual path has been deprecated a long time ago already and we already mentioned this in the past in a blog post so it's only time to get rid of it in v2.7.0.