### PR TITLE
Add a note on checking out submodules for development

### DIFF
--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -57,6 +57,9 @@ tests:
 
     git clone https://github.com/StackStorm/st2.git
     cd st2
+    # Note: Some of the tests rely on the submodules so you need to check them
+    # out to make sure all the tests will pass locally
+    git submodule update --init --recursive
     make requirements
 
 Configure System User


### PR DESCRIPTION
Some of the new tests now (sadly, couldn't come up with a better way) rely on submodule so for all the tests to pass on the development environment (all the CI services already check out submodules by default) user needs to checkout out the submodules.