### PR TITLE
Migrate Brocade -> Extreme

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -108,8 +108,8 @@ The following is a list of auth backends for the community edition to help get t
 LDAP (Enterprise Edition)
 -------------------------
 |st2|-developed auth backends such as LDAP are only available in |bwc|. For more information on
-|bwc|, please visit https://www.brocade.com/en/products-services/network-automation/workflow-composer.html
-The auth backends included with |bwc| are developed, tested, maintained, and supported by Brocade.
+|bwc|, please visit https://www.extremenetworks.com/product/workflow-composer/
+The auth backends included with |bwc| are developed, tested, maintained, and supported by Extreme Networks.
 
 LDAP
 ^^^^

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,8 +115,8 @@ extlinks = {
 # Use for variables substitutions
 
 if tags.has('enterprise'):
-    print "Building BWC docs"
-    product_replace = "\n.. |st2| replace:: BWC\n.. |fullname| replace:: Brocade Workflow Composer"
+    print "Building EWC docs"
+    product_replace = "\n.. |st2| replace:: EWC\n.. |fullname| replace:: Extreme Workflow Composer"
 else:
     print "Building StackStorm docs"
     product_replace = "\n.. |st2| replace:: StackStorm\n.. |fullname| replace:: StackStorm"
@@ -124,7 +124,7 @@ else:
 rst_epilog = """
 %s
 .. _exchange: https://exchange.stackstorm.org/
-.. |bwc| replace:: Brocade Workflow Composer
+.. |bwc| replace:: Extreme Workflow Composer
 .. |ipf| replace:: IP Fabric Automation Suite
 """ % product_replace
 

--- a/docs/source/info.py
+++ b/docs/source/info.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file contains values that differ between open-source
-# to commercial (BWC) documentation. Everything that might
+# to commercial (EWC) documentation. Everything that might
 # change from one version to another in conf.py should be 
 # placed here, otherwise you WILL break the build.
 
@@ -11,7 +11,7 @@ master_doc = 'index'
 
 project = u'StackStorm'
 copyright = u'2014 - %s, StackStorm' % (datetime.now().strftime("%Y"))
-author = u'Brocade Communications Inc'
+author = u'Extreme Networks, Inc'
 
 base_url = u'https://docs.stackstorm.com/'
 htmlhelp_basename = 'StackStormDoc'

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -156,7 +156,7 @@ If you are installing from behind a proxy, you can use the environment variables
 |bwc|
 -----
 
-Here's an example showing how to add :doc:`Brocade Workflow Composer </install/bwc>`, with
+Here's an example showing how to add :doc:`Extreme Workflow Composer </install/bwc>`, with
 `LDAP <https://bwc-docs.brocade.com/authentication.html#ldap>`_ authentication and
 `RBAC <https://bwc-docs.brocade.com/rbac.html>`_ configuration to allow/restrict/limit |st2|
 functionality to specific users:
@@ -166,7 +166,7 @@ functionality to specific users:
     - name: Install StackStorm Enterprise
       hosts: all
       roles:
-        - name: Install and configure StackStorm Enterprise (BWC)
+        - name: Install and configure StackStorm Enterprise (EWC)
           role: bwc
           vars:
             bwc_repo: enterprise
@@ -187,7 +187,7 @@ functionality to specific users:
             # Configure RBAC
             # See: https://bwc-docs.brocade.com/rbac.html
             bwc_rbac:
-              # Define BWC roles and permissions
+              # Define EWC roles and permissions
               # https://bwc-docs.brocade.com/rbac.html#defining-roles-and-permission-grants
               roles:
                 - name: core_local_only
@@ -213,7 +213,7 @@ functionality to specific users:
                   roles:
                     - system_admin
 
-        - name: Verify BWC Installation
+        - name: Verify EWC Installation
           role: bwc_smoketests
 
 .. note::

--- a/docs/source/install/bwc.rst
+++ b/docs/source/install/bwc.rst
@@ -4,35 +4,35 @@ Installing |bwc|
 StackStorm is an event-driven DevOps automation platform with all the essential features suitable
 for small businesses and teams. It’s free and open source under the Apache 2.0 license.
 
-|bwc| (BWC) is the commercial version of the StackStorm automation platform. BWC adds priority
+|bwc| (EWC) is the commercial version of the StackStorm automation platform. EWC adds priority
 support, advanced features such as fine-tuned access control, LDAP, and Workflow Designer. To
-learn more about |bwc|, get an evaluation license, or request a quote, visit `brocade.com/bwc
-<http://www.brocade.com/bwc>`_.
+learn more about |bwc|, get an evaluation license, or request a quote, visit `extremenetworks.com/product/workflow-composer
+<https://www.extremenetworks.com/product/workflow-composer/>`_.
 
-You can also add Brocade Network Automation Suites on top of a |bwc| system. See
+You can also add Network Automation Suites on top of an |bwc| system. See
 `bwc-docs.brocade.com/solutions/overview.html <https://bwc-docs.brocade.com/solutions/overview.html>`_
 to learn more.
 
 To install |bwc| for a quick evaluation, run the commands below on a clean 64-bit Linux box that
-meets the :doc:`/install/system_requirements`. Replace ``${BWC_LICENSE_KEY}`` with the key you
-received when registering for evaluation or purchasing BWC.
+meets the :doc:`/install/system_requirements`. Replace ``${EWC_LICENSE_KEY}`` with the key you
+received when registering for evaluation or purchasing EWC.
 
 .. code-block:: bash
 
   curl -sSL -O https://brocade.com/bwc/install/install.sh && chmod +x install.sh
-  ./install.sh --user=st2admin --password='Ch@ngeMe' --license=${BWC_LICENSE_KEY}
+  ./install.sh --user=st2admin --password='Ch@ngeMe' --license=${EWC_LICENSE_KEY}
 
 Already have a working StackStorm system, and want to add |bwc|? No problem! No need to install a
 new system. You can install |bwc| on top of your existing system. Just run these commands, again
-replacing ``${BWC_LICENSE_KEY}`` with the license key you received when registering:
+replacing ``${EWC_LICENSE_KEY}`` with the license key you received when registering:
 
 * On Ubuntu systems:
 
   .. code-block:: bash
 
-    # Set up Brocade Workflow Composer repository access
-    curl -s https://${BWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.deb.sh | sudo bash
-    # Install Brocade Workflow Composer
+    # Set up Extreme Workflow Composer repository access
+    curl -s https://${EWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.deb.sh | sudo bash
+    # Install Extreme Workflow Composer
     sudo apt-get install -y bwc-enterprise
 
 
@@ -40,9 +40,9 @@ replacing ``${BWC_LICENSE_KEY}`` with the license key you received when register
 
   .. code-block:: bash
 
-    # Set up Brocade Workflow Composer repository access
-    curl -s https://${BWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
-    # Install Brocade Workflow Composer
+    # Set up Extreme Workflow Composer repository access
+    curl -s https://${EWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
+    # Install Extreme Workflow Composer
     sudo yum install -y bwc-enterprise
 
 To understand the full details of the installation procedure, or to install |bwc| manually, follow

--- a/docs/source/install/common/bwc_intro.rst
+++ b/docs/source/install/common/bwc_intro.rst
@@ -5,5 +5,5 @@
 To learn more about |bwc|, request a quote, or get an evaluation license go to
 `stackstorm.com/product <https://stackstorm.com/product/#enterprise/>`_.
 
-To install |bwc|, replace ``${BWC_LICENSE_KEY}`` in the command below with the key you received
+To install |bwc|, replace ``${EWC_LICENSE_KEY}`` in the command below with the key you received
 when registering or purchasing, and run these commands:

--- a/docs/source/install/common/verify.rst
+++ b/docs/source/install/common/verify.rst
@@ -32,4 +32,4 @@ At this point you have a minimal working installation, and can happily play with
 packs from `StackStorm Exchange <https://exchange.stackstorm.org>`__.
 
 But there is no joy without a Web UI, no security without SSL or authentication, no fun without
-ChatOps, and no money without Brocade Workflow Composer. Read on!
+ChatOps, and no money without |bwc|. Read on!

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -219,9 +219,9 @@ Upgrade to |bwc|
 
 .. code-block:: bash
 
-  # Set up Brocade Workflow Composer repository access
-  curl -s https://${BWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.deb.sh | sudo bash
-  # Install Brocade Workflow Composer
+  # Set up Extreme Workflow Composer repository access
+  curl -s https://${EWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.deb.sh | sudo bash
+  # Install Extreme Workflow Composer
   sudo apt-get install -y bwc-enterprise
 
 .. rubric:: What's Next?

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -28,7 +28,7 @@ Choose the option that best suits your needs.
 
 Upgrading to |bwc|? This is installed as a set of additional packages on top of StackStorm. You
 can either install StackStorm + |bwc| in one go, or add the |bwc| packages to an existing
-StackStorm system. If you are using |bwc|, you can also add Brocade Network Automation Suites.
+StackStorm system. If you are using |bwc|, you can also add Network Automation Suites.
 Read the :doc:`/install/bwc` documentation for more.
 
 .. _ref-one-line-install:
@@ -84,7 +84,7 @@ For more details on reference deployments, or OS-specific installation instructi
     RHEL 6 / CentOS 6 <rhel6>
     Docker <docker>
     Ansible Playbooks <ansible>
-    Brocade Workflow Composer <bwc>
+    Extreme Workflow Composer <bwc>
     config/index
     upgrades
     uninstall

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -70,7 +70,7 @@ restricted to localhost.
 --------------------------------------
 * **nginx** provides SSL termination, redirects HTTP to HTTPS, serves WebUI static components, and
   reverse-proxies REST API endpoints to st2* web services.
-* **StackStorm WebUI** (st2web, and Workflow Designer, for Brocade Workflow Composer) are
+* **StackStorm WebUI** (st2web, and Workflow Designer, for Extreme Workflow Composer) are
   installed at ``/opt/stackstorm/static/webui`` and configured via ``webui/config.js``. ``st2web``
   comes in its own ``deb`` and ``rpm`` package. Workflow Designer is deployed as part of the
   ``bwc-enterprise`` package. They are HTML5 applications, served as static HTML, and call |st2|
@@ -94,7 +94,7 @@ The required dependencies are RabbitMQ, MongoDB, and PostgreSQL. The optional de
 
   - nginx for SSL termination, reverse-proxying API endpoints and serving static HTML.
   - Redis or Zookeeper for concurrency policies (see :doc:`/reference/policies`).
-  - LDAP for Brocade Workflow Composer LDAP authentication.
+  - LDAP for |bwc| LDAP authentication.
 
 
 Multi-box/HA deployment

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -284,9 +284,9 @@ Upgrade to |bwc|
 
 .. code-block:: bash
 
-  # Set up Brocade Workflow Composer repository access
-  curl -s https://${BWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
-  # Install Brocade Workflow Composer
+  # Set up Extreme Workflow Composer repository access
+  curl -s https://${EWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
+  # Install Extreme Workflow Composer
   sudo yum install -y bwc-enterprise
 
 .. rubric:: What's Next?

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -271,9 +271,9 @@ Upgrade to |bwc|
 
 .. code-block:: bash
 
-  # Set up Brocade Workflow Composer repository access
-  curl -s https://${BWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
-  # Install Brocade Workflow Composer
+  # Set up Extreme Workflow Composer repository access
+  curl -s https://${EWC_LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
+  # Install Extreme Workflow Composer
   sudo yum install -y bwc-enterprise
 
 .. rubric:: What's Next?

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -73,7 +73,7 @@ any skipped versions:
 v2.5
 '''''
 
-* If you have the `Brocade DC Fabric Automation Suite <https://bwc-docs.brocade.com/solutions/dcfabric/overview.html>`_
+* If you have the `DC Fabric Automation Suite <https://bwc-docs.brocade.com/solutions/dcfabric/overview.html>`_
   version 1.1 installed, you must upgrade this to >= v1.1.1. Follow `these instructions <https://bwc-docs.brocade.com/solutions/dcfabric/install.html#upgrade-from-previous-version>`_.
 
 v2.4

--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -3,9 +3,9 @@ Role Based Access Control
 
 .. note::
 
-   Role Based Access Control (RBAC) is only available in Brocade Workflow Composer. For information
-   about Brocade Workflow Composer and the differences between StackStorm and Brocade Workflow
-   Composer, please see `stackstorm.com/product <https://stackstorm.com/product/#enterprise>`_.
+   Role Based Access Control (RBAC) is only available in |bwc|. For information
+   about |bwc| and the differences between StackStorm and |bwc|, please see
+   `stackstorm.com/product <https://stackstorm.com/product/#enterprise>`_.
 
 Role Based Access Control (RBAC) allows system administrators to restrict users' access and limit
 the operations they can perform. For instance, you could give your database operator access only
@@ -230,10 +230,10 @@ There are some exceptions, described below:
 Enabling RBAC
 -------------
 
-If you installed BWC using the :doc:`one-line install </install/bwc>`, RBAC will be automatically
+If you installed |bwc| using the :doc:`one-line install </install/bwc>`, RBAC will be automatically
 enabled. It will assign the ``admin`` role to ``stanley`` and ``st2admin``. 
 
-If you installed BWC separately, by installing the ``bwc-enterprise`` package on top of |st2|, you
+If you installed |bwc| separately, by installing the ``bwc-enterprise`` package on top of |st2|, you
 will need to manually enable RBAC, and assign ``admin`` privileges to ``stanley``. It is not
 enabled by default. To enable it, add this section to ``/etc/st2/st2.conf``:
 

--- a/docs/source/troubleshooting/submit_debug_info.rst
+++ b/docs/source/troubleshooting/submit_debug_info.rst
@@ -21,21 +21,21 @@ By default, this utility sends us the following information:
 
 All this information is bundled up in a tarball and encrypted using our
 public key via public-key cryptography. Once submitted, this bundled information
-is only accessible to Brocade employees and it is used solely for
+is only accessible to Extreme Networks employees and it is used solely for
 debugging purposes.
 
-To send debug information to Brocade, run this CLI command:
+To send debug information to Extreme Networks, run this CLI command:
 
 .. sourcecode:: bash
 
     st2-submit-debug-info
 
-    This will submit the following information to Brocade: logs, configs, content, system_info
+    This will submit the following information to Extreme Networks: logs, configs, content, system_info
     Are you sure you want to proceed? [y/n] y
     2015-02-10 16:43:54,733  INFO - Collecting files...
     2015-02-10 16:43:55,714  INFO - Creating tarball...
     2015-02-10 16:43:55,892  INFO - Encrypting tarball...
-    2015-02-10 16:44:02,591  INFO - Debug tarball successfully uploaded to Brocade
+    2015-02-10 16:44:02,591  INFO - Debug tarball successfully uploaded to Extreme Networks
 
 By default, the command will run in an interactive mode. If you want to run it in a
 non-interactive mode and assuming "yes" as the answer to all the questions, you
@@ -91,7 +91,7 @@ After review, the archive can be uploaded using the ``--existing-file`` option:
     st2-submit-debug-info --config /etc/st2debug/submit-debug-info.yaml --existing-file my-st2-debug-file.tar.gz
 
     2016-02-24 23:56:13,019  INFO - Encrypting tarball...
-    2016-02-24 23:56:13,814  INFO - Debug tarball successfully uploaded to Brocade (name=my-st2-debug-file.tar.gz.asc)
+    2016-02-24 23:56:13,814  INFO - Debug tarball successfully uploaded to Extreme Networks (name=my-st2-debug-file.tar.gz.asc)
     2016-02-24 23:56:13,814  INFO - When communicating with support, please let them know the tarball name - my-st2-debug-file.tar.gz.asc
 
 
@@ -122,12 +122,12 @@ the YAML config file:
 
     st2-submit-debug-info --config <path to config file>
 
-    This will submit the following information to Brocade: logs, configs, content, system_info, shell_commands
+    This will submit the following information to Extreme Networks: logs, configs, content, system_info, shell_commands
     Are you sure you want to proceed? [y/n] y
     2016-01-19 06:12:18,587  INFO - Collecting files...
     2016-01-19 06:12:19,602  INFO - Creating tarball...
     2016-01-19 06:12:19,708  INFO - Encrypting tarball...
-    2016-01-19 06:12:43,949  INFO - Debug tarball successfully uploaded to Brocade (name=st2-debug-output-70386ae8e4fe-2016-01-19-06:12:18.tar.gz.asc)
+    2016-01-19 06:12:43,949  INFO - Debug tarball successfully uploaded to Extreme Networks (name=st2-debug-output-70386ae8e4fe-2016-01-19-06:12:18.tar.gz.asc)
     2016-01-19 06:12:43,949  INFO - When communicating with support, please let them know the tarball name - st2-debug-output-70386ae8e4fe-2016-01-19-06:12:18.tar.gz.asc
 
 We can pass through any command line arguments provided to ``st2-submit-debug-info``.
@@ -143,7 +143,7 @@ For example:
     2016-01-19 06:25:09,024  INFO - Collecting files...
     2016-01-19 06:25:09,617  INFO - Creating tarball...
     2016-01-19 06:25:09,725  INFO - Encrypting tarball...
-    2016-01-19 06:25:13,727  INFO - Debug tarball successfully uploaded to Brocade (name=st2-debug-output-70386ae8e4fe-2016-01-19-06:25:09.tar.gz.asc)
+    2016-01-19 06:25:13,727  INFO - Debug tarball successfully uploaded to Extreme Networks (name=st2-debug-output-70386ae8e4fe-2016-01-19-06:25:09.tar.gz.asc)
     2016-01-19 06:25:13,727  INFO - When communicating with support, please let them know the tarball name - st2-debug-output-70386ae8e4fe-2016-01-19-06:25:09.tar.gz.asc
 
 * To send specific information or to exclude particular information, use the
@@ -153,12 +153,12 @@ For example:
 
     st2-submit-debug-info --exclude-shell-commands --config <path to config file>
 
-    This will submit the following information to Brocade: logs, configs, content, system_info
+    This will submit the following information to Extreme Networks: logs, configs, content, system_info
     Are you sure you want to proceed? [y/n] y
     2016-01-19 06:28:25,533  INFO - Collecting files...
     2016-01-19 06:28:25,895  INFO - Creating tarball...
     2016-01-19 06:28:26,002  INFO - Encrypting tarball...
-    2016-01-19 06:28:29,559  INFO - Debug tarball successfully uploaded to Brocade (name=st2-debug-output-70386ae8e4fe-2016-01-19-06:28:25.tar.gz.asc)
+    2016-01-19 06:28:29,559  INFO - Debug tarball successfully uploaded to Extreme Networks (name=st2-debug-output-70386ae8e4fe-2016-01-19-06:28:25.tar.gz.asc)
     2016-01-19 06:28:29,559  INFO - When communicating with support, please let them know the tarball name - st2-debug-output-70386ae8e4fe-2016-01-19-06:28:25.tar.gz.asc
 
 * To review the debugging information without encrypting and uploading:


### PR DESCRIPTION
Begin migrating "Brocade" references to "Extreme"

This is an initial pass. There will be further work required, especially as underlying product names get changed with upcoming releases.