### PR TITLE
Pin to < 1.8 for Sphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=1.8.1,<1.9
+sphinx>=1.7.5,<1.8
 sphinx-autobuild


### PR DESCRIPTION
Having problems with search with Sphinx 1.8.x, so will pin to 1.7.x for now.