### PR TITLE
Clarify REMOTE_USER and REMOTE_ADDR need to come in as a CGI environment variable

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -70,15 +70,18 @@ Proxy Auth Mode
 
 Proxy mode can be used when there is a service that sits in front of StackStorm
 that performs user authentication (ex: load balancer, apache, nginx, etc). When
-the frontend service authenticates a user it will need to make an API call
+the frontend service authenticates a user, it will need to make an API call
 ``POST https://<stackstorm>/auth/v1/tokens`` to the ``st2auth`` service in order
-to obtain an auth token. In this request the following headers need to be added:
+to obtain an auth token. In this request the following CGI environment variables
+need to be set:
 
 * ``remote_addr`` Source of the request (hostname/ip).
-* ``remote_user`` User identity of proxy authenticated user.
+* ``remote_user`` User identity (username) of proxy authenticated user.
+
+When using a reverse proxy such as Apache, this is usually done automatically by
+a proxy upon successful authentication.
 
 The request will return an auth token that can be used to make further API calls.
-
 
 .. _ref-auth-backends:
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -68,20 +68,21 @@ to make further API calls.
 Proxy Auth Mode
 ---------------
 
-Proxy mode can be used when there is a service that sits in front of StackStorm
+Proxy mode can be used when there is a service (proxy) that sits in front of StackStorm
 that performs user authentication (ex: load balancer, apache, nginx, etc). When
 the frontend service authenticates a user, it will need to make an API call
 ``POST https://<stackstorm>/auth/v1/tokens`` to the ``st2auth`` service in order
 to obtain an auth token. In this request the following CGI environment variables
 need to be set:
 
-* ``remote_addr`` Source of the request (hostname/ip).
-* ``remote_user`` User identity (username) of proxy authenticated user.
+* ``REMOTE_ADDR`` - Source of the request (hostname/ip of the user who authenticated against the
+  proxy).
+* ``REMOTE_USER`` - User identity (username) of proxy authenticated user.
 
-When using a reverse proxy such as Apache, this is usually done automatically by
-a proxy upon successful authentication.
+The request will return an auth token that authenticated user can use to make further API calls.
 
-The request will return an auth token that can be used to make further API calls.
+When using a reverse proxy such as Apache in front of st2auth, those two CGI environment variables
+are usually set automatically by a proxy upon successful authentication.
 
 .. _ref-auth-backends:
 


### PR DESCRIPTION
Some clarification on proxy st2auth authentication mode.

Current documentation was wrong since it said those values need to come in as headers, but they really need to come in as CGI environment variables (that's the standard way when authentication is handled by a proxy infront of the service).

Related https://github.com/StackStorm/st2/pull/4224#issuecomment-402132318.