### PR TITLE
Fix typo - 'var' should be 'vars'

### DIFF
--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -114,7 +114,7 @@ Variables
 ---------
 
 ActionChain offers the convenience of named variables. Global vars are set at the top of the
-definition with the ``var`` keyword.
+definition with the ``vars`` keyword.
 
 Tasks publish new variables with the ``publish`` keyword. Variables are handy when you need to mash
 up a reusable value from the input, globals, datastore values, and results of multiple action


### PR DESCRIPTION
All of the later examples use `vars` as the top-level keyword for global variables. All of the workflows in `st2/contrib/examples` and `st2tests/fixtures` use `vars`, and Python code expects a `vars` key (and not a `var` key).