### PR TITLE
Updated winexe URL, suppress Mistral warnings

### DIFF
--- a/docs/source/install/common/setup_mistral_database.rst
+++ b/docs/source/install/common/setup_mistral_database.rst
@@ -11,4 +11,4 @@ Run these commands to set up the Mistral PostgreSQL database:
   # Setup Mistral DB tables, etc.
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
   # Register mistral actions
-  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+  /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v -e openstack -e keystone

--- a/docs/source/install/config/windows_runners.rst
+++ b/docs/source/install/config/windows_runners.rst
@@ -36,7 +36,7 @@ or obtain a pre-built binary.
 
 * **Ubuntu**: Instructions and binary packages for 14.04 and 16.04 are available `here <https://doublefault0.wordpress.com/2017/02/21/winexe-1-1-ubuntu-16-04/>`_.
 
-* **RHEL/CentOS**:  Instructions for compiling RPMs are `here <https://github.com/beardedeagle/winexe-rpm>`_.
+* **RHEL/CentOS**:  `These instructions <https://github.com/beardedeagle/winexe-rpm>`_ explain how to build RPMs for RHEL/CentOS systems.
 
 Supported Windows Versions
 --------------------------

--- a/docs/source/install/config/windows_runners.rst
+++ b/docs/source/install/config/windows_runners.rst
@@ -31,11 +31,12 @@ To install on RHEL/CentOS, run:
 
     sudo yum install samba-client
 
-You will need to compile `winexe <https://sourceforge.net/p/winexe/winexe-waf/ci/master/tree/>`_
-packages for your system. This `script <https://github.com/beardedeagle/winexe-rpm>`_ can be used
-to build RPM packages. The instructions `here
-<https://sourceforge.net/p/winexe/winexe-waf/ci/master/tree/>`_ can be used to build binaries for
-Ubuntu systems.
+``winexe`` is not distributed in normal RHEL/Ubuntu package repositories. You will need to compile it yourself,
+or obtain a pre-built binary.
+
+* **Ubuntu**: Instructions and binary packages for 14.04 and 16.04 are available `here <https://doublefault0.wordpress.com/2017/02/21/winexe-1-1-ubuntu-16-04/>`_.
+
+* **RHEL/CentOS**:  Instructions for compiling RPMs are `here <https://github.com/beardedeagle/winexe-rpm>`_.
 
 Supported Windows Versions
 --------------------------

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -41,7 +41,7 @@ This is the standard upgrade procedure:
    .. sourcecode:: bash
 
      /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
-     /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v openstack
+     /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v -e openstack -e keystone
 
    .. warning::
 

--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -403,7 +403,7 @@ also be made to offer different services.
 
   .. code-block:: bash
 
-      $ /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate
+      $ /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v -e openstack -e keystone
 
 8. Replace ``/etc/st2/st2.conf`` with the sample ``st2.conf`` provided below. This config points to
    the controller node or configuration values of ``database``, ``messaging`` and ``mistral``.


### PR DESCRIPTION
Better winexe URL for Ubuntu systems, and be more consistent with suppressing spurious Mistral warnings when running `populate` commands.

Related #705 