### PR TITLE
Fix nginx to install from 'nginx.org' repo on EL, instead of 'EPEL' (v2.6)

### DIFF
--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -197,8 +197,11 @@ you will need to add the official Nginx repository:
   enabled=1
   EOT"
 
-  # Install st2web and nginx
-  sudo yum -y install st2web nginx
+  # Install nginx, avoid epel repo in favor of nginx.org
+  sudo yum --disablerepo='epel' install -y nginx
+
+  # Install st2web
+  sudo yum install -y st2web
 
   # Generate a self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -173,8 +173,11 @@ you will need to add the official Nginx repository:
   enabled=1
   EOT"
 
-  # Install st2web and nginx
-  sudo yum install -y st2web nginx
+  # Install nginx, avoid epel repo in favor of nginx.org
+  sudo yum --disablerepo='epel' install -y nginx
+
+  # Install st2web
+  sudo yum install -y st2web
 
   # Generate a self-signed certificate or place your existing certificate under /etc/ssl/st2
   sudo mkdir -p /etc/ssl/st2


### PR DESCRIPTION
See original issue https://github.com/StackStorm/st2docs/pull/709

(cherry picked from commit 826fb22)