### PR TITLE
Add instruction on apt and yum repos GPG key update

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -11,6 +11,27 @@ from, you may need to run additional :ref:`migration scripts<migration-scripts-t
 If you skipped a version and are upgrading to a newer version, please make sure you also run the
 migration scripts for skipped versions.
 
+Update GPG Key
+--------------
+
+.. warning::
+
+    The GPG keys for StackStorm's apt and yum reposities metadata signing are updated. Any systems with
+    StackStorm installed will complain about GPG key error on signature verification when running apt or yum
+    update. Please go through the following instructions to update the GPG key.
+
+For Ubuntu, add the new gpg key with the following command before running ``apt-get update``. If you are
+running a non production version of StackStorm, then replace ``stable`` in the curl URL with the appropriate
+repository name.
+
+    .. sourcecode:: bash
+
+        curl -L https://packagecloud.io/StackStorm/stable/gpgkey | sudo apt-key add -
+
+For RHEL/CentOS, running ``yum update`` will auto retrieve the new GPG key for the respository.
+``yum update`` will ask if you want to import the new GPG key, verify that the key is retrieved from
+``https://packagecloud.io/StackStorm/stable/gpgkey`` and enter ``y`` to confirm.
+
 General Upgrade Procedure
 -------------------------
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -8,6 +8,9 @@ Upgrade Notes
 |st2| v3.0
 ----------
 
+* The GPG keys for StackStorm's apt and yum reposities metadata signing are updated. Any systems with
+  StackStorm installed will complain about GPG key error on signature verification when running apt or yum
+  update. Please see the :doc:`upgrades documentation <install/upgrades>` for how to update the GPG key.
 * Python |st2| client methods have been renamed from ``st2client.liveactions.*`` to
   ``st2client.executions.*``. Previously those methods already represented operations on
   execution objects, but were incorrectly named.


### PR DESCRIPTION
Packagecloud migrated metadata GPG key. This breaks apt and yum update on systems with st2 already installed. Upgrade notes are added to highlight the change and instructions included to update the gpg key.