### PR TITLE
Added documentation about the required tooz interface

### DIFF
--- a/docs/source/reference/policies.rst
+++ b/docs/source/reference/policies.rst
@@ -117,6 +117,11 @@ Other supported coordination backends include:
 * PostgreSQL
 * file (for testing when all the services are running on a single host)
 
+StackStorm utilizes the ``OpenStack Tooz`` library for communicating with the
+coordination backend. The coordination backend must support the ``Locking``
+functionality as defined by the ``Tooz`` interface. Please refrence the
+`OpenStack Tooz compatability page <https://docs.openstack.org/tooz/latest/user/compatibility.html>`_
+for more information what interfaces are implemented by various backends.
 For the full list of the supported backends and how to configure them, please visit
 `OpenStack Tooz documentation <https://docs.openstack.org/tooz/latest/>`_.
 

--- a/docs/source/reference/policies.rst
+++ b/docs/source/reference/policies.rst
@@ -122,6 +122,7 @@ coordination backend. The coordination backend must support the ``Locking``
 functionality as defined by the ``Tooz`` interface. Please refrence the
 `OpenStack Tooz compatability page <https://docs.openstack.org/tooz/latest/user/compatibility.html>`_
 for more information what interfaces are implemented by various backends.
+
 For the full list of the supported backends and how to configure them, please visit
 `OpenStack Tooz documentation <https://docs.openstack.org/tooz/latest/>`_.
 


### PR DESCRIPTION
Previously the documentation did not specify which features/functionality was required to be implemented by the tooz backend. This made it hard to reason about which backend to choose.

I did some research and code grepping and found that StackStorm only utilizes the `Locking` functionality portion of the tooz interface. https://docs.openstack.org/tooz/latest/user/compatibility.html

Added this to the docs, along with a link to the compatibility matrix so that other can make an informed decision.