### PR TITLE
Typo in webhooks

### DIFF
--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -136,7 +136,7 @@ The body of this request needs to be JSON and must contain the following attribu
 * ``payload`` - Object with a trigger payload.
 
 This example shows how to send data to the generic webhook using ``curl``, and how to match this
-data using rule criteria (replace ``localhost`` with your st2 host if called remotely):
+data using rule criteria (replace ``localhost`` with your |st2| host if called remotely):
 
 .. sourcecode:: bash
 

--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -126,7 +126,7 @@ Using a Generic Webhook
 -----------------------
 
 By default, a special-purpose webhook with the name ``st2`` is already registered. Instead of
-using ``st2.core.webhook``, it allows you to specify any trigger that is known to |st2| (either by
+using ``core.st2.webhook``, it allows you to specify any trigger that is known to |st2| (either by
 default or from custom sensors and triggers in packs), so you can use it to trigger rules that
 aren’t explicitly set up to be triggered by webhooks.
 


### PR DESCRIPTION
## Chaning points and reasons

* [L-129](https://github.com/StackStorm/st2docs/pull/757/files#diff-b34504abb6d8d4e238e93b40a67ed5b1L129) - ``st2.core.webhook`` doens't exist in the default triggers.
* [L-139](https://github.com/StackStorm/st2docs/pull/757/files#diff-b34504abb6d8d4e238e93b40a67ed5b1R139) - Except for the case that `st2` has meaning for itself, this document uses `|st2|` macro to replace product name.
