### PR TITLE
Explicitly state MongoDB 3.6 not supported

### DIFF
--- a/docs/source/install/__mongodb_note.rst
+++ b/docs/source/install/__mongodb_note.rst
@@ -1,5 +1,5 @@
 .. note::
 
-  The currently preferred and supported version of MongoDB is 3.4. This is the version
-  installed by the installer script. MongoDB 3.4 is supported in StackStorm v2.2.0 and above.
-  Older versions of StackStorm (prior to v1.6.0) only supported MongoDB 2.x.
+  The currently supported version of MongoDB is 3.4. This is the version installed by
+  the installer script. MongoDB 3.6 does not currently work with StackStorm. Support
+  for 3.6 will be added in a future version of StackStorm


### PR DESCRIPTION
Be very clear that v3.4 is the only supported version right now, and that v3.6 does not work.