### PR TITLE
Added note on mistral vs action timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             make .clone-st2
       - restore_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
+      - run: sudo apt install python-dev
       - run: make docs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
@@ -27,6 +28,7 @@ jobs:
             make .clone-st2
       - restore_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
+      - run: sudo apt install python-dev
       - run: make ewcdocs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}


### PR DESCRIPTION
Trying to reduce confusion between Mistral's `timeout:` parameter, and underlying action `timeout:`.