### PR TITLE
Add new document on reporting security issues / vulnerabilities

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 |fullname| Documentation
-======================================
+========================
 
 Contents:
 
@@ -48,6 +48,11 @@ Contents:
     Roadmap <roadmap>
 
 .. toctree::
+    :maxdepth: 1
+    :caption: Other
+
+    security
+
+.. toctree::
     :maxdepth: 2
     :caption: Lost and Found
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,7 +52,3 @@ Contents:
     :caption: Other
 
     security
-
-.. toctree::
-    :maxdepth: 2
-    :caption: Lost and Found

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -1,0 +1,31 @@
+Security
+========
+
+Here at StackStorm we take security were seriously. If you believe you found a security issue or a
+vulnerability, please report it to us using one of the methods described below.
+
+Reporting a Vulnerability
+-------------------------
+
+.. note::
+
+   Please do not report security issues using our public Github repository or Slack instance. Use
+   the private mailing list described bellow.
+
+If you believe you found a security issue or a vulnerability, please send a description of it to
+our private mailing list at info [at] stackstorm [dot] com
+
+You are also encouraged to encrypt this email using PGP. Keys of our developers can be found at
+https://raw.githubusercontent.com/StackStorm/st2/master/KEYS.
+
+Once you've submitted an issue, you should receive an acknowledgment from one our of team members
+in 48 hours or less. If further action is necessary, you may receive additional follow-up emails.
+
+How Are Vulnerabilities Handled
+-------------------------------
+
+We follow the industry de facto standard of `Responsible Disclosure <https://en.wikipedia.org/wiki/Responsible_disclosure>`_
+for handling security issues. This means we disclose the issue only after a fix or mitigation for
+the issue has been released.
+
+We of course always give full credit to people who have reported the issue.

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -1,7 +1,7 @@
 Security
 ========
 
-Here at StackStorm we take security were seriously. If you believe you found a security issue or a
+Here at StackStorm we take security very seriously. If you believe you found a security issue or a
 vulnerability, please report it to us using one of the methods described below.
 
 Reporting a Vulnerability
@@ -9,14 +9,11 @@ Reporting a Vulnerability
 
 .. note::
 
-   Please do not report security issues using our public Github repository or Slack instance. Use
+   Please do not report security issues using our public Github repository or Slack chat. Use
    the private mailing list described bellow.
 
 If you believe you found a security issue or a vulnerability, please send a description of it to
 our private mailing list at info [at] stackstorm [dot] com
-
-You are also encouraged to encrypt this email using PGP. Keys of our developers can be found at
-https://raw.githubusercontent.com/StackStorm/st2/master/KEYS.
 
 Once you've submitted an issue, you should receive an acknowledgment from one our of team members
 in 48 hours or less. If further action is necessary, you may receive additional follow-up emails.


### PR DESCRIPTION
It turns out we had no document on how to report security issues.

This pull request fixes that.