### PR TITLE
set windows runner deprecation timeline

### DIFF
--- a/docs/source/_includes/__windows_runners_deprecation_notice.rst
+++ b/docs/source/_includes/__windows_runners_deprecation_notice.rst
@@ -1,6 +1,8 @@
 .. note::
 
-    Windows runners will be DEPRECATED in a future release. These runners are being replaced
+    Windows runners are DEPRECATED as of version ``2.9``. These runners are replaced
     by :ref:`WinRM Runners <ref-winrm-runners>` which use a native Python implementation
     of the WinRM protocol. Please migrate all existing actions over to these new runners. Any new
     code should prefer WinRM Runners over the Windows Runners.
+
+    The legacy Windows runners will be REMOVED in version ``3.1``.


### PR DESCRIPTION
Legacy Windows runners to be DEPRECATED in 2.9, REMOVED in 3.1.