### PR TITLE
And more info about the timezone format for core.st2.CronTimer trigger

### DIFF
--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -762,6 +762,7 @@ fire on every value.
 
 Available parameter ``timezone``, ``year``, ``month``, ``day``, ``week``, ``day_of_week``,
 ``hour``, ``minute``, ``second``.
+Note ``timezone`` use the pytz format, e.g. ``Asia/Shanghai``.
 
 Run action every Sunday at midnight
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add more info for the timezone parameter of core.st2.CronTimer trigger,
the timezones use the pytz format, e.g. `Asia/Shanghai`.