### PR TITLE
Small improvements to authentication & virtualenv notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ docs/source/orquesta/context.rst
 docs/source/orquesta/yaql.rst
 docs/source/orquesta/jinja.rst
 docs/source/orquesta/languages
+
+# Local Sphinx build output
+.doctrees

--- a/docs/source/__auth_usage.rst
+++ b/docs/source/__auth_usage.rst
@@ -1,6 +1,26 @@
-To acquire a new token via the CLI, run the ``st2 auth`` command.  If password is not provided,
-then ``st2 auth`` will prompt for the password. If successful, a token is returned in the
-response:
+To use the CLI, use the ``st2 login`` command. If you do not provide a password, it will prompt for
+the password:
+
+.. code-block:: bash
+
+    # without password
+    st2 login yourusename
+    Password:
+
+    # with password
+    st2 login yourusername -p 'yourpassword'
+
+    # write password to config file
+    st2 login -w yourusername -p 'yourpassword'
+
+.. note::
+
+    If your password contains special characters such as ``$``, they may be interpreted by the shell.
+    Wrap your password in single quotes (``'``) as above.
+
+If you need to acquire a token - for example to use with an API call, use the ``st2 auth`` command.
+If a password is not provided, it will prompt for the password. If successful, a token is returned
+in the response:
 
 .. code-block:: bash
 
@@ -10,11 +30,6 @@ response:
     # without password
     st2 auth yourusename
     Password:
-
-.. note::
-
-    If your password contains special characters such as ``$``, they may be interpreted by the shell.
-    Wrap your password in single quotes (``'``) as above.
 
 The following is a sample API call via ``curl`` using that token:
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -254,8 +254,9 @@ Run the following ``curl`` commands to test:
 Usage
 -----
 
-Once st2auth is enabled, API calls require the token to be passed via the headers. CLI calls
-require the token to be included as a CLI argument or as an environment variable.
+Once authentication is enabled, API calls require a token to be passed via the headers. CLI calls
+require the token to be included as a CLI argument or as an environment variable. Using ``st2 login``
+will simplify logging in, getting a token, and automatically adding it to the environment.
 
 .. include:: __auth_usage.rst
 

--- a/docs/source/install/common/configure_authentication.rst
+++ b/docs/source/install/common/configure_authentication.rst
@@ -15,17 +15,13 @@
 
     sudo st2ctl restart-component st2api
 
-* Authenticate, set the token environment variable, and check that it works:
+* Authenticate, and check that it works:
 
   .. code-block:: bash
 
-    # Get an auth token to use in CLI or API
-    st2 auth st2admin
-
-    # A shortcut to authenticate and export the token
-    export ST2_AUTH_TOKEN=$(st2 auth st2admin -p 'Ch@ngeMe' -t)
+    # Login - you will be prompted for password (default 'Ch@ngeMe')
+    st2 login st2admin
 
     # Check that it works
     st2 action list
 
-Check out the :doc:`/reference/cli` to learn other convenient ways to authenticate via CLI.

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -120,8 +120,8 @@ Finally, you can install a pack from existing local dir:
 
 .. code-block:: bash
 
-    # Install a pack from '/tmp/bitcoin' dir
-    st2 pack install file:///tmp/bitcoin
+    # Install a pack from '/home/stanley/bitcoin' dir
+    st2 pack install file:///home/stanley/bitcoin
 
 
 Running ``st2 pack install`` on an already installed pack will **replace** it with the requested
@@ -199,7 +199,7 @@ you work with configuration management or have a very specific deployment workfl
 Packs are placed in the system pack directory - by default ``/opt/stackstorm/packs``. A
 ``virtualenv`` needs to be created for each pack containing Python actions/sensors under
 ``/opt/stackstorm/virtualenv``. Python dependencies are installed inside the virtualenv with
-``pip -r requirements.txt``. Normally this is done automatically for you at pack install time.
+``pip -r requirements.txt``. If you use ``st2 pack install``, this is handled automatically for you.
 
 When |st2| loads the content, it looks into the system packs directory (``/opt/stackstorm/packs``)
 and any additional directories listed in ``packs_base_paths`` in ``st2.conf``
@@ -220,12 +220,12 @@ a schema defined in ``/opt/stackstorm/packs/<pack_dir>/config.schema.yaml``. See
 
 When the pack content changes, it has to be registered again (reloaded). To register individual
 packs, use ``st2 pack register --packs=pack1,pack2``. To register everything at once, use
-``st2ctl reload`` (run it with ``-h`` to explore the fine-tuning flags).
+``sudo st2ctl reload``. Use ``-h`` to explore the fine-tuning flags.
 
 Installing Packs from Private Repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you're installing a pack from a private repository on GitHub, you can use HTTPS auth
+If you are installing a pack from a private repository on GitHub, you can use HTTPS authentication
 with a `personal access token 
 <https://help.github.com/articles/creating-an-access-token-for-command-line-use/>`__,
 or create a `deploy key <https://github.com/blog/2024-read-only-deploy-keys>`__ to use SSH.
@@ -236,17 +236,16 @@ Access tokens are used with HTTPS URLs, for example:
 
    $ st2 pack install https://<user>:<token>@github.com/username/repo.git
 
-Be advised that your token will be logged in StackStorm, git, your shell history, and probably
-some other log files, including git error logs if anything fails. Using SSH auth is a much better
-idea most of the time.
+Your token will be logged in |st2|, git, your shell history, and probably other log files, including
+git error logs. Using SSH authentication is usually a better choice.
 
-For SSH (URLs starting with ``git@``) auth you have to create a `deploy key
-<https://github.com/blog/2024-read-only-deploy-keys>`__, and require the system user running the
-command (usually root, depending on your configuration) to have a private key. Deploy keys are
-more secure than personal access tokens and can be configured on a per-repo basis.
+For SSH (URLs starting with ``git@``) authentication you have to create a `deploy key
+<https://github.com/blog/2024-read-only-deploy-keys>`__. Note that pack installation is run as
+``root`` by default. |st2| will use root's SSH configuration and private keys. Use
+``~root/.ssh/config`` to configure a Git-specific private key if you do not want to use root's
+default private key. 
 
-Other git hosting services should also support either SSH or HTTPS auth, and would be configured
-in a similar fashion.
+Deploy keys are more secure than personal access tokens and can be configured on a per-repo basis.
 
 Using Python 3 for Pack Python Virtual Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -587,8 +587,7 @@ Once this user is created |st2| will allow access to this user. (Optional) To va
 
 .. sourcecode:: bash
 
-    $ st2 auth rbac_user1 -p '<RBACU1_PASSWORD>'
-    $ export ST2_AUTH_TOKEN=<USER_SCOPED_AUTH_TOKEN>
+    $ st2 login rbac_user1 -p '<RBACU1_PASSWORD>'
     $ st2 action list
 
 Role Creation
@@ -671,8 +670,7 @@ Lets take this for a spin using the |st2| CLI.
 
   .. sourcecode:: bash
 
-    $ st2 auth rbac_user1 -p '<RBACU1_PASSWORD>'
-    $ export ST2_AUTH_TOKEN=<USER_SCOPED_AUTH_TOKEN>
+    $ st2 login rbac_user1 -p '<RBACU1_PASSWORD>'
     $ st2 action list
 
 2. Validate rule visibility and creation:

--- a/docs/source/reference/packs.rst
+++ b/docs/source/reference/packs.rst
@@ -36,9 +36,9 @@ At the topmost level are the main folders ``actions``, ``rules``, ``sensors``, `
 
 * ``pack.yaml`` - Metadata file that describes and identifies the folder as a pack.
 * ``config.schema.yaml`` - Schema that defines configuration elements used by a pack.
-* ``requirements.txt`` - File containing a list of Python dependencies. If your pack uses Python
-  actions and/or sensors, you can specify any Python libraries you need here. They will
-  automatically be installed in a pack-specific virtualenv when you install the pack.
+* ``requirements.txt`` - File containing a list of Python dependencies. Each pack has its own Python
+  virtualenv. If you need any specific Python libraries, specify them here, and they will be
+  automatically installed at pack install time.
 
 Site-specific pack configuration files are stored at ``/opt/stackstorm/configs/``. See
 :doc:`configuration schema</reference/pack_configs>` for more information.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -18,10 +18,9 @@ The best way to explore |st2| is to use the CLI. Start by running a few commands
     # Get help. It's a lot. Explore.
     st2 -h
 
-    # Authenticate and export the token. Make sure ST2_AUTH_URL and
-    # ST2_API_URL are set correctly (http vs https, endpoint, and etc).
-    # Replace the username and password in the example below appropriately.
-    export ST2_AUTH_TOKEN=`st2 auth -t -p 'Ch@ngeMe' st2admin`
+    # Login - add "-w" to save the password if you like
+    # st2admin/Ch@ngeMe is the default username & password. Replace if needed
+    st2 login st2admin -p 'Ch@ngeMe'
 
     # List the actions from the 'core' pack
     st2 action list --pack=core


### PR DESCRIPTION
Encourage use of `st2 login` over `st2 auth`, and small tweaks to wording around virtualenvs & packs.