### PR TITLE
Add more detailed information for the packagecloud gpg key migration

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -22,29 +22,27 @@ Update GPG Key
     
     Failure to update the keys will result in signature verification errors during package update.
 
-For |st2| community version on Ubuntu, remove the old gpg key and then add the new gpg key with the following
-commands before running ``apt-get update``. If you are running a non production version of StackStorm, then
-replace ``stable`` in the curl URL with the appropriate repository name.
+For |st2| community version on Ubuntu, run the following command to setup the repo for ``apt``. If you
+are running a non production version of StackStorm, then replace ``stable`` in the curl URL with the
+appropriate repository name.
 
 .. sourcecode:: bash
 
-    sudo apt-key remove C2E73424D59097AB
-    curl -L https://packagecloud.io/StackStorm/stable/gpgkey | sudo apt-key add -
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.deb.sh | sudo bash
 
-For |st2| enterprise version on Ubuntu, the old gpg key for stable and enterprise repos are the same but the
-new gpg keys for these repos are different. The new gpg key for the enterprise repo will need to be added
-separately.
+For |st2| enterprise version on Ubuntu, both the gpg keys for community and enterprise need to be
+imported separately. Run the following commands to setup both repos for ``apt``. If you are running
+a non production version of StackStorm, then replace ``stable`` in the curl URLs with the appropriate
+repository name. Replace ``<license_key>`` with your enterprise license key.
 
 .. sourcecode:: bash
 
-    sudo apt-key remove C2E73424D59097AB
-    curl -L https://packagecloud.io/StackStorm/stable/gpgkey | sudo apt-key add -
-    curl -L https://packagecloud.io/StackStorm/enterprise/gpgkey | sudo apt-key add -
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.deb.sh | sudo bash
+    curl -s https://<license_key>:@packagecloud.io/install/repositories/StackStorm/enterprise/script.deb.sh | sudo bash
 
 For reference, the following is the error shown if the new gpg key(s) is not added on Ubuntu. Please
 note the URLs that failed on retrieval should be ``https://packagecloud.io/StackStorm/stable`` for the
-|st2| community or core platform and ``https://packagecloud.io/StackStorm/enterprise`` for the |st2|
-enterprise repo::
+|st2| community and ``https://packagecloud.io/StackStorm/enterprise`` for the |st2| enterprise repo::
 
     $ sudo apt-get update
     Get:7 https://packagecloud.io/StackStorm/stable/ubuntu xenial InRelease [23.2 kB]
@@ -59,24 +57,33 @@ enterprise repo::
     W: Failed to fetch https://packagecloud.io/StackStorm/stable/ubuntu/dists/xenial/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C2E73424D59097AB
     W: Some index files failed to download. They have been ignored, or old ones used instead.
 
-For RHEL/CentOS, running ``yum update`` will auto-retrieve the new gpg key for appropriate respository.
-``yum update`` will ask if you want to import the new gpg keys. Verify that the key is retrieved from
-``https://packagecloud.io/StackStorm/stable/gpgkey`` for the |st2| community or core platform and
-enter ``y`` to confirm. For |st2| enterprise repo, additional key needs to be retrieved from
-``https://packagecloud.io/StackStorm/enterprise/gpgkey``.
-
-Prior to running ``yum update``, the old gpg key can be optionally removed with the following commands.
+For |st2| community version on RHEL/CentOS, run the following command to setup the repo for ``yum``. If you
+are running a non production version of StackStorm, then replace ``stable`` in the curl URL with the
+appropriate repository name.
 
 .. sourcecode:: bash
 
-    # Replace x86_64 and 7 in the following command with your CPU architecture and RHEL/CentOS version:
-    gpg --homedir /var/lib/yum/repos/x86_64/7/StackStorm_stable/gpgdir --delete-key C2E73424D59097AB
-    gpg --homedir /var/lib/yum/repos/x86_64/7/StackStorm_enterprise/gpgdir --delete-key C2E73424D59097AB
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
+
+For |st2| enterprise version on RHEL/CentOS, both the gpg keys for community and enterprise need to be
+import separately. Run the following commands to setup both repos for ``yum``. If you are running a
+non production version of StackStorm, then replace ``stable`` in the curl URLs with the appropriate
+repository name. Replace ``<license_key>`` with your enterprise license key.
+
+.. sourcecode:: bash
+
+    curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
+    curl -s https://<license_key>:@packagecloud.io/install/repositories/StackStorm/enterprise/script.rpm.sh | sudo bash
+
+If the new gpg keys are not setup in advanced on RHEL/CentOS, running ``yum update`` will auto-retrieve
+the new gpg key for appropriate respository. ``yum update`` will ask if you want to import the new gpg keys.
+Verify that the key is retrieved from ``https://packagecloud.io/StackStorm/stable/gpgkey`` for the |st2|
+community and enter ``y`` to confirm. For |st2| enterprise repo, additional key needs to be retrieved from
+``https://packagecloud.io/StackStorm/enterprise/gpgkey``.
 
 For reference, the following is a sample output from ``yum update``. Please note the URLs where the key
 is retrieved from should be ``https://packagecloud.io/StackStorm/stable`` for the
-|st2| community or core platform and ``https://packagecloud.io/StackStorm/enterprise`` for the |st2|
-enterprise repo::
+|st2| community and ``https://packagecloud.io/StackStorm/enterprise`` for the |st2| enterprise repo::
 
     $ sudo yum update
     Loaded plugins: fastestmirror

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -22,8 +22,8 @@ Update GPG Key
     
     Failure to update the keys will result in signature verification errors during package update.
 
-For |st2| community version on Ubuntu, run the following command to setup the repo for ``apt``. If you
-are running a non production version of StackStorm, then replace ``stable`` in the curl URL with the
+For |st2| community version on Ubuntu, run the following command to update your keys. If you
+are running a non production version of StackStorm, then replace ``stable`` in the URL with the
 appropriate repository name.
 
 .. sourcecode:: bash
@@ -31,8 +31,8 @@ appropriate repository name.
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.deb.sh | sudo bash
 
 For |st2| enterprise version on Ubuntu, both the gpg keys for community and enterprise need to be
-imported separately. Run the following commands to setup both repos for ``apt``. If you are running
-a non production version of StackStorm, then replace ``stable`` in the curl URLs with the appropriate
+imported separately. Run the following commands to update both keys. If you are running
+a non production version of StackStorm, then replace ``stable`` in the curl with the appropriate
 repository name. Replace ``<license_key>`` with your enterprise license key.
 
 .. sourcecode:: bash
@@ -57,8 +57,8 @@ note the URLs that failed on retrieval should be ``https://packagecloud.io/Stack
     W: Failed to fetch https://packagecloud.io/StackStorm/stable/ubuntu/dists/xenial/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C2E73424D59097AB
     W: Some index files failed to download. They have been ignored, or old ones used instead.
 
-For |st2| community version on RHEL/CentOS, run the following command to setup the repo for ``yum``. If you
-are running a non production version of StackStorm, then replace ``stable`` in the curl URL with the
+For |st2| community version on RHEL/CentOS, run the following command to update the keys. If you
+are running a non production version of StackStorm, then replace ``stable`` in the URL with the
 appropriate repository name.
 
 .. sourcecode:: bash
@@ -66,8 +66,8 @@ appropriate repository name.
     curl -s https://packagecloud.io/install/repositories/StackStorm/stable/script.rpm.sh | sudo bash
 
 For |st2| enterprise version on RHEL/CentOS, both the gpg keys for community and enterprise need to be
-import separately. Run the following commands to setup both repos for ``yum``. If you are running a
-non production version of StackStorm, then replace ``stable`` in the curl URLs with the appropriate
+import separately. Run the following commands to update the keys. If you are running a
+non production version of StackStorm, then replace ``stable`` in the URLs with the appropriate
 repository name. Replace ``<license_key>`` with your enterprise license key.
 
 .. sourcecode:: bash
@@ -78,7 +78,7 @@ repository name. Replace ``<license_key>`` with your enterprise license key.
 If the new gpg keys are not setup in advanced on RHEL/CentOS, running ``yum update`` will auto-retrieve
 the new gpg key for appropriate respository. ``yum update`` will ask if you want to import the new gpg keys.
 Verify that the key is retrieved from ``https://packagecloud.io/StackStorm/stable/gpgkey`` for the |st2|
-community and enter ``y`` to confirm. For |st2| enterprise repo, additional key needs to be retrieved from
+community and enter ``y`` to confirm. For |st2| enterprise repo, an additional key needs to be retrieved from
 ``https://packagecloud.io/StackStorm/enterprise/gpgkey``.
 
 For reference, the following is a sample output from ``yum update``. Please note the URLs where the key

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -22,17 +22,84 @@ Update GPG Key
     
     Failure to update the keys will result in signature verification errors during package update.
 
-For Ubuntu, add the new gpg key with the following command before running ``apt-get update``. If you are
-running a non production version of StackStorm, then replace ``stable`` in the curl URL with the appropriate
-repository name.
+For |st2| community version on Ubuntu, remove the old gpg key and then add the new gpg key with the following
+commands before running ``apt-get update``. If you are running a non production version of StackStorm, then
+replace ``stable`` in the curl URL with the appropriate repository name.
 
-    .. sourcecode:: bash
+.. sourcecode:: bash
 
-        curl -L https://packagecloud.io/StackStorm/stable/gpgkey | sudo apt-key add -
+    sudo apt-key remove C2E73424D59097AB
+    curl -L https://packagecloud.io/StackStorm/stable/gpgkey | sudo apt-key add -
 
-For RHEL/CentOS, running ``yum update`` will auto-retrieve the new GPG key for the respository.
-``yum update`` will ask if you want to import the new GPG key. Verify that the key is retrieved from
-``https://packagecloud.io/StackStorm/stable/gpgkey`` and enter ``y`` to confirm.
+For |st2| enterprise version on Ubuntu, the old gpg key for stable and enterprise repos are the same but the
+new gpg keys for these repos are different. The new gpg key for the enterprise repo will need to be added
+separately.
+
+.. sourcecode:: bash
+
+    sudo apt-key remove C2E73424D59097AB
+    curl -L https://packagecloud.io/StackStorm/stable/gpgkey | sudo apt-key add -
+    curl -L https://packagecloud.io/StackStorm/enterprise/gpgkey | sudo apt-key add -
+
+For reference, the following is the error shown if the new gpg key(s) is not added on Ubuntu. Please
+note the URLs that failed on retrieval should be ``https://packagecloud.io/StackStorm/stable`` for the
+|st2| community or core platform and ``https://packagecloud.io/StackStorm/enterprise`` for the |st2|
+enterprise repo::
+
+    $ sudo apt-get update
+    Get:7 https://packagecloud.io/StackStorm/stable/ubuntu xenial InRelease [23.2 kB]
+    Err:7 https://packagecloud.io/StackStorm/stable/ubuntu xenial InRelease
+    The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C2E73424D59097AB
+    Hit:8 http://archive.ubuntu.com/ubuntu xenial InRelease         
+    Hit:9 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
+    Hit:10 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
+    Fetched 23.2 kB in 1s (12.3 kB/s)
+    Reading package lists... Done
+    W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://packagecloud.io/StackStorm/stable/ubuntu xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C2E73424D59097AB
+    W: Failed to fetch https://packagecloud.io/StackStorm/stable/ubuntu/dists/xenial/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C2E73424D59097AB
+    W: Some index files failed to download. They have been ignored, or old ones used instead.
+
+For RHEL/CentOS, running ``yum update`` will auto-retrieve the new gpg key for appropriate respository.
+``yum update`` will ask if you want to import the new gpg keys. Verify that the key is retrieved from
+``https://packagecloud.io/StackStorm/stable/gpgkey`` for the |st2| community or core platform and
+enter ``y`` to confirm. For |st2| enterprise repo, additional key needs to be retrieved from
+``https://packagecloud.io/StackStorm/enterprise/gpgkey``.
+
+Prior to running ``yum update``, the old gpg key can be optionally removed with the following commands.
+
+.. sourcecode:: bash
+
+    # Replace x86_64 and 7 in the following command with your CPU architecture and RHEL/CentOS version:
+    gpg --homedir /var/lib/yum/repos/x86_64/7/StackStorm_stable/gpgdir --delete-key C2E73424D59097AB
+    gpg --homedir /var/lib/yum/repos/x86_64/7/StackStorm_enterprise/gpgdir --delete-key C2E73424D59097AB
+
+For reference, the following is a sample output from ``yum update``. Please note the URLs where the key
+is retrieved from should be ``https://packagecloud.io/StackStorm/stable`` for the
+|st2| community or core platform and ``https://packagecloud.io/StackStorm/enterprise`` for the |st2|
+enterprise repo::
+
+    $ sudo yum update
+    Loaded plugins: fastestmirror
+    Loading mirror speeds from cached hostfile
+    StackStorm_stable/x86_64/signature                                                             |  836 B  00:00:00     
+    Retrieving key from https://packagecloud.io/StackStorm/stable/gpgkey
+    Importing GPG key 0xF6C28448:
+    Userid     : "https://packagecloud.io/StackStorm/stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
+    Fingerprint: 2664 b321 ca26 c6be fe81 aa46 723c b7a7 f6c2 8448
+    From       : https://packagecloud.io/StackStorm/stable/gpgkey
+    Is this ok [y/N]: y
+    StackStorm_stable/x86_64/signature                                                             | 1.0 kB  00:00:15 !!! 
+    StackStorm_stable-source/signature                                                             |  836 B  00:00:00     
+    Retrieving key from https://packagecloud.io/StackStorm/stable/gpgkey
+    Importing GPG key 0xF6C28448:
+    Userid     : "https://packagecloud.io/StackStorm/stable (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
+    Fingerprint: 2664 b321 ca26 c6be fe81 aa46 723c b7a7 f6c2 8448
+    From       : https://packagecloud.io/StackStorm/stable/gpgkey
+    Is this ok [y/N]: y
+    StackStorm_stable-source/signature                                                             |  951 B  00:00:10 !!! 
+    (1/2): StackStorm_stable-source/primary                                                        |  175 B  00:00:00     
+    (2/2): StackStorm_stable/x86_64/primary                                                        |  27 kB  00:00:00     
+    StackStorm_stable                                                                                             124/124
 
 General Upgrade Procedure
 -------------------------


### PR DESCRIPTION
Include additional step for st2 enterprise user to import gpg key for the enterprise repo. Include sample output on apt-get update and yum update. Identify the URL users should look for when apt-get update and yum update complains on gpg key verification.