### PR TITLE
Explicitly create a Python2 virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== st2docs virtualenv ===================="
 	@echo
-	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages $(VIRTUALENV_DIR)
+	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages --python=/usr/bin/python2 $(VIRTUALENV_DIR)
 
 	# Setup PYTHONPATH in bash activate script...
 	echo '' >> $(VIRTUALENV_DIR)/bin/activate


### PR DESCRIPTION
Greetings here!

In modern Debian and Ubuntu distributions, the `virtualenv` package installed from repositories creates Python3 virtual environment by default. Since the docs are still building with Py2, we just need to provide a path to correct binary executable. It also should be safe for any other platform.

@Kami @LindsayHill Please review. Many thanks!
