### PR TITLE
Use -1 for no limit, not 0

### DIFF
--- a/docs/source/datastore.rst
+++ b/docs/source/datastore.rst
@@ -41,7 +41,7 @@ Get individual key-value pair or list all:
     # To list first 50 key-value pairs (default)
     st2 key list
     # To list all the key-value pairs in the datastore
-    st2 key list -n 0
+    st2 key list -n -1
 
     # Get value for key "os_keystone_endpoint"
     st2 key get os_keystone_endpoint
@@ -103,18 +103,18 @@ Load this file using this command:
     st2 key load mydata.yaml
 
 The load command also allows you to directly load the output of the ``st2 key list -j`` command.
-If you have more than 50 key-value pairs, use ``st2 key list -n 0 -j`` to export all keys. This
+If you have more than 50 key-value pairs, use ``st2 key list -n -1 -j`` to export all keys. This
 is useful if you want to migrate datastore items from a different cluster or if you want to
 version control the datastore items and load them from version controlled files:
 
 .. code-block:: bash
 
     # JSON
-    st2 key list -n 0 -j > mydata.json
+    st2 key list -n -1 -j > mydata.json
     st2 key load mydata.json
 
     # YAML
-    st2 key list -n 0 -y > mydata.yaml
+    st2 key list -n -1 -y > mydata.yaml
     st2 key load mydata.yaml
 
 


### PR DESCRIPTION
We changed to use `-n -1` for 'no limit', not `-n 0`.

Attempts to use `-n 0` result in this:
```shell
$ st2 key list -n 0
ERROR: 400 Client Error: Bad Request
MESSAGE: Limit, "0" specified, must be a positive number or -1 for full result set. for url: http://127.0.0.1:9101/v1/keys/?scope=system&decrypt=false&limit=0
```