### PR TITLE
Updated docs for retrieving objects from the datastore

### DIFF
--- a/docs/source/reference/jinja.rst
+++ b/docs/source/reference/jinja.rst
@@ -26,8 +26,16 @@ retrieving the data.
     # Pass the result of this expression to the action st2.kv.set
     {{ {'complex': 'structure', 'foo': ['x', True]} | to_json_string }}
 
+    # Or set it on the CLI
+    st2 key set foo '{"complex": "structure", "foo": ["x", True]}'
+
     # Read the data back in using the st2kv and from_json_string filters
     {{ st2kv.system.foo | from_json_string }}
+
+When accessing ``numbers``, ``integers``, ``objects`` and ``arrays`` in an action
+definition file, utilizing the ``from_json_string`` filter is NOT necessary. For
+more information on accessing key-value pairs from Actions see:
+:ref:`Referencing Key-Value Pairs in Action Definitions<referencing-key-value-pairs-in-action-definitions>`
 
 .. _jinja-jinja-filters:
 

--- a/docs/source/reference/jinja.rst
+++ b/docs/source/reference/jinja.rst
@@ -32,10 +32,13 @@ retrieving the data.
     # Read the data back in using the st2kv and from_json_string filters
     {{ st2kv.system.foo | from_json_string }}
 
-When accessing ``numbers``, ``integers``, ``objects`` and ``arrays`` in an action
-definition file, utilizing the ``from_json_string`` filter is NOT necessary. For
+When accessing ``numbers``, ``integers``, ``objects`` and ``arrays`` in an Action
+Definition file, utilizing the ``from_json_string`` filter is NOT necessary. For
 more information on accessing key-value pairs from Actions see:
 :ref:`Referencing Key-Value Pairs in Action Definitions<referencing-key-value-pairs-in-action-definitions>`
+
+Accessing ``numbers``, ``integers``, ``objects`` and ``arrays`` in other places,
+such as Mistral workflows, utilizing ``from_json_string`` is still necessary.
 
 .. _jinja-jinja-filters:
 


### PR DESCRIPTION
I got confused in https://github.com/StackStorm/st2/issues/4153 . Thanks to @Kami i got set straight by not using the ``from_json_string`` filter in my action definitions.

This update hopefully clarifies how to access `objects` and `arrays` in Action Definitions.