### PR TITLE
Add backslash for escape sequences

### DIFF
--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -76,7 +76,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL:
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
   [mongodb-org-3.4]
   name=MongoDB Repository
-  baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
+  baseurl=https://repo.mongodb.org/yum/redhat/\\\$releasever/mongodb-org/3.4/x86_64/
   gpgcheck=1
   enabled=1
   gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
@@ -192,7 +192,7 @@ you will need to add the official Nginx repository:
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/nginx.repo
   [nginx]
   name=nginx repo
-  baseurl=http://nginx.org/packages/rhel/$releasever/x86_64/
+  baseurl=http://nginx.org/packages/rhel/\\\$releasever/x86_64/
   gpgcheck=1
   enabled=1
   EOT"

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -20,8 +20,7 @@ Install libffi-devel Package
 RHEL 6 may not ship with ``libffi-devel`` package, which is a dependency for |st2|. If that is the
 case, set up the ``server-optional`` repository, following the instructions at
 https://access.redhat.com/solutions/265523.
-Or, find a version of ``libffi-devel`` compatible with the ``libffi`` version installed. For
-example:
+Or, find a version of ``libffi-devel`` compatible with the ``libffi`` version installed. For example:
 
 .. code :: bash
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -61,7 +61,7 @@ Install MongoDB, RabbitMQ, and PostgreSQL:
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-3.4.repo
   [mongodb-org-3.4]
   name=MongoDB Repository
-  baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
+  baseurl=https://repo.mongodb.org/yum/redhat/\\\$releasever/mongodb-org/3.4/x86_64/
   gpgcheck=1
   enabled=1
   gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
@@ -168,7 +168,7 @@ you will need to add the official Nginx repository:
   sudo sh -c "cat <<EOT > /etc/yum.repos.d/nginx.repo
   [nginx]
   name=nginx repo
-  baseurl=http://nginx.org/packages/rhel/$releasever/x86_64/
+  baseurl=http://nginx.org/packages/rhel/\\\$releasever/x86_64/
   gpgcheck=1
   enabled=1
   EOT"


### PR DESCRIPTION
`$releasever` will be null character without escape character in bash