### PR TITLE
Add note on retry policy not being st2notifier service restart safe

### DIFF
--- a/docs/source/reference/policies.rst
+++ b/docs/source/reference/policies.rst
@@ -155,3 +155,7 @@ times out:
 
 Keep in mind that retrying an execution results in a new execution which shares all the attributes
 from the retried execution (parameters, context, etc).
+
+Maximum value of the ``delay`` parameter is ``120`` seconds. Keep in mind that right now, retry
+functionality is not ``st2notifier`` service restart safe. This means if there are any pending
+executions to be retried and ``st2notifier`` is restarted, those executions will be lost.


### PR DESCRIPTION
Corresponding documentation change for https://github.com/StackStorm/st2/pull/3637.