### PR TITLE
Remove Beta tag from WinRM

### DIFF
--- a/docs/source/install/common/configure_ssh_and_sudo.rst
+++ b/docs/source/install/common/configure_ssh_and_sudo.rst
@@ -30,7 +30,7 @@ testing.
 * Configure SSH access and enable passwordless sudo on the remote hosts which |st2| will be running
   remote actions on via SSH. Using the public key generated in the previous step, follow the
   instructions at :ref:`config-configure-ssh`. To control Windows boxes, configure access for
-  :doc:`Windows runners </install/config/windows_runners>`.
+  :doc:`Windows runners </install/config/winrm_runners>`.
 
 * If you are using a different user, or path to their SSH key, you will need to change this
   section in ``/etc/st2/st2.conf``:

--- a/docs/source/install/config/index.rst
+++ b/docs/source/install/config/index.rst
@@ -12,7 +12,6 @@ config file with all configuration options can be found at
 
     config
     webui
-    windows_runners
     winrm_runners
 
 

--- a/docs/source/install/config/windows_runners.rst
+++ b/docs/source/install/config/windows_runners.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Windows Runners Configuration
 =============================
 

--- a/docs/source/install/config/winrm_runners.rst
+++ b/docs/source/install/config/winrm_runners.rst
@@ -1,13 +1,6 @@
 WinRM Runners Configuration
 ===========================
 
-.. note::
-
-  WinRM runners are currently in beta which means there might be rough edges and things might
-  break.
-
-  If you do encounter an issue, please get in touch and we will do our best to assist you.
-
 Supported Windows Versions
 --------------------------
 

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -31,8 +31,7 @@ share a dedicated Python virtualenv, and are configured via ``/etc/st2/st2.conf`
 * **st2actionrunners** run actions from packs under ``/opt/stackstorm/packs`` via a variety of
   :doc:`/reference/runners`. Runners may require some runner-specific configurations, e.g. SSH
   needs to be configured for running remote actions based on ``remote-shell-runner`` and
-  ``remote-command-runner``. Windows prerequisites must be in place to run Windows runners. See
-  :doc:`Runners </reference/runners>` for details.
+  ``remote-command-runner``. 
 * **st2resultstracker** keeps track of long-running workflow executions, calling the Mistral API
   endpoint.
 * **st2notifier** generates ``st2.core.actiontrigger`` and ``st2.core.notifytrigger``


### PR DESCRIPTION
As above. Remove beta tag from WinRM runners. 

Note that legacy Windows runners will be removed in 3.1, and so we're starting to remove some references here.