### PR TITLE
Remove a slash before $PWD since it already starts with a slash

### DIFF
--- a/docs/source/reference/packs.rst
+++ b/docs/source/reference/packs.rst
@@ -231,7 +231,7 @@ available at :github_st2:`st2/contrib/hello_st2 <contrib/hello_st2>`.
     cd hello_st2
     git init && git add ./* && git commit -m "Initial commit"
     # Install from local git repo
-    st2 pack install file:///$PWD
+    st2 pack install file://$PWD
 
   When you make code changes, ``run st2 pack install`` again: it will do the upgrade.
   Once you push it to GitHub, you will install and update it right from there:


### PR DESCRIPTION
We consistently have users using three slashes in the protocol part of the URL when running `st2 pack install file://$PWD`. This is because our documentation has three slashes. This fixes that.

This is an issue because three slashes expands to:

```bash
st2 pack install file:////directory/to/pack
```

due to the value of `$PWD` starting with a slash.

The filepath part of that is then `//directory/path/to/pack`, and filenames that start with two slashes [are "interpreted in an implementation-defined manner"](https://unix.stackexchange.com/a/12284), which can sometimes mean a remote directory (Samba or NFS share).

Removing a slash makes the command expand to:

```bash
st2 pack install file:///directory/to/pack
```

and the filepath part of that is then `/directory/to/path`, which is intended.

To further confuse things, [more than two starting slashes is interpreted simply as one slash](https://unix.stackexchange.com/a/12284):

```bash
////////////sooooo/many/slashes  ->  /sooooo/many/slashes
```

and [multiple slashes that don't start a filepath are also interpreted as single slashes](https://unix.stackexchange.com/a/11965):

```bash
/many/////////slashes//in/the/middle  ->  /many/slashes/in/the/middle
```

So yeah, let's fix this to remove a potential source of error/confusion.

Edit: Clarified `$PWD` format.