### PR TITLE
Fix Node upgrade for RHEL/CentOS

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -119,7 +119,7 @@ v2.10
 
   .. sourcecode:: bash
 
-     curl -sL https://rpm.nodesource.com/setup_10.x | sudo -E bash -
+     sudo sed -i.bak 's|^baseurl=\(https://rpm.nodesource.com\)/[^/]\{1,\}/\(.*\)$|baseurl=\1/pub_10.x/\2|g' /etc/yum.repos.d/nodesource-*.repo
      sudo yum clean all
      sudo rpm -e --nodeps npm
      sudo yum upgrade st2chatops


### PR DESCRIPTION
Update the upgrade instructions for RHEL and CentOS distros to something that works with `yum`.

When the Nodesource scripts are run again for node 10, they create duplicate `.repo` files, which `yum` then proceeds to complain about, ignore, and subsequently error out when upgrading st2chatops.

This should be merged before 2.10 is released.