### PR TITLE
Replace 'it fail' with 'it will fail'

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -51,7 +51,7 @@ If you are trying to install |st2| on a server with other applications, or local
 you may run into problems. In that case, you should use one of the manual installation methods.
 
 The script itself is not idempotent. If you try to re-run the script on top of a failed
-installation, it fail. Start again with a clean system, or switch to a manual install.
+installation, it will fail. Start again with a clean system, or switch to a manual install.
 
 If you're installing behind a proxy, just export the proxy ENV variables
 ``http_proxy``, ``https_proxy``, ``no_proxy`` before running the script.


### PR DESCRIPTION
Happened to be reading this section and noticed that `will` was missing. Corrected.