### PR TITLE
Added puppet-st2 documentation

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -26,6 +26,8 @@ Here's an overview of the options:
   internal mirror for the |st2| repos. 
 * **Ansible Playbooks:** If you are an Ansible user, check these :doc:`/install/ansible` for
   installing |st2|. Ideal for repeatable, consistent, idempotent installation of |st2|.
+* **Puppet Module:** For Puppet users, check these :doc:`/install/puppet` for
+  installing |st2|. A robust and idempotent method of installing and configuring |st2|.
 * **Docker:** |st2| is now supported on Docker - check out our :doc:`docker` instructions.
 
 Choose the option that best suits your needs.
@@ -89,6 +91,7 @@ For more details on reference deployments, or OS-specific installation instructi
     RHEL 6 / CentOS 6 <rhel6>
     Docker <docker>
     Ansible Playbooks <ansible>
+    Puppet Module <puppet>
     Extreme Workflow Composer <bwc>
     config/index
     upgrades

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -26,7 +26,7 @@ Here's an overview of the options:
   internal mirror for the |st2| repos. 
 * **Ansible Playbooks:** If you are an Ansible user, check these :doc:`/install/ansible` for
   installing |st2|. Ideal for repeatable, consistent, idempotent installation of |st2|.
-* **Puppet Module:** For Puppet users, check these :doc:`/install/puppet` for
+* **Puppet Module:** For Puppet users, check this :doc:`/install/puppet` for
   installing |st2|. A robust and idempotent method of installing and configuring |st2|.
 * **Docker:** |st2| is now supported on Docker - check out our :doc:`docker` instructions.
 

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -1,11 +1,14 @@
 Puppet Module
 =============
 
-If you're ready to take complete control of your |st2| instances, then the ``stackstorm-st2``
-is for you! It offers repeatable, configurable, and idempotent production-friendly
-|st2| installations.
+If you're ready to take complete control of your |st2| instances, then ``stackstorm-st2``
+Puppet module is for you! It offers repeatable, configurable, and idempotent
+production-friendly |st2| installations.
 
-The source code for all the Puppet module is available as a GitHub repo:
+The ``stackstorm-st2`` Puppet Module is available on Puppet Forge:
+`stackstorm-st2 <https://forge.puppet.com/stackstorm/st2>`_
+
+Source code for the module is available as a GitHub repo:
 `StackStorm/puppet-st2 <https://github.com/stackstorm/puppet-st2/>`_
 
 .. contents:: Contents

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -29,7 +29,7 @@ Quick Start
 -----------
 
 The first step is installing Puppet, for this please consule the
-`Puppet Installation documentation <https://puppet.com/docs/puppet/latest/install_linux.html>`
+`Puppet Installation documentation <https://puppet.com/docs/puppet/latest/install_linux.html>`_
 
 To get started with a single node deployment, and default configuration settings, run these
 commands (expected to run as `root`):
@@ -146,11 +146,11 @@ authentication see the :doc:`authentication documentation </authentication>` pag
 
 The following backends are currently available:
 
-- ``flat_file`` - Authenticates against an htpasswd file (default) `link <https://github.com/StackStorm/st2-auth-backend-flat-file>`
-- ``keystone`` - Authenticates against an OpenStack Keystone service `link <https://github.com/StackStorm/st2-auth-backend-keystone>`
-- ``ldap`` - Authenticates against an LDAP server such as OpenLDAP or Active Directory `link <https://github.com/StackStorm/st2-auth-backend-ldap>`
-- ``mongodb`` - Authenticates against a collection named users in MongoDB `link <https://github.com/StackStorm/st2-auth-backend-mongodb>`
-- ``pam`` - Authenticates against the PAM Linux service `link <https://github.com/StackStorm/st2-auth-backend-pam>`
+- ``flat_file`` - Authenticates against an htpasswd file (default) `link <https://github.com/StackStorm/st2-auth-backend-flat-file>`_
+- ``keystone`` - Authenticates against an OpenStack Keystone service `link <https://github.com/StackStorm/st2-auth-backend-keystone>`_
+- ``ldap`` - Authenticates against an LDAP server such as OpenLDAP or Active Directory `link <https://github.com/StackStorm/st2-auth-backend-ldap>`_
+- ``mongodb`` - Authenticates against a collection named users in MongoDB `link <https://github.com/StackStorm/st2-auth-backend-mongodb>`_
+- ``pam`` - Authenticates against the PAM Linux service `link <https://github.com/StackStorm/st2-auth-backend-pam>`_
   
 By default the ``flat_file`` backend is used. To change this you can configure
 it when instantiating the ``::st2`` class in a manifest file:

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -37,7 +37,7 @@ The first step is installing Puppet, for this please consult the
 
 To get started with a single node deployment, and default configuration settings,
 we're going to install the ``stackstorm-st2`` module and its dependencies, then
-tell Puppet to perform a full install of StackStorm: In order to accmplish this
+tell Puppet to perform a full install of StackStorm. In order to accomplish this,
 run the following commands (expected to run as `root`):
 
 .. code-block:: bash

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -1,11 +1,11 @@
 Puppet Module
 =============
 
-If you're ready to take complete control of your |st2| instances, then ``stackstorm-st2``
+If you're ready to take complete control of your |st2| instances, then the ``stackstorm-st2``
 Puppet module is for you! It offers repeatable, configurable, and idempotent
 production-friendly |st2| installations.
 
-The ``stackstorm-st2`` Puppet Module is available on Puppet Forge:
+The ``stackstorm-st2`` Puppet module is available on Puppet Forge:
 `stackstorm-st2 <https://forge.puppet.com/stackstorm/st2>`_
 
 Source code for the module is available as a GitHub repo:

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -1,0 +1,310 @@
+Puppet Module
+=============
+
+If you're ready to take complete control of your |st2| instances, then ``puppet-st2`` 
+is for you! It offers repeatable, configurable, and idempotent production-friendly
+|st2| installations.
+
+The source code for all the Puppet module is available as a GitHub repo: 
+`StackStorm/puppet-st2 <https://github.com/stackstorm/puppet-st2/>`_
+
+.. contents:: Contents
+   :local:
+
+---------------------------
+
+Supported Platforms
+-------------------
+
+The Puppet module supports the same platforms as manual installation, i.e.:
+
+* Ubuntu Trusty (14.04)
+* Ubuntu Xenial (16.04)
+* RHEL 6/CentOS 6
+* RHEL 7/CentOS 7
+
+The same system size :doc:`requirements </install/system_requirements>` also apply.
+
+Quick Start
+-----------
+
+The first step is installing Puppet, for this please consule the
+`Puppet Installation documentation <https://puppet.com/docs/puppet/latest/install_linux.html>`
+
+To get started with a single node deployment, and default configuration settings, run these
+commands (expected to run as `root`):
+
+.. code-block:: bash
+
+  mkdir modules/
+  git clone https://github.com/StackStorm/puppet-st2 modules/st2
+  
+  # run librarian-puppet to download all of our module dependencies defined in
+  # ./modules/st2/build/<os_name>/Puppetfile
+  # valid <os_name> values are (NOTE: Puppet 3.x installs are deprecated):
+  #  centos6   # Puppet 3.x on RHEL/CentOS 6
+  #  centos7   # Puppet 3.x on RHEL/CentOS 7
+  #  ubuntu14  # Puppet 3.x on Ubuntu 14
+  #  ubuntu16  # Puppet 3.x on Ubuntu 16
+  #  puppet4   # Puppet 4 on any OS
+  #  puppet5   # Puppet 5 on any OS
+  /opt/puppetlabs/puppet/bin/gem install librarian-puppet
+  cp modules/st2/build/<os_name>/Puppetfile .
+  /opt/puppetlabs/puppet/bin/librarian-puppet install --path=./modules
+
+  # run StackStorm full install using puppet
+  /opt/puppetlabs/bin/puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+
+.. note::
+
+    Please keep in mind that the default StackStorm login credentials according to https://github.com/StackStorm/puppet-st2/blob/master/manifests/params.pp are: ``st2admin:Ch@ngeMe``. Don't forget to change them to a more secure settings.
+
+
+Classes
+-------
+
+``::st2::profile::fullinstall`` is the quick and easy way to get StackStorm up
+and running. The ``puppet-st2`` module provides numerous additional classes
+in order to configure StackStorm just the way you like it. Below is a list of
+classes available for configuration:
+
+
+- ``::st2`` - The main configuration point for the |st2| installation.
+- ``::st2::profile::client`` - Profile to install all client libraries for |st2|
+- ``::st2::profile::fullinstall`` - Full installation of StackStorm and dependencies
+- ``::st2::profile::mistral`` - Install of OpenStack Mistral
+- ``::st2::profile::mongodb`` - |st2| configured MongoDB installation
+- ``::st2::profile::nodejs`` - |st2| configured NodeJS installation
+- ``::st2::profile::python`` - Python installed and configured for |st2|
+- ``::st2::profile::rabbitmq`` - |st2| configured RabbitMQ installation
+- ``::st2::proflle::server`` - |st2| server components
+- ``::st2::profile::web`` - |st2| WebUI components
+- ``::st2::profile::chatops`` - |st2| chatops components
+
+
+Resource Types
+--------------
+
+Along with the configuration classes, there are a number of defined resources
+provided that allow installation and configuration of StackStorm's components.
+
+- ``::st2::auth_user`` - Configures a user (and password) in ``flat_file`` auth
+- ``::st2::kv`` - Defines a key/value pair in the |st2| datastore
+- ``::st2::pack`` - Installs and configures a |st2| pack
+- ``::st2::user`` - Configures a system-level (linux) user and SSH keys
+  
+Installing and Configuring Packs
+--------------------------------
+
+StackStorm packs can be installed and configured directly from Puppet. This can
+be done via the ``::st2::pack`` and ``st2::pack::config`` defined types.
+
+Installation/Configuration via Manifest:
+
+.. code-block:: puppet
+                
+  # install pack from the exchange
+  st2::pack { 'linux': }
+  
+  # install pack from a git URL
+  st2::pack { 'private':
+    repo_url => 'https://private.domain.tld/git/stackstorm-private.git',
+  }
+  
+  # install pack and apply configuration
+  st2::pack { 'slack':
+    config   => {
+      'post_message_action' => {
+        'webhook_url' => 'XXX',
+      },
+    },
+  }
+  
+Installation/Configuration via Hiera:
+
+.. code-block:: yaml
+                
+  st2::packs:
+    linux:
+      ensure: present
+    private:
+      ensure: present
+      repo_url: https://private.domain.tld/git/stackstorm-private.git
+    slack:
+      ensure: present
+      config:
+        post_message_action:
+          webhook_url: XXX
+
+Configuring Authentication
+--------------------------
+
+StackStorm uses a pluggable authentication system where auth is delegated to an
+external service called a "backend". The ``st2auth`` service can be configured
+to use various backends (only one active). For more information on StackStorm
+authentication see the :doc:`authentication documentation </authentication>` page.
+
+The following backends are currently available:
+
+- ``flat_file`` - Authenticates against an htpasswd file (default) `link <https://github.com/StackStorm/st2-auth-backend-flat-file>`
+- ``keystone`` - Authenticates against an OpenStack Keystone service `link <https://github.com/StackStorm/st2-auth-backend-keystone>`
+- ``ldap`` - Authenticates against an LDAP server such as OpenLDAP or Active Directory `link <https://github.com/StackStorm/st2-auth-backend-ldap>`
+- ``mongodb`` - Authenticates against a collection named users in MongoDB `link <https://github.com/StackStorm/st2-auth-backend-mongodb>`
+- ``pam`` - Authenticates against the PAM Linux service `link <https://github.com/StackStorm/st2-auth-backend-pam>`
+  
+By default the ``flat_file`` backend is used. To change this you can configure
+it when instantiating the ``::st2`` class in a manifest file:
+
+Configuration via Manifest:
+
+.. code-block:: puppet
+                
+  class { '::st2':
+    auth_backend => 'ldap',
+  }
+  
+
+Configuration via Hiera:
+
+.. code-block:: yaml
+                
+  st2::auth_backend: ldap
+
+Each backend has their own custom configuration settings. The settings can be
+found by looking at the backend class in the manifests/st2/auth/ directory.
+These parameters map 1-for-1 to the configuration options defined in each backends
+GitHub page (links above). Backend configurations are passed in as a hash using
+the ``auth_backend_config`` option. This option can be changed when instantiating
+the ``::st2`` class in a manifest file:
+
+Configuration via Manifest:
+
+.. code-block:: puppet
+                
+  class { '::st2':
+    auth_backend        => 'ldap',
+    auth_backend_config => {
+      ldap_uri      => 'ldaps://ldap.domain.tld',
+      bind_dn       => 'cn=ldap_stackstorm,ou=service accounts,dc=domain,dc=tld',
+      bind_pw       => 'some_password',
+      ref_hop_limit => 100,
+      user          => {
+        base_dn       => 'ou=domain_users,dc=domain,dc=tld',
+        search_filter => '(&(objectClass=user)(sAMAccountName={username})(memberOf=cn=stackstorm_users,ou=groups,dc=domain,dc=tld))',
+        scope         => 'subtree'
+      },
+    },
+  }
+  
+Configuration via Hiera:
+
+.. code-block:: yaml
+                
+  st2::auth_backend: ldap
+  st2::auth_backend_config:
+    ldap_uri: "ldaps://ldap.domain.tld"
+    bind_dn: "cn=ldap_stackstorm,ou=service accounts,dc=domain,dc=tld"
+    bind_pw: "some_password"
+    ref_hop_limit: 100
+    user:
+      base_dn: "ou=domain_users,dc=domain,dc=tld"
+      search_filter: "(&(objectClass=user)(sAMAccountName={username})(memberOf=cn=stackstorm_users,ou=groups,dc=domain,dc=tld))"
+      scope: "subtree"
+
+      
+Configuring ChatOps
+-------------------
+
+``puppet-st2`` can be used to managed the ChatOps configuration of your StackStorm
+installation. We provide support for configuring all Hubot settings, installing
+custom ChatOps adapters, and finally configuring any and all adapter settings.
+
+Configuration via Manifest:
+
+.. code-block:: puppet
+                
+  class { '::st2':
+    chatops_hubot_alias  => "'!'",
+    chatops_hubot_name   => '"@RosieRobot"',
+    chatops_api_key      => '"xxxxyyyyy123abc"',
+    chatops_web_url      => '"stackstorm.domain.tld"',
+    chatops_adapter      => {
+      hubot-adapter => {
+        package => 'hubot-rocketchat',
+        source  => 'git+ssh://git@git.company.com:npm/hubot-rocketchat#master',
+      },
+    },
+    chatops_adapter_conf => {
+      HUBOT_ADAPTER        => 'rocketchat',
+      ROCKETCHAT_URL       => 'https://chat.company.com:443',
+      ROCKETCHAT_ROOM      => 'stackstorm',
+      LISTEN_ON_ALL_PUBLIC => true,
+      ROCKETCHAT_USER      => 'st2',
+      ROCKETCHAT_PASSWORD  => 'secret123',
+      ROCKETCHAT_AUTH      => 'password',
+      RESPOND_TO_DM        => true,
+    },
+  }
+
+Configuration via Hiera:
+
+.. code-block:: yaml
+                
+  # character to trigger the bot that the message is a command
+  # example: !help
+  st2::chatops_hubot_alias: "'!'"
+  
+  # name of the bot in chat, sometimes requires special characters like @
+  st2::chatops_hubot_name: '"@RosieRobot"'
+  
+  # API key generated by: st2 apikey create
+  st2::chatops_api_key: '"xxxxyyyyy123abc"'
+ 
+  # Public URL used by ChatOps to offer links to execution details via the WebUI.
+  st2::chatops_web_url: '"stackstorm.domain.tld"'
+  
+  # install and configure hubot adapter (rocketchat, nodejs module installed by ::nodejs)
+  st2::chatops_adapter:
+    hubot-adapter:
+      package: 'hubot-rocketchat'
+      source: 'git+ssh://git@git.company.com:npm/hubot-rocketchat#master'
+
+  # adapter configuration (hash)
+  st2::chatops_adapter_conf:
+    HUBOT_ADAPTER: rocketchat
+    ROCKETCHAT_URL: "https://chat.company.com:443"
+    ROCKETCHAT_ROOM: 'stackstorm'
+    LISTEN_ON_ALL_PUBLIC: true
+    ROCKETCHAT_USER: st2
+    ROCKETCHAT_PASSWORD: secret123
+    ROCKETCHAT_AUTH: password
+    RESPOND_TO_DM: true
+
+
+Configuring Key/Value pairs
+---------------------------
+
+The puppet type ``::st2::kv`` can be used to manage key/value pairs in the
+StackStorm :doc:`datastore </datastore>`:
+
+Configuring via Manifests:
+
+.. code-block:: puppet
+                
+  st2::kv { 'my_key_name':
+    value => 'SomeValue',
+  }
+
+  st2::kv { 'another_key':
+    value => 'moreData',
+  }
+
+Configuration via Hiera:
+
+.. code-block:: yaml
+                
+  st2::kvs:
+    my_key_name:
+      value: SomeValue
+    another_key:
+      value: moreData

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -40,8 +40,8 @@ The first step is installing Puppet, for this please consult the
 
 To get started with a single node deployment, and default configuration settings,
 we're going to install the ``stackstorm-st2`` module and its dependencies, then
-tell Puppet to perform a full install of StackStorm. In order to accomplish this,
-run the following commands (expected to run as `root`):
+tell Puppet to perform a full install of |st2|. In order to accomplish this,
+run the following commands as ``root``:
 
 .. code-block:: bash
 
@@ -50,21 +50,21 @@ run the following commands (expected to run as `root`):
 
 .. note::
 
-    Please keep in mind that the default StackStorm login credentials according to https://github.com/StackStorm/puppet-st2/blob/master/manifests/params.pp are: ``st2admin:Ch@ngeMe``. Don't forget to change them to a more secure settings.
+    The default |st2| login credentials according to https://github.com/StackStorm/puppet-st2/blob/master/manifests/params.pp are: ``st2admin:Ch@ngeMe``. Don't forget to change them.
 
 
 Classes
 -------
 
-``::st2::profile::fullinstall`` is the quick and easy way to get StackStorm up
+``::st2::profile::fullinstall`` is the quick and easy way to get |st2| up
 and running. The ``stackstorm-st2`` module provides numerous additional classes
-in order to configure StackStorm just the way you like it. Below is a list of
+in order to configure |st2| just the way you like it. Below is a list of
 classes available for configuration:
 
 
 - ``::st2`` - The main configuration point for the |st2| installation.
 - ``::st2::profile::client`` - Profile to install all client libraries for |st2|
-- ``::st2::profile::fullinstall`` - Full installation of StackStorm and dependencies
+- ``::st2::profile::fullinstall`` - Full installation of |st2| and dependencies
 - ``::st2::profile::mistral`` - Install of OpenStack Mistral
 - ``::st2::profile::mongodb`` - |st2| configured MongoDB installation
 - ``::st2::profile::nodejs`` - |st2| configured NodeJS installation
@@ -79,7 +79,7 @@ Resource Types
 --------------
 
 Along with the configuration classes, there are a number of defined resources
-provided that allow installation and configuration of StackStorm's components.
+provided that allow installation and configuration of |st2|'s components.
 
 - ``::st2::auth_user`` - Configures a user (and password) in ``flat_file`` auth
 - ``::st2::kv`` - Defines a key/value pair in the |st2| datastore
@@ -89,7 +89,7 @@ provided that allow installation and configuration of StackStorm's components.
 Installing and Configuring Packs
 --------------------------------
 
-StackStorm packs can be installed and configured directly from Puppet. This can
+|st2| packs can be installed and configured directly from Puppet. This can
 be done via the ``::st2::pack`` and ``st2::pack::config`` defined types.
 
 Installation/Configuration via Manifest:
@@ -132,10 +132,10 @@ Installation/Configuration via Hiera:
 Configuring Authentication
 --------------------------
 
-StackStorm uses a pluggable authentication system where auth is delegated to an
+|st2| uses a pluggable authentication system where authentication is delegated to an
 external service called a "backend". The ``st2auth`` service can be configured
-to use various backends (only one active). For more information on StackStorm
-authentication see the :doc:`authentication documentation </authentication>` page.
+to use various backends. Note only one is active at any one time. For more information on |st2|
+authentication see the :doc:`authentication documentation </authentication>`.
 
 The following backends are currently available:
 
@@ -164,8 +164,8 @@ Configuration via Hiera:
   st2::auth_backend: ldap
 
 Each backend has their own custom configuration settings. The settings can be
-found by looking at the backend class in the manifests/st2/auth/ directory.
-These parameters map 1-for-1 to the configuration options defined in each backends
+found by looking at the backend class in the ``manifests/st2/auth/`` directory.
+These parameters map 1-for-1 to the configuration options defined in each backend's
 GitHub page (links above). Backend configurations are passed in as a hash using
 the ``auth_backend_config`` option. This option can be changed when instantiating
 the ``::st2`` class in a manifest file:
@@ -208,9 +208,9 @@ Configuration via Hiera:
 Configuring ChatOps
 -------------------
 
-``stackstorm-st2`` can be used to managed the ChatOps configuration of your StackStorm
+``stackstorm-st2`` can manage the ChatOps configuration of your |st2|
 installation. We provide support for configuring all Hubot settings, installing
-custom ChatOps adapters, and finally configuring any and all adapter settings.
+custom ChatOps adapters, and configuring all adapter settings.
 
 Configuration via Manifest:
 
@@ -277,8 +277,8 @@ Configuration via Hiera:
 Configuring Key/Value pairs
 ---------------------------
 
-The puppet type ``::st2::kv`` can be used to manage key/value pairs in the
-StackStorm :doc:`datastore </datastore>`:
+The puppet type ``::st2::kv`` can manage key/value pairs in the
+|st2| :doc:`datastore </datastore>`:
 
 Configuring via Manifests:
 

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -1,7 +1,7 @@
 Puppet Module
 =============
 
-If you're ready to take complete control of your |st2| instances, then ``puppet-st2``
+If you're ready to take complete control of your |st2| instances, then the ``stackstorm-st2``
 is for you! It offers repeatable, configurable, and idempotent production-friendly
 |st2| installations.
 
@@ -28,33 +28,22 @@ The same system size :doc:`requirements </install/system_requirements>` also app
 Quick Start
 -----------
 
-The first step is installing Puppet, for this please consule the
-`Puppet Installation documentation <https://puppet.com/docs/puppet/latest/install_linux.html>`_
-
-To get started with a single node deployment, and default configuration settings, run these
-commands (expected to run as `root`):
+The first step is installing Puppet, for this please consult the
+`official Puppet installation documentation <https://puppet.com/docs/puppet/latest/install_linux.html>`_
 
 .. note::
 
   Puppet versions <= 3.x are no longer supported. Please utilize Puppet >= 4.
 
-First, create a file called ``Puppetfile`` with the following content:
-
-.. code-block:: ruby
-
-  forge 'https://forgeapi.puppetlabs.com'
-  mod 'stackstorm/st2'
-
-Next, utilize ``librarian-puppet`` to download and install the ``puppet-st2`` module
-and its dependencies, then execute Puppet to install StackStorm and all of its dependencies:
+To get started with a single node deployment, and default configuration settings,
+we're going to install the ``stackstorm-st2`` module and its dependencies, then
+tell Puppet to perform a full install of StackStorm: In order to accmplish this
+run the following commands (expected to run as `root`):
 
 .. code-block:: bash
 
-  /opt/puppetlabs/puppet/bin/gem install librarian-puppet
-  # note: you must execute this command in the same directory where the Puppetfile resides
-  /opt/puppetlabs/puppet/bin/librarian-puppet install --path=./modules
-
-  /opt/puppetlabs/bin/puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+  puppet module install stackstorm-st2
+  puppet apply -e "include ::st2::profile::fullinstall"
 
 .. note::
 
@@ -65,7 +54,7 @@ Classes
 -------
 
 ``::st2::profile::fullinstall`` is the quick and easy way to get StackStorm up
-and running. The ``puppet-st2`` module provides numerous additional classes
+and running. The ``stackstorm-st2`` module provides numerous additional classes
 in order to configure StackStorm just the way you like it. Below is a list of
 classes available for configuration:
 
@@ -216,7 +205,7 @@ Configuration via Hiera:
 Configuring ChatOps
 -------------------
 
-``puppet-st2`` can be used to managed the ChatOps configuration of your StackStorm
+``stackstorm-st2`` can be used to managed the ChatOps configuration of your StackStorm
 installation. We provide support for configuring all Hubot settings, installing
 custom ChatOps adapters, and finally configuring any and all adapter settings.
 

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -1,11 +1,11 @@
 Puppet Module
 =============
 
-If you're ready to take complete control of your |st2| instances, then ``puppet-st2`` 
+If you're ready to take complete control of your |st2| instances, then ``puppet-st2``
 is for you! It offers repeatable, configurable, and idempotent production-friendly
 |st2| installations.
 
-The source code for all the Puppet module is available as a GitHub repo: 
+The source code for all the Puppet module is available as a GitHub repo:
 `StackStorm/puppet-st2 <https://github.com/stackstorm/puppet-st2/>`_
 
 .. contents:: Contents
@@ -35,19 +35,25 @@ To get started with a single node deployment, and default configuration settings
 commands (expected to run as `root`):
 
 .. note::
-   
+
   Puppet versions <= 3.x are no longer supported. Please utilize Puppet >= 4.
+
+First, create a file called ``Puppetfile`` with the following content:
+
+.. code-block:: ruby
+
+  forge 'https://forgeapi.puppetlabs.com'
+  mod 'stackstorm/st2'
+
+Next, utilize ``librarian-puppet`` to download and install the ``puppet-st2`` module
+and its dependencies, then execute Puppet to install StackStorm and all of its dependencies:
 
 .. code-block:: bash
 
-  # create a Puppetfile that defines our StackStorm module
-  echo -e "forge 'https://forgeapi.puppetlabs.com'\n mod 'stackstorm/st2'" > Puppetfile
-
-  # setup librarian-puppet to download and install our module and its dependencies
   /opt/puppetlabs/puppet/bin/gem install librarian-puppet
+  # note: you must execute this command in the same directory where the Puppetfile resides
   /opt/puppetlabs/puppet/bin/librarian-puppet install --path=./modules
 
-  # run StackStorm full install using puppet
   /opt/puppetlabs/bin/puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
 
 .. note::
@@ -87,7 +93,7 @@ provided that allow installation and configuration of StackStorm's components.
 - ``::st2::kv`` - Defines a key/value pair in the |st2| datastore
 - ``::st2::pack`` - Installs and configures a |st2| pack
 - ``::st2::user`` - Configures a system-level (linux) user and SSH keys
-  
+
 Installing and Configuring Packs
 --------------------------------
 
@@ -97,15 +103,15 @@ be done via the ``::st2::pack`` and ``st2::pack::config`` defined types.
 Installation/Configuration via Manifest:
 
 .. code-block:: puppet
-                
+
   # install pack from the exchange
   st2::pack { 'linux': }
-  
+
   # install pack from a git URL
   st2::pack { 'private':
     repo_url => 'https://private.domain.tld/git/stackstorm-private.git',
   }
-  
+
   # install pack and apply configuration
   st2::pack { 'slack':
     config   => {
@@ -114,11 +120,11 @@ Installation/Configuration via Manifest:
       },
     },
   }
-  
+
 Installation/Configuration via Hiera:
 
 .. code-block:: yaml
-                
+
   st2::packs:
     linux:
       ensure: present
@@ -146,23 +152,23 @@ The following backends are currently available:
 - ``ldap`` - Authenticates against an LDAP server such as OpenLDAP or Active Directory . See the `LDAP backend documentation <https://github.com/StackStorm/st2-auth-backend-ldap>`_
 - ``mongodb`` - Authenticates against a collection named users in MongoDB. See the `MongoDB backend <https://github.com/StackStorm/st2-auth-backend-mongodb>`_
 - ``pam`` - Authenticates against the PAM Linux service. See the `PAM backend documentation <https://github.com/StackStorm/st2-auth-backend-pam>`_
-  
+
 By default the ``flat_file`` backend is used. To change this you can configure
 it when instantiating the ``::st2`` class in a manifest file:
 
 Configuration via Manifest:
 
 .. code-block:: puppet
-                
+
   class { '::st2':
     auth_backend => 'ldap',
   }
-  
+
 
 Configuration via Hiera:
 
 .. code-block:: yaml
-                
+
   st2::auth_backend: ldap
 
 Each backend has their own custom configuration settings. The settings can be
@@ -175,7 +181,7 @@ the ``::st2`` class in a manifest file:
 Configuration via Manifest:
 
 .. code-block:: puppet
-                
+
   class { '::st2':
     auth_backend        => 'ldap',
     auth_backend_config => {
@@ -190,11 +196,11 @@ Configuration via Manifest:
       },
     },
   }
-  
+
 Configuration via Hiera:
 
 .. code-block:: yaml
-                
+
   st2::auth_backend: ldap
   st2::auth_backend_config:
     ldap_uri: "ldaps://ldap.domain.tld"
@@ -206,7 +212,7 @@ Configuration via Hiera:
       search_filter: "(&(objectClass=user)(sAMAccountName={username})(memberOf=cn=stackstorm_users,ou=groups,dc=domain,dc=tld))"
       scope: "subtree"
 
-      
+
 Configuring ChatOps
 -------------------
 
@@ -217,7 +223,7 @@ custom ChatOps adapters, and finally configuring any and all adapter settings.
 Configuration via Manifest:
 
 .. code-block:: puppet
-                
+
   class { '::st2':
     chatops_hubot_alias  => "'!'",
     chatops_hubot_name   => '"@RosieRobot"',
@@ -244,20 +250,20 @@ Configuration via Manifest:
 Configuration via Hiera:
 
 .. code-block:: yaml
-                
+
   # character to trigger the bot that the message is a command
   # example: !help
   st2::chatops_hubot_alias: "'!'"
-  
+
   # name of the bot in chat, sometimes requires special characters like @
   st2::chatops_hubot_name: '"@RosieRobot"'
-  
+
   # API key generated by: st2 apikey create
   st2::chatops_api_key: '"xxxxyyyyy123abc"'
- 
+
   # Public URL used by ChatOps to offer links to execution details via the WebUI.
   st2::chatops_web_url: '"stackstorm.domain.tld"'
-  
+
   # install and configure hubot adapter (rocketchat, nodejs module installed by ::nodejs)
   st2::chatops_adapter:
     hubot-adapter:
@@ -285,7 +291,7 @@ StackStorm :doc:`datastore </datastore>`:
 Configuring via Manifests:
 
 .. code-block:: puppet
-                
+
   st2::kv { 'my_key_name':
     value => 'SomeValue',
   }
@@ -297,7 +303,7 @@ Configuring via Manifests:
 Configuration via Hiera:
 
 .. code-block:: yaml
-                
+
   st2::kvs:
     my_key_name:
       value: SomeValue

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -34,22 +34,17 @@ The first step is installing Puppet, for this please consule the
 To get started with a single node deployment, and default configuration settings, run these
 commands (expected to run as `root`):
 
+.. note::
+   
+  Puppet versions <= 3.x are no longer supported. Please utilize Puppet >= 4.
+
 .. code-block:: bash
 
-  mkdir modules/
-  git clone https://github.com/StackStorm/puppet-st2 modules/st2
-  
-  # run librarian-puppet to download all of our module dependencies defined in
-  # ./modules/st2/build/<os_name>/Puppetfile
-  # valid <os_name> values are (NOTE: Puppet 3.x installs are deprecated):
-  #  centos6   # Puppet 3.x on RHEL/CentOS 6
-  #  centos7   # Puppet 3.x on RHEL/CentOS 7
-  #  ubuntu14  # Puppet 3.x on Ubuntu 14
-  #  ubuntu16  # Puppet 3.x on Ubuntu 16
-  #  puppet4   # Puppet 4 on any OS
-  #  puppet5   # Puppet 5 on any OS
+  # create a Puppetfile that defines our StackStorm module
+  echo -e "forge 'https://forgeapi.puppetlabs.com'\n mod 'stackstorm/st2'" > Puppetfile
+
+  # setup librarian-puppet to download and install our module and its dependencies
   /opt/puppetlabs/puppet/bin/gem install librarian-puppet
-  cp modules/st2/build/<os_name>/Puppetfile .
   /opt/puppetlabs/puppet/bin/librarian-puppet install --path=./modules
 
   # run StackStorm full install using puppet
@@ -146,11 +141,11 @@ authentication see the :doc:`authentication documentation </authentication>` pag
 
 The following backends are currently available:
 
-- ``flat_file`` - Authenticates against an htpasswd file (default) `link <https://github.com/StackStorm/st2-auth-backend-flat-file>`_
-- ``keystone`` - Authenticates against an OpenStack Keystone service `link <https://github.com/StackStorm/st2-auth-backend-keystone>`_
-- ``ldap`` - Authenticates against an LDAP server such as OpenLDAP or Active Directory `link <https://github.com/StackStorm/st2-auth-backend-ldap>`_
-- ``mongodb`` - Authenticates against a collection named users in MongoDB `link <https://github.com/StackStorm/st2-auth-backend-mongodb>`_
-- ``pam`` - Authenticates against the PAM Linux service `link <https://github.com/StackStorm/st2-auth-backend-pam>`_
+- ``flat_file`` - Authenticates against an htpasswd file (default). See the `flat-file backend documentation <https://github.com/StackStorm/st2-auth-backend-flat-file>`_
+- ``keystone`` - Authenticates against an OpenStack Keystone service See the `keystone backend documentation <https://github.com/StackStorm/st2-auth-backend-keystone>`_
+- ``ldap`` - Authenticates against an LDAP server such as OpenLDAP or Active Directory . See the `LDAP backend documentation <https://github.com/StackStorm/st2-auth-backend-ldap>`_
+- ``mongodb`` - Authenticates against a collection named users in MongoDB. See the `MongoDB backend <https://github.com/StackStorm/st2-auth-backend-mongodb>`_
+- ``pam`` - Authenticates against the PAM Linux service. See the `PAM backend documentation <https://github.com/StackStorm/st2-auth-backend-pam>`_
   
 By default the ``flat_file`` backend is used. To change this you can configure
 it when instantiating the ``::st2`` class in a manifest file:

--- a/docs/source/install/puppet_chef_salt_ansible.rst
+++ b/docs/source/install/puppet_chef_salt_ansible.rst
@@ -26,7 +26,7 @@ Puppet
 
 |st2| provides a community-supported Puppet module. This module is actively maintained, and sees frequent updates.
 
-Check the `puppet-st2 <https://github.com/stackstorm/puppet-st2/>`_ repository for more details on how to use this module.
+See :doc:`/install/puppet` for details on how to get started.
 
 Chef
 ====


### PR DESCRIPTION
`puppet-st2` just reached the `1.0` milestone and wanted to document it as an installation option in the official StackStorm docs.

This document will grow over time as more features and enhancements are added to the `puppet-st2` module. 