### PR TITLE
Push built docs direct from CircleCI to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,19 @@ jobs:
               aws s3 sync generated-site/st2docs/* \
               s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
             fi
+      - run:
+          # Check the install scripts to see if this is the current GA version
+          name: Check if current GA branch, in which case also deploy to main site
+          command: |
+            GA_VER=$(curl -sSL https://stackstorm.com/packages/install.sh|grep ^BRANCH=|sed 's/[^0-9.]*//g')
+            if [ "${CIRCLE_BRANCH}" = "${GA_VER}" ]; then
+              aws s3 sync generated-site/st2docs/* \
+              s3://${ST2DOCS_BUCKET}/ --dryrun
+              aws s3 sync generated-site/ewcdocs/* \
+              s3://${EWCDOCS_BUCKET}/ --dryrun
+            else
+              echo "Not current GA version"
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: make docs
       - run:
           name: Store HTML docs in workspace dir
-          command: mkdir /tmp/st2docs && cp -r docs/build/html/ /tmp/st2docs/
+          command: mkdir /tmp/st2docs && cp -r docs/build/html/* /tmp/st2docs/
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -41,7 +41,7 @@ jobs:
       - run: make ewcdocs
       - run:
           name: Store HTML docs in workspace dir
-          command: mkdir /tmp/ewcdocs && cp -r docs/build/html/ /tmp/ewcdocs/
+          command: mkdir /tmp/ewcdocs && cp -r docs/build/html/* /tmp/ewcdocs/
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -60,14 +60,14 @@ jobs:
           name: Deploy to docs.stackstorm.com and ewc-docs.extremenetworks.com
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
-              aws s3 sync generated-site/st2docs/* \
+              aws s3 sync generated-site/st2docs/ \
               s3://${ST2DOCS_BUCKET}/latest --dryrun
-              aws s3 sync generated-site/ewcdocs/* \
+              aws s3 sync generated-site/ewcdocs/ \
               s3://${EWCDOCS_BUCKET}/latest --dryrun
             else
-              aws s3 sync generated-site/st2docs/* \
+              aws s3 sync generated-site/st2docs/ \
               s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
-              aws s3 sync generated-site/st2docs/* \
+              aws s3 sync generated-site/st2docs/ \
               s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
             fi
       - run:
@@ -76,9 +76,9 @@ jobs:
           command: |
             GA_VER=$(curl -sSL https://stackstorm.com/packages/install.sh|grep ^BRANCH=|sed 's/[^0-9.]*//g')
             if [ "${CIRCLE_BRANCH}" = "${GA_VER}" ]; then
-              aws s3 sync generated-site/st2docs/* \
+              aws s3 sync generated-site/st2docs/ \
               s3://${ST2DOCS_BUCKET}/ --dryrun
-              aws s3 sync generated-site/ewcdocs/* \
+              aws s3 sync generated-site/ewcdocs/ \
               s3://${EWCDOCS_BUCKET}/ --dryrun
             else
               echo "Not current GA version"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             else
               aws s3 sync generated-site/st2docs/ \
               s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH}
-              aws s3 sync generated-site/st2docs/ \
+              aws s3 sync generated-site/ewcdocs/ \
               s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH}
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,4 +99,3 @@ workflows:
               only:
                 - master
                 - /v[0-9]+\.[0-9]+/
-                - docs_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,14 +60,14 @@ jobs:
           name: Deploy to docs.stackstorm.com and ewc-docs.extremenetworks.com
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
-              aws s3 sync generated-site/st2docs \
+              aws s3 sync generated-site/st2docs/* \
               s3://${ST2DOCS_BUCKET}/latest --dryrun
-              aws s3 sync generated-site/ewcdocs \
+              aws s3 sync generated-site/ewcdocs/* \
               s3://${EWCDOCS_BUCKET}/latest --dryrun
             else
-              aws s3 sync generated-site/st2docs \
+              aws s3 sync generated-site/st2docs/* \
               s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
-              aws s3 sync generated-site/st2docs \
+              aws s3 sync generated-site/st2docs/* \
               s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+# Set ST2DOCS_BUCKET and EWCDOCS_BUCKET variables in CircleCI Environment
+
 version: 2
 jobs:
   st2docs:
@@ -13,6 +15,13 @@ jobs:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
       - run: sudo apt install python-dev
       - run: make docs
+      - run:
+          name: Store HTML docs in workspace dir
+          command: mkdir /tmp/st2docs && cp -r docs/build/html/ /tmp/st2docs/
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - st2docs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
           paths:
@@ -30,13 +39,50 @@ jobs:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
       - run: sudo apt install python-dev
       - run: make ewcdocs
+      - run:
+          name: Store HTML docs in workspace dir
+          command: mkdir /tmp/ewcdocs && cp -r docs/build/html/ /tmp/ewcdocs/
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ewcdocs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
           paths:
             - ~/.cache/pip
+  deploy:
+    docker:
+      - image: cibuilds/aws:1.16.43
+    steps:
+      - attach_workspace:
+          at: ./generated-site
+      - run:
+          name: Deploy to docs.stackstorm.com and ewc-docs.extremenetworks.com
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              aws s3 sync generated-site/st2docs \
+              s3://${ST2DOCS_BUCKET}/latest --dry-run
+              aws s3 sync generated-site/ewcdocs \
+              s3://${EWCDOCS_BUCKET}/latest --dry-run
+            else
+              aws s3 sync generated-site/st2docs \
+              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH} --dry-run
+              aws s3 sync generated-site/st2docs \
+              s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dry-run
+            fi
+
 workflows:
   version: 2
   docs_checks:
     jobs:
       - st2docs
       - ewcdocs
+      - deploy:
+          requires:
+            - st2docs
+            - ewcdocs
+          filters:
+            branches:
+              only:
+                - master
+                - /v[0-9]+\.[0-9]+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
 
 workflows:
   version: 2
-  docs_checks:
+  build-deploy:
     jobs:
       - st2docs
       - ewcdocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,14 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
               aws s3 sync generated-site/st2docs/ \
-              s3://${ST2DOCS_BUCKET}/latest --dryrun
+              s3://${ST2DOCS_BUCKET}/latest
               aws s3 sync generated-site/ewcdocs/ \
-              s3://${EWCDOCS_BUCKET}/latest --dryrun
+              s3://${EWCDOCS_BUCKET}/latest
             else
               aws s3 sync generated-site/st2docs/ \
-              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
+              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH}
               aws s3 sync generated-site/st2docs/ \
-              s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
+              s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH}
             fi
       - run:
           # Check the install scripts to see if this is the current GA version
@@ -77,9 +77,9 @@ jobs:
             GA_VER=$(curl -sSL https://stackstorm.com/packages/install.sh|grep ^BRANCH=|sed 's/[^0-9.]*//g')
             if [ "${CIRCLE_BRANCH}" = "${GA_VER}" ]; then
               aws s3 sync generated-site/st2docs/ \
-              s3://${ST2DOCS_BUCKET}/ --dryrun
+              s3://${ST2DOCS_BUCKET}/
               aws s3 sync generated-site/ewcdocs/ \
-              s3://${EWCDOCS_BUCKET}/ --dryrun
+              s3://${EWCDOCS_BUCKET}/
             else
               echo "Not current GA version"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           root: /tmp
           paths:
             - st2docs
+      - store_artifacts:
+          path: /tmp/st2docs
+          destination: st2docs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
           paths:
@@ -46,6 +49,9 @@ jobs:
           root: /tmp
           paths:
             - ewcdocs
+      - store_artifacts:
+          path: /tmp/ewcdocs
+          destination: ewcdocs
       - save_cache:
           key: v1-dependency-cache-{{ checksum "st2/requirements.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,14 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
               aws s3 sync generated-site/st2docs \
-              s3://${ST2DOCS_BUCKET}/latest --dry-run
+              s3://${ST2DOCS_BUCKET}/latest --dryrun
               aws s3 sync generated-site/ewcdocs \
-              s3://${EWCDOCS_BUCKET}/latest --dry-run
+              s3://${EWCDOCS_BUCKET}/latest --dryrun
             else
               aws s3 sync generated-site/st2docs \
-              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH} --dry-run
+              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
               aws s3 sync generated-site/st2docs \
-              s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dry-run
+              s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH} --dryrun
             fi
 
 workflows:
@@ -86,3 +86,4 @@ workflows:
               only:
                 - master
                 - /v[0-9]+\.[0-9]+/
+                - docs_build


### PR DESCRIPTION
@Kami here's an initial pass at changing our Docs build process.

Our CircleCI checks here already build the docs as part of testing them, so we should just re-use that, rather than doing yet another rebuild on our CICD systems.

Store the docs in the workspace, then on commits to master or vX.Y, restore from that workspace and push the built docs to S3.

Note that current process copies pre-release docs to `docs.stackstorm.com/latest` as well as `/docs.stackstorm.com/3.0dev`. I don't think there's any value in copying content to the `3.0dev` directory, for pre-release versions. There *is* value in copying GA releases to their own folder, i.e. `/2.8`, `/2.9`, etc, 

TODO:

- [x] Figure out how to programmatically identify the current GA version, and if our branch matches that, then *also* copy docs to ${BUCKETNAME}/ (that is, the top level of docs.stackstorm.com). ~Would appreciate some help on that~ - NOW DONE