### PR TITLE
Add upgrade notes section for v2.8 release

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -79,14 +79,21 @@ The following sections call out the migration scripts that need to be run when u
 respective version. If you are upgrading across multiple versions, make sure you run the scripts for
 any skipped versions:
 
+v2.8
+''''
+
+* This version introduced new ``st2workflowengine`` service which needs to be configured in
+  ``/etc/st2/st2.conf`` config file for it to work. For more information, please refer to Upgrade
+  Notes - :ref:`ref-upgrade-nptes-v2-8`.
+
 v2.5
-'''''
+''''
 
 * If you have the `DC Fabric Automation Suite <https://ewc-docs.extremenetworks.com/solutions/dcfabric/overview.html>`_
   version 1.1 installed, you must upgrade this to >= v1.1.1. Follow `these instructions <https://ewc-docs.extremenetworks.com/solutions/dcfabric/install.html#upgrade-from-previous-version>`_.
 
 v2.4
-'''''
+''''
 
 * Node.js v6 is now used by ChatOps (previously v4 was used). The following procedure should be
   used to upgrade:
@@ -117,7 +124,7 @@ This is a known issue, and will be resolved in a future release. This only appli
 It is not required for those using Open Source StackStorm.
 
 v2.2
-'''''
+''''
 
 * The database schema for Mistral has changed. The executions_v2 table is no longer used. The
   table is being broken down into workflow_executions_v2, task_executions_v2, and
@@ -159,7 +166,7 @@ v2.2
      sudo service mistral-api start
 
 v2.1
-'''''
+''''
 
 * Datastore model migration - Scope names are now ``st2kv.system`` and ``st2kv.user`` as
   opposed to ``system`` and ``user``.
@@ -180,7 +187,7 @@ v2.1
   and workflows have changed.
 
 v1.5
-'''''
+''''
 
 * Datastore model migration
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,6 +3,35 @@
 Upgrade Notes
 =============
 
+|st2| v2.8
+----------
+
+* This version introduces new ``Orchestra`` runner and Orchestra workflows. For this functionality
+  to work, new ``st2workflowengine`` service needs to be installed and running.
+
+  If you are installing StackStorm on a new server using the official installation script this
+  service is automatically installed and started.
+
+  If you are  upgrading from a previous release using instructions from the "Upgrades"
+  documentation page, you need to ensure ``/etc/st2/st2.conf`` file contains a new
+  ``workflow_engine`` section with the corresponding ``logging`` config option otherwise the
+  service won't start.
+
+  After you have completed all the steps from the "Upgrades" page, you need to add the following
+  entry to ``/etc/st2/st2.conf`` config file:
+
+  .. code-block:: ini
+
+    [workflow_engine]
+    logging = /etc/st2/logging.workflowengine.conf
+
+  After you have saved the configuration file you need to start the ``st2workflowengine`` service
+  (all other services should already be running).
+
+  .. code-block:: ini
+
+    sudo st2ctl start
+
 |st2| v2.7
 ----------
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -6,7 +6,7 @@ Upgrade Notes
 |st2| v2.8
 ----------
 
-* This version introduces new ``Orchestra`` runner and Orchestra workflows. For this functionality
+* This version introduces new Orchestra runner and Orchestra workflows. For this functionality
   to work, new ``st2workflowengine`` service needs to be installed and running.
 
   If you are installing StackStorm on a new server using the official installation script this
@@ -31,6 +31,10 @@ Upgrade Notes
   .. code-block:: ini
 
     sudo st2ctl start
+
+  You can verify that the new ``st2workflowengine`` service has indeed been started by running
+  ``sudo st2ctl`` status and inspecting the service log file at
+  ``/var/log/st2/st2workflowengine.log``.
 
 |st2| v2.7
 ----------

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -12,13 +12,13 @@ Upgrade Notes
   If you are installing StackStorm on a new server using the official installation script this
   service is automatically installed and started.
 
-  If you are  upgrading from a previous release using instructions from the "Upgrades"
+  If you are  upgrading from a previous release using instructions from the :doc:`/install/upgrades`
   documentation page, you need to ensure ``/etc/st2/st2.conf`` file contains a new
-  ``workflow_engine`` section with the corresponding ``logging`` config option otherwise the
+  ``workflow_engine`` section with the corresponding ``logging`` config option, otherwise the
   service won't start.
 
-  After you have completed all the steps from the "Upgrades" page, you need to add the following
-  entry to ``/etc/st2/st2.conf`` config file:
+  After you have completed all the steps from the "General Upgrade Procedure" page, you need to add
+  the following entry to ``/etc/st2/st2.conf`` config file:
 
   .. code-block:: ini
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -33,7 +33,7 @@ Upgrade Notes
     sudo st2ctl start
 
   You can verify that the new ``st2workflowengine`` service has indeed been started by running
-  ``sudo st2ctl`` status and inspecting the service log file at
+  ``sudo st2ctl status`` and by inspecting the service log file at
   ``/var/log/st2/st2workflowengine.log``.
 
 |st2| v2.7

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,6 +3,8 @@
 Upgrade Notes
 =============
 
+.. _ref-upgrade-nptes-v2-8:
+
 |st2| v2.8
 ----------
 


### PR DESCRIPTION
New ``st2workflowengine`` service doesn't start automatically on upgrade due to ``st2.conf`` config file missing ``workflow_engine.logging`` section.

Keep in mind that this section doesn't get automatically added on upgrade if user chooses to keep the existing ``st2.conf`` file and doesn't manually resolve the conflicts between the existing and new config file (that's actually desired, because if a user would select to pick a new st2.conf file, it would wipe out the existing settings and credentials and manual merge / diff is also error prone).