### PR TITLE
Explicitly install crudini (it's used later on)

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -34,6 +34,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL:
   EOT"
   sudo apt-get update
 
+  sudo apt-get install -y crudini
   sudo apt-get install -y mongodb-org
   sudo apt-get install -y rabbitmq-server
   sudo apt-get install -y postgresql

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -82,6 +82,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL:
   gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
   EOT"
 
+  sudo yum -y install crudini
   sudo yum -y install mongodb-org
   sudo yum -y install rabbitmq-server
   sudo service mongod start

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -67,6 +67,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL:
   gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
   EOT"
 
+  sudo yum -y install crudini
   sudo yum -y install mongodb-org
   sudo yum -y install rabbitmq-server
   sudo systemctl start mongod rabbitmq-server


### PR DESCRIPTION
It's used in the "Setup Datastore Encryption" section (`docs/source/install/common/datastore_crypto_key.rst`) but it's never installed anywhere.

Don't know what the package is called on (or what repos to use) for RHEL systems. 😕