### PR TITLE
Removed extra slash in URLs

### DIFF
--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -38,7 +38,7 @@ Similarly to ActionChains, Mistral workflows have an action metadata file in
 
 Let's start with a very basic workflow that calls a |st2| action and notifies |st2| when the
 workflow is done. The files used in this example are also located under
-:github_st2:`/usr/share/doc/st2/examples </contrib/examples>` if |st2| is already installed (see
+:github_st2:`/usr/share/doc/st2/examples <contrib/examples>` if |st2| is already installed (see
 also :ref:`deploy examples <start-deploy-examples>`).
 
 The first task is named ``run-cmd``. It executes a shell command on the server where |st2| is
@@ -291,7 +291,7 @@ files:
 More Examples
 -------------
 
-There are more workflow examples under :github_st2:`/usr/share/doc/st2/examples </contrib/examples/actions/workflows/>`. These include error handling, repeat, and retries.
+There are more workflow examples under :github_st2:`/usr/share/doc/st2/examples <contrib/examples/actions/workflows/>`. These include error handling, repeat, and retries.
 
 Check out this step-by-step tutorial on building a workflow in |st2| https://stackstorm.com/2015/07/08/automating-with-mistral-workflow/
 

--- a/docs/source/mistral_jinja.rst
+++ b/docs/source/mistral_jinja.rst
@@ -252,5 +252,5 @@ More Examples
 -------------
 
 More workflow examples using Jinja expressions can be found at
-:github_st2:`/usr/share/doc/st2/examples </contrib/examples/actions/workflows/>`. The examples are
+:github_st2:`/usr/share/doc/st2/examples <contrib/examples/actions/workflows/>`. The examples are
 prefixed with ``mistral-jinja``.

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -152,7 +152,7 @@ This section describes all the available operators which can be used in the crit
 .. note::
 
     **For Developers:** The criteria comparison functions are defined in
-    :github_st2:`st2/st2common/st2common/operators.py </st2common/st2common/operators.py>`.
+    :github_st2:`st2/st2common/st2common/operators.py <st2common/st2common/operators.py>`.
 
 ================= =================================================================
  Operator          Description


### PR DESCRIPTION
Some URLs constructed using `github_st2` shortcut had an extra, unnecessary `/` inserted.