### PR TITLE
Remove IRC references

### DIFF
--- a/docs/source/__engage_community.rst
+++ b/docs/source/__engage_community.rst
@@ -3,4 +3,3 @@
 * Slack community channel: `stackstorm-community.slack.com <https://stackstorm-community.slack.com>`__ (Register `here <https://stackstorm.com/community-signup>`__)
 * Support: support@stackstorm.com
 * `Support Knowledge Base <https://stackstorm.reamaze.com/>`_
-* IRC: `#stackstorm on irc.freenode.org <http://webchat.freenode.net/?channels=stackstorm>`_

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -209,7 +209,6 @@ developers when the values are available and allows us to perform basic "static"
 code.
 
 .. _`PEP8 Python Style Guide`: http://www.python.org/dev/peps/pep-0008/
-.. _irc`: http://webchat.freenode.net/?channels=stackstorm
 .. _`Docstring conventions`: https://libcloud.readthedocs.org/en/latest/development.html#docstring-conventions
 
 .. toctree::

--- a/docs/source/troubleshooting/ask_for_support.rst
+++ b/docs/source/troubleshooting/ask_for_support.rst
@@ -3,13 +3,12 @@
 Ask for help!
 =============
 
-We stand behind |st2| and make our best effort to support you. Ask for support on any of the
-following channels:
+We stand behind |st2| and make our best effort to support you. Ask for support via one of these
+channels:
 
 * `Slack <https://stackstorm-community.slack.com>`_: If you're not a Slacker yet, here's a good
   excuse to become one! Come hang out, chat to us, search the archives to see if anyone else has
   faced the same problem. Register `here <https://stackstorm.com/community-signup>`_.
-* `IRC <http://webchat.freenode.net/?channels=stackstorm/>`_: We can all get our geek fix!
 * `Email support <support@stackstorm.com/>`_ and we'll get back to you as soon as we can.
 
 Please have the following list ready so we can help you faster:


### PR DESCRIPTION
IRC is getting little/no StackStorm traffic - most conversations happening via Slack. So better to remove the reference