### PR TITLE
Use python2.7, not python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== st2docs virtualenv ===================="
 	@echo
-	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages --python=/usr/bin/python2 $(VIRTUALENV_DIR)
+	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages --python=python2.7 $(VIRTUALENV_DIR)
 
 	# Setup PYTHONPATH in bash activate script...
 	echo '' >> $(VIRTUALENV_DIR)/bin/activate


### PR DESCRIPTION
MacOS does not have `/usr/bin/python2`, it has `/usr/bin/python2.7`

We don't care about supporting older versions of Python than that

Changes #784 