### PR TITLE
Corrected explanation about the functionality to parse parameters which are array of objects type.

### DIFF
--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -412,7 +412,7 @@ like this:
 
 .. sourcecode:: bash
 
-    st2 run mypack.set_interfaces \
+    st2 run --auto-dict mypack.set_interfaces \
       nic_info="target:eth0,ipaddr:192.168.0.10,netmask:255.255.255.0,mtu:1454" \
       nic_info="target:eth1,ipaddr:192.168.0.11,netmask:255.255.255.0,mtu:2000"
 
@@ -423,6 +423,14 @@ and look like this:
 
     [{'netmask': '255.255.255.0', 'ipaddr': '192.168.0.10', 'target': 'eth0', 'mtu': 1454},
      {'netmask': '255.255.255.0', 'ipaddr': '192.168.0.11', 'target': 'eth1', 'mtu': 2000}]
+
+.. note::
+
+  The st2 cli option ``--auto-dict`` is required to use this functionality. When you run action
+  without this option, each colon separated parameters are not parsed as dict object but just string.
+
+  And this option and its functionality will be deprecated in the next release in favor of a more
+  robust conversion method.
 
 To parse each value in the object as an expected type, you need to specify the type of each value
 in the action metadata, like this.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -413,8 +413,8 @@ like this:
 .. sourcecode:: bash
 
     st2 run mypack.set_interfaces \
-      nic_info="target:eth0,ipaddr:192.168.0.10,netmask:255.255.255.0,mtu=1454" \
-      nic_info="target:eth1,ipaddr:192.168.0.11,netmask:255.255.255.0,mtu=2000"
+      nic_info="target:eth0,ipaddr:192.168.0.10,netmask:255.255.255.0,mtu:1454" \
+      nic_info="target:eth1,ipaddr:192.168.0.11,netmask:255.255.255.0,mtu:2000"
 
 In this case, the ``nic_info`` value passed to the ``mypack.set_interfaces`` action would be parsed
 and look like this:


### PR DESCRIPTION
## Background
The changing of [#3909](https://github.com/StackStorm/st2/pull/3909) in the st2 has not been applied to the st2docs.

## Changing points
This patch corrects followings.

- Added a flag `--auto-dict` to parse the colon separated characters in an array typed parameter as array of objects.
- Added description that `--auto-dict` parameter will be deprecated in near future, that is referred from [the description in the usage of st2client](https://github.com/StackStorm/st2/blob/master/st2client/st2client/commands/action.py#L315-L317).
- Fixed a typo of delimiter of array of objects.