### PR TITLE
Chatops Doc Improvements & BWC Removals

### DIFF
--- a/docs/source/_redirects/install/bwc.html
+++ b/docs/source/_redirects/install/bwc.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url=ewc.html" />
+</head>
+<body>
+<p>This page has moved to <a href="ewc.html">here</a>.</p>
+</body>
+</html>

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -136,9 +136,9 @@ The following is a list of auth backends for the community edition to help get t
 
 LDAP (Enterprise Edition)
 -------------------------
-|st2|-developed auth backends such as LDAP are only available in |bwc|. For more information on
-|bwc|, please visit https://www.extremenetworks.com/product/workflow-composer/
-The auth backends included with |bwc| are developed, tested, maintained, and supported by Extreme Networks.
+|st2|-developed auth backends such as LDAP are only available in |ewc|. For more information on
+|ewc|, please visit https://stackstorm.com/features/#ewc
+The auth backends included with |ewc| are developed, tested, maintained, and supported by Extreme Networks.
 
 LDAP
 ^^^^

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -51,12 +51,47 @@ Configuration
 Package-based Install
 ~~~~~~~~~~~~~~~~~~~~~
 
-If you installed StackStorm following the :doc:`install docs </install/index>`, the ``st2chatops``
-package will take care of everything for you. Hubot with the necessary adapters is already bundled,
-and environment variables are sourced from ``/opt/stackstorm/chatops/st2chatops.env``.
+If you installed |st2| following the :doc:`install docs </install/index>`, the ``st2chatops``
+package will take care of `almost` everything for you. Hubot with the necessary adapters is already
+installed, and StackStorm API keys have been configured. 
 
-Edit the file to specify your Chat service and bot credentials. If you need extra environment
-settings for Hubot, you should store them in ``st2chatops.env`` as well.
+You just need to tell |st2| which Chat service to use - e.g. Slack, MatterMost, etc. You will also need
+to give it credentials. Your Chat service may also need configuration. For example, to configure Slack,
+you first need to add a new Hubot integration to Slack. You can do this through Slack's admin interface.
+Take note of the ``HUBOT_SLACK_TOKEN`` that Slack provides.
+
+Then edit the file ``/opt/stackstorm/chatops/st2chatops.env``. Edit and uncomment the variables for 
+your adapter. For example, if you are configuring Slack, look for this section:
+
+.. code-block:: bash
+
+    # Slack settings (https://github.com/slackhq/hubot-slack):
+    #
+    # export HUBOT_ADAPTER=slack
+    # Obtain the Slack token from your app page at api.slack.com, it's the "Bot
+    # User OAuth Access Token" in the "OAuth & Permissions" section.
+    # export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
+    # Uncomment the following line to force hubot to exit if disconnected from slack.
+    # export HUBOT_SLACK_EXIT_ON_DISCONNECT=1
+
+Edit this file so it looks something like this:
+
+.. code-block:: bash
+
+    # Slack settings (https://github.com/slackhq/hubot-slack):
+    #
+    export HUBOT_ADAPTER=slack
+    # Obtain the Slack token from your app page at api.slack.com, it's the "Bot
+    # User OAuth Access Token" in the "OAuth & Permissions" section.
+    export HUBOT_SLACK_TOKEN=xoxb-SUPER-SECRET-TOKEN
+    # Uncomment the following line to force hubot to exit if disconnected from slack.
+    export HUBOT_SLACK_EXIT_ON_DISCONNECT=1
+
+Your specific Chat service may require different settings. Any environment settings needed can be
+added to this file. 
+
+Once you have finished making changes, restart ``st2chatops`` with ``sudo systemctl restart st2chatops``.
+Check your :ref:`log files<ref_chatops_logging>` to ensure that it is successfully connected. 
 
 If you want the ChatOps messages to include the right hyperlink to execution url for the action
 you kicked off via ChatOps, you have to point |st2| to the external address for the host running
@@ -70,17 +105,17 @@ the web UI. To do so, edit the ``webui`` section in ``/etc/st2/st2.conf``. For e
 Using an External Adapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``st2chatops`` package has an extensive list of built-in adapters for chat services, but if an
-adapter for a service you use isn't bundled there, you can install it manually.
+The ``st2chatops`` package includes adapters for common chat services, but if an
+adapter for a service you use isn't bundled there, don't worry: you can install it manually.
 
-For example, here's how to connect StackStorm to Mattermost using the ``hubot-mattermost`` adapter:
+For example, here's how to connect |st2| to Yammer using the ``hubot-yammer`` adapter:
 
 1. Install the adapter.
 
   .. code-block:: bash
 
     $ cd /opt/stackstorm/chatops
-    $ sudo npm install hubot-mattermost
+    $ sudo npm install hubot-yammer
 
 
 2. Modify ``/opt/stackstorm/chatops/st2chatops.env`` to include
@@ -88,17 +123,16 @@ For example, here's how to connect StackStorm to Mattermost using the ``hubot-ma
 
   .. code-block:: bash
 
-    export HUBOT_ADAPTER=mattermost
-    export MATTERMOST_ENDPOINT=/hubot/incoming
-    export MATTERMOST_INCOME_URL=http://mm:31337/hooks/ncwc66caqf8d7c4gnqby1196qo
-    export MATTERMOST_TOKEN=oqwx9d4khjra8cw3zbis1w6fqy
+    export HUBOT_ADAPTER=yammer
+    export HUBOT_YAMMER_ACCESS_TOKEN="secret_access_token"
+    export HUBOT_YAMMER_GROUPS="groups list"
 
 
 3. Restart the service.
 
   .. code-block:: bash
 
-    $ sudo service st2chatops restart
+    $ sudo systemctl restart st2chatops
 
 Hubot should now connect to your chat service. Congratulations!
 
@@ -181,6 +215,8 @@ You should now be able to go into your chatroom, and execute the command
 .. figure:: /_static/images/chatops_command_out.png
 
 To customize the command output you can use Jinja templates as described in :doc:`aliases`.
+
+.. _ref_chatops_logging:
 
 Logging
 =======

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -90,7 +90,7 @@ Edit this file so it looks something like this:
 Your specific Chat service may require different settings. Any environment settings needed can be
 added to this file. 
 
-Once you have finished making changes, restart ``st2chatops`` with ``sudo systemctl restart st2chatops``.
+Once you have finished making changes, restart ``st2chatops`` with ``sudo service st2chatops restart``.
 Check your :ref:`log files<ref_chatops_logging>` to ensure that it is successfully connected. 
 
 If you want the ChatOps messages to include the right hyperlink to execution url for the action

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,7 +124,7 @@ else:
 rst_epilog = """
 %s
 .. _exchange: https://exchange.stackstorm.org/
-.. |bwc| replace:: Extreme Workflow Composer
+.. |ewc| replace:: Extreme Workflow Composer
 .. |ipf| replace:: IP Fabric Automation Suite
 """ % product_replace
 

--- a/docs/source/inquiries.rst
+++ b/docs/source/inquiries.rst
@@ -465,7 +465,7 @@ user that's been assigned to this role will still be permitted to respond.
 
 
 To lock down a specific Inquiry to a set of users or RBAC roles (the latter of which is only
-available with :doc:`enterprise features</install/bwc>`), the ``users`` and ``roles`` parameters
+available with :doc:`enterprise features</install/ewc>`), the ``users`` and ``roles`` parameters
 should be used. These offer additional restriction on a per-Inquiry basis, but they don't remove
 any restrictions imposed on the aforementioned RBAC settings, if any. These parameter-based
 restrictions are cumulative with any existing RBAC restrictions.

--- a/docs/source/install/__mongodb_note.rst
+++ b/docs/source/install/__mongodb_note.rst
@@ -1,5 +1,5 @@
 .. note::
 
   The currently supported version of MongoDB is 3.4. This is the version installed by
-  the installer script. MongoDB 3.6 does not currently work with StackStorm. Support
-  for 3.6 will be added in a future version of StackStorm
+  the installer script. MongoDB 3.6 and newer does not currently work with StackStorm.
+  Support for 4.0 will be added in a future version of StackStorm

--- a/docs/source/install/ansible.rst
+++ b/docs/source/install/ansible.rst
@@ -62,8 +62,8 @@ complete installation:
 - ``nodejs`` - Dependency for ``st2chatops``.
 - ``st2chatops`` - Install and configure st2chatops for hubot adapter integration with |st2|.
 - ``st2smoketests`` - Simple checks to see if |st2| is working.
-- ``bwc`` - Install and configure |bwc|, including ``LDAP`` and ``RBAC``.
-- ``bwc_smoketests`` - Simple checks to see if |bwc| is working.
+- ``ewc`` - Install and configure |ewc|, including ``LDAP`` and ``RBAC``.
+- ``ewc_smoketests`` - Simple checks to see if |ewc| is working.
 
 Example Play
 ---------------------------
@@ -159,10 +159,10 @@ If you are installing from behind a proxy, you can use the environment variables
         - st2
 
 
-|bwc|
+|ewc|
 -----
 
-Here's an example showing how to add :doc:`Extreme Workflow Composer </install/bwc>`, with
+Here's an example showing how to add :doc:`Extreme Workflow Composer </install/ewc>`, with
 `LDAP <https://ewc-docs.extremenetworks.com/authentication.html#ldap>`_ authentication and
 `RBAC <https://ewc-docs.extremenetworks.com/rbac.html>`_ configuration to allow/restrict/limit |st2|
 functionality to specific users:
@@ -173,14 +173,14 @@ functionality to specific users:
       hosts: all
       roles:
         - name: Install and configure StackStorm Enterprise (EWC)
-          role: bwc
+          role: ewc
           vars:
-            bwc_repo: enterprise
-            bwc_license: CHANGE-ME-PLEASE
-            bwc_version: latest
+            ewc_repo: enterprise
+            ewc_license: CHANGE-ME-PLEASE
+            ewc_version: latest
             # Configure LDAP backend
             # See: https://ewc-docs.extremenetworks.com/authentication.html#ldap
-            bwc_ldap:
+            ewc_ldap:
               backend_kwargs:
                 bind_dn: "cn=Administrator,cn=users,dc=change-you-org,dc=net"
                 bind_password: "foobar123"
@@ -192,7 +192,7 @@ functionality to specific users:
                 id_attr: "samAccountName"
             # Configure RBAC
             # See: https://ewc-docs.extremenetworks.com/rbac.html
-            bwc_rbac:
+            ewc_rbac:
               # Define EWC roles and permissions
               # https://ewc-docs.extremenetworks.com/rbac.html#defining-roles-and-permission-grants
               roles:
@@ -220,7 +220,7 @@ functionality to specific users:
                     - system_admin
 
         - name: Verify EWC Installation
-          role: bwc_smoketests
+          role: ewc_smoketests
 
 .. note::
 

--- a/docs/source/install/common/bwc_intro.rst
+++ b/docs/source/install/common/bwc_intro.rst
@@ -1,9 +1,0 @@
-|bwc| adds Workflow Designer (a graphical tool for workflow creation/editing), RBAC and LDAP to
-|st2|. It is deployed as a set of additional packages on top of |st2|. You will need an active
-|bwc| subscription, and a license key to access |bwc| repositories. 
-
-To learn more about |bwc|, request a quote, or get an evaluation license go to
-`stackstorm.com/product <https://stackstorm.com/product/#enterprise/>`_.
-
-To install |bwc|, replace ``${EWC_LICENSE_KEY}`` in the command below with the key you received
-when registering or purchasing, and run these commands:

--- a/docs/source/install/common/configure_chatops.rst
+++ b/docs/source/install/common/configure_chatops.rst
@@ -12,7 +12,8 @@
   ``Chat service adapter settings`` section in ``st2chatops.env``:
   `Slack <https://github.com/slackhq/hubot-slack>`_,
   `HipChat <https://github.com/hipchat/hubot-hipchat>`_,
-  `Yammer <https://github.com/athieriot/hubot-yammer>`_,
   `Flowdock <https://github.com/flowdock/hubot-flowdock>`_,
   `IRC <https://github.com/nandub/hubot-irc>`_ ,
+  `Mattermost <https://github.com/loafoe/hubot-matteruser>`_,
+  `RocketChat <https://github.com/RocketChat/hubot-rocketchat>`_,
   `XMPP <https://github.com/markstory/hubot-xmpp>`_.

--- a/docs/source/install/common/ewc_intro.rst
+++ b/docs/source/install/common/ewc_intro.rst
@@ -1,0 +1,9 @@
+|ewc| adds Workflow Designer (a graphical tool for workflow creation/editing), RBAC and LDAP to
+|st2|. It is deployed as a set of additional packages on top of |st2|. You will need an active
+|ewc| subscription, and a license key to access |ewc| repositories. 
+
+To learn more about |ewc|, request a quote, or get an evaluation license go to
+`stackstorm.com/product <https://stackstorm.com/features/#ewc/>`_.
+
+To install |ewc|, replace ``${EWC_LICENSE_KEY}`` in the command below with the key you received
+when registering or purchasing, and run these commands:

--- a/docs/source/install/common/verify.rst
+++ b/docs/source/install/common/verify.rst
@@ -32,4 +32,4 @@ At this point you have a minimal working installation, and can happily play with
 packs from `StackStorm Exchange <https://exchange.stackstorm.org>`__.
 
 But there is no joy without a Web UI, no security without SSL or authentication, no fun without
-ChatOps, and no money without |bwc|. Read on!
+ChatOps, and no money without |ewc|. Read on!

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -213,10 +213,10 @@ A Note on Security
 
 .. include:: common/security_notes.rst
 
-Upgrade to |bwc|
+Upgrade to |ewc|
 ----------------
 
-.. include:: common/bwc_intro.rst
+.. include:: common/ewc_intro.rst
 
 .. code-block:: bash
 

--- a/docs/source/install/ewc.rst
+++ b/docs/source/install/ewc.rst
@@ -1,21 +1,21 @@
-Installing |bwc|
+Installing |ewc|
 ================
 
 StackStorm is an event-driven DevOps automation platform with all the essential features suitable
 for small businesses and teams. It’s free and open source under the Apache 2.0 license.
 
-|bwc| (EWC) is the commercial version of the StackStorm automation platform. EWC adds priority
+|ewc| (EWC) is the commercial version of the StackStorm automation platform. EWC adds priority
 support, advanced features such as fine-tuned access control, LDAP, and Workflow Designer. To
-learn more about |bwc|, get an evaluation license, or request a quote, visit `extremenetworks.com/product/workflow-composer
-<https://www.extremenetworks.com/product/workflow-composer/>`_.
+learn more about |ewc|, get an evaluation license, or request a quote, visit `stackstorm.com/features/#ewc
+<https://stackstorm.com/features/#ewc>`_.
 
-You can also add Network Automation Suites on top of an |bwc| system. See
+You can also add Network Automation Suites on top of an |ewc| system. See
 `ewc-docs.extremenetworks.com/solutions/overview.html <https://ewc-docs.extremenetworks.com/solutions/overview.html>`_
 to learn more.
 
 Quick Evaluation
 ----------------
-To install |bwc| for a quick evaluation, run the commands below on a clean 64-bit Linux box that
+To install |ewc| for a quick evaluation, run the commands below on a clean 64-bit Linux box that
 meets the :doc:`/install/system_requirements`. Replace ``${EWC_LICENSE_KEY}`` with the key you
 received when registering for evaluation or purchasing EWC.
 
@@ -26,8 +26,8 @@ received when registering for evaluation or purchasing EWC.
 
 Upgrading from Community
 ------------------------
-Already have a working StackStorm system, and want to add |bwc|? No problem! No need to install a
-new system. You can install |bwc| on top of your existing system. Just run these commands, again
+Already have a working StackStorm system, and want to add |ewc|? No problem! No need to install a
+new system. You can install |ewc| on top of your existing system. Just run these commands, again
 replacing ``${EWC_LICENSE_KEY}`` with the license key you received when registering:
 
 * On Ubuntu systems:
@@ -49,14 +49,14 @@ replacing ``${EWC_LICENSE_KEY}`` with the license key you received when register
     # Install Extreme Workflow Composer
     sudo yum install -y bwc-enterprise
 
-To understand the full details of the installation procedure, or to install |bwc| manually, follow
+To understand the full details of the installation procedure, or to install |ewc| manually, follow
 the installation guide for your Linux version: :doc:`/install/deb`, :doc:`/install/rhel7`, or
-:doc:`/install/rhel6`. It will walk you through installing and configuring StackStorm and |bwc|.
-The last step of the instructions is "Upgrade to |bwc|".
+:doc:`/install/rhel6`. It will walk you through installing and configuring StackStorm and |ewc|.
+The last step of the instructions is "Upgrade to |ewc|".
 
 High Availability deployment
 ----------------------------
-Using |bwc| in production and need better safety for all important operations you delegate to automation engine?
+Using |ewc| in production and need better safety for all important operations you delegate to automation engine?
 StackStorm was built with High Availability in mind - check out :ref:`StackStorm Enterprise HA in Kubernetes <ref-ewc-ha>` for  deployment blueprint.
 
 .. only:: community

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -35,10 +35,10 @@ Here's an overview of the options:
 
 Choose the option that best suits your needs.
 
-Upgrading to |bwc|? This is installed as a set of additional packages on top of StackStorm. You
-can either install StackStorm + |bwc| in one go, or add the |bwc| packages to an existing
-StackStorm system. If you are using |bwc|, you can also add Network Automation Suites.
-Read the :doc:`/install/bwc` documentation for more.
+Upgrading to |ewc|? This is installed as a set of additional packages on top of StackStorm. You
+can either install StackStorm + |ewc| in one go, or add the |ewc| packages to an existing
+StackStorm system. If you are using |ewc|, you can also add Network Automation Suites.
+Read the :doc:`/install/ewc` documentation for more.
 
 .. _ref-one-line-install:
 
@@ -96,7 +96,7 @@ For more details on reference deployments, or OS-specific installation instructi
     Kubernetes / HA <k8s_ha>
     Ansible Playbooks <ansible>
     Puppet Module <puppet>
-    Extreme Workflow Composer <bwc>
+    Extreme Workflow Composer <ewc>
     config/index
     upgrades
     uninstall

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -101,7 +101,7 @@ ________________
 Installation
 ~~~~~~~~~~~~
 By default, StackStorm Community free and open-source version is deployed via Helm chart.
-If you want to install :doc:`StackStorm Enterprise (Extreme Workflow Composer) </install/bwc>`, run:
+If you want to install :doc:`StackStorm Enterprise (Extreme Workflow Composer) </install/ewc>`, run:
 
 .. code-block:: bash
 

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -93,7 +93,7 @@ The required dependencies are RabbitMQ, MongoDB, and PostgreSQL. The optional de
 
   - nginx for SSL termination, reverse-proxying API endpoints and serving static HTML.
   - Redis or Zookeeper for concurrency policies (see :doc:`/reference/policies`).
-  - LDAP for |bwc| LDAP authentication.
+  - LDAP for |ewc| LDAP authentication.
 
 
 Multi-box/HA deployment

--- a/docs/source/install/rhel6.rst
+++ b/docs/source/install/rhel6.rst
@@ -284,10 +284,10 @@ A Note on Security
 
 .. include:: common/security_notes.rst
 
-Upgrade to |bwc|
+Upgrade to |ewc|
 ----------------
 
-.. include:: common/bwc_intro.rst
+.. include:: common/ewc_intro.rst
 
 .. code-block:: bash
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -271,10 +271,10 @@ A Note on Security
 
 .. include:: common/security_notes.rst
 
-Upgrade to |bwc|
+Upgrade to |ewc|
 ----------------
 
-.. include:: common/bwc_intro.rst
+.. include:: common/ewc_intro.rst
 
 .. code-block:: bash
 

--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -82,7 +82,7 @@ below. Only execute the instructions for your distribution.
 
     sudo apt-get purge st2 st2mistral st2chatops st2web
 
-  If you have |bwc| installed, instead use:
+  If you have |ewc| installed, instead use:
 
   .. sourcecode:: bash
 
@@ -97,7 +97,7 @@ below. Only execute the instructions for your distribution.
 
     sudo yum erase st2 st2mistral st2chatops st2web st2python
 
-  If you have |bwc| installed, instead use: 
+  If you have |ewc| installed, instead use: 
 
   .. sourcecode:: bash
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -241,13 +241,13 @@ v2.4
      sudo rpm -e --nodeps npm
      sudo yum upgrade st2chatops
 
-* |bwc| users on RHEL or CentOS must run this command after upgrading packages:
+* |ewc| users on RHEL or CentOS must run this command after upgrading packages:
 
   .. sourcecode:: bash
 
      sudo /opt/stackstorm/st2/bin/pip install --find-links /opt/stackstorm/share/wheels --no-index --quiet --upgrade st2-enterprise-auth-backend-ldap
 
-This is a known issue, and will be resolved in a future release. This only applies to |bwc| users.
+This is a known issue, and will be resolved in a future release. This only applies to |ewc| users.
 It is not required for those using Open Source StackStorm.
 
 v2.2

--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -3,8 +3,8 @@ Role Based Access Control
 
 .. note::
 
-   Role Based Access Control (RBAC) is only available in |bwc|. For information
-   about |bwc| and the differences between StackStorm and |bwc|, please see
+   Role Based Access Control (RBAC) is only available in |ewc|. For information
+   about |ewc| and the differences between StackStorm and |ewc|, please see
    `stackstorm.com/product <https://stackstorm.com/product/#enterprise>`_.
 
 Role Based Access Control (RBAC) allows system administrators to restrict users' access and limit
@@ -230,10 +230,10 @@ There are some exceptions, described below:
 Enabling RBAC
 -------------
 
-If you installed |bwc| using the :doc:`one-line install </install/bwc>`, RBAC will be automatically
+If you installed |ewc| using the :doc:`one-line install </install/ewc>`, RBAC will be automatically
 enabled. It will assign the ``admin`` role to ``stanley`` and ``st2admin``. 
 
-If you installed |bwc| separately, by installing the ``bwc-enterprise`` package on top of |st2|, you
+If you installed |ewc| separately, by installing the ``bwc-enterprise`` package on top of |st2|, you
 will need to manually enable RBAC, and assign ``admin`` privileges to ``stanley``. It is not
 enabled by default. To enable it, add this section to ``/etc/st2/st2.conf``:
 

--- a/docs/source/troubleshooting/basic_chatops_troubleshooting.rst
+++ b/docs/source/troubleshooting/basic_chatops_troubleshooting.rst
@@ -14,10 +14,10 @@ Troubleshooting Using Hubot Self-check Script:
 ----------------------------------------------
 
 We have a `self-check script <https://github.com/StackStorm/st2chatops/blob/master/scripts/self-check.sh>`_ 
-to help you debug ChatOps issues in StackStorm 1.5 and above.
+to help you debug ChatOps issues.
 
-Just copy the script and run it on your server. It will run a few essential tests that will provide you basic troubleshooting steps in
-case of a failure.
+Just copy the script and run it on your server. It will run a few essential tests that will provide
+you basic troubleshooting steps in case of a failure.
 
 -----------------------------
 Manual Troubleshooting Steps:
@@ -111,12 +111,16 @@ either throws an error, or gives an acknowledgement message without result, or n
      fails with an unexpected error that the bot can't process. This can be checked in 
      StackStorm execution history through CLI or Web UI.
 
-4. Gives an acknowledgement message, then an error:
+4. Result message is delayed:
+     Seeing really long delays with your result messages? Check that all services are running
+     correctly, especially ``st2rulesengine`` and ``st2scheduler``.
+     
+5. Gives an acknowledgement message, then an error:
      If the default commands (like ``!st2 list actions``) run fine, but your own
      aliases throw errors, the format of your alias or the underlying action is most
      likely the problem. Debug according to the error.
 
-5.  Bonus: have you tried turning StackStorm off and on again?
+6.  Bonus: have you tried turning StackStorm off and on again?
      ``sudo st2ctl restart`` or ``sudo st2ctl reload --register-all`` sometimes seem to 
      magically fix problems, often quite unexpectedly. Restarting just the
      ``st2chatops`` service also works sometimes: ``sudo service st2chatops restart``.


### PR DESCRIPTION
A few things going on here:

1/ Improve the ChatOps docs. A few small fixes, and more content around initial setup, attempting to remove some confusion.
2/ Change use of `|bwc|` shortcode to use `|ewc|`. No effect on rendered docs.
3/ Move `/install/bwc.html` doc to `/install/ewc.html`, **and** make sure we have a redirect for old link.

Note: ewcdocs CircleCI job will fail until related PR in github.com/StackStorm/ipfabric-docs is created & merged. That PR will also have failing CI until this PR is merged...