### PR TITLE
Patch and unpatch docker and puppet install docs for ewc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	cp -R ipfabric/docs/source/* docs/source/
 	rm docs/source/_includes/community_only_installs_overview.rst
 	touch docs/source/_includes/community_only_installs_overview.rst
+	rm docs/source/install/puppet_chef_salt_ansible.rst
 	rm docs/source/install/docker.rst
 	rm docs/source/install/puppet.rst
 
@@ -129,6 +130,7 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	git checkout docs/source/_includes/solutions.rst
 	git checkout docs/source/_includes/community_only_installs_overview.rst
 	git checkout docs/source/_includes/community_only_installs_toctree.rst
+	git checkout docs/source/install/puppet_chef_salt_ansible.rst
 	git checkout docs/source/install/docker.rst
 	git checkout docs/source/install/puppet.rst
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,8 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	@echo "=========================================================="
 	@echo
 	cp -R ipfabric/docs/source/* docs/source/
+	rm docs/source/_includes/community_only_installs_overview.rst
+	touch docs/source/_includes/community_only_installs_overview.rst
 	rm docs/source/install/docker.rst
 	rm docs/source/install/puppet.rst
 

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	@echo
 	git checkout docs/source/info.py
 	git checkout docs/source/_includes/solutions.rst
+	git checkout docs/source/_includes/community_only_installs_overview.rst
 	git checkout docs/source/_includes/community_only_installs_toctree.rst
 	git checkout docs/source/install/docker.rst
 	git checkout docs/source/install/puppet.rst

--- a/Makefile
+++ b/Makefile
@@ -109,20 +109,27 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 .patch-solutions:
 	@echo
 	@echo "=========================================================="
-	@echo "                     PATCHING BWC DOCS"
+	@echo "                     PATCHING EWC DOCS"
 	@echo "=========================================================="
 	@echo
 	cp -R ipfabric/docs/source/* docs/source/
+	rm docs/source/install/docker.rst
+	rm docs/source/install/puppet.rst
+	rm docs/source/install/vagrant.rst
 
 .PHONY: .git-checkout-local-changes
 .git-checkout-local-changes:
 	@echo
 	@echo "=========================================================="
-	@echo "                     UNPATCHING BWC DOCS"
+	@echo "                     UNPATCHING EWC DOCS"
 	@echo "=========================================================="
 	@echo
 	git checkout docs/source/info.py
 	git checkout docs/source/_includes/solutions.rst
+	git checkout docs/source/_includes/community_only_installs_toctree.rst
+	git checkout docs/source/install/docker.rst
+	git checkout docs/source/install/puppet.rst
+	git checkout docs/source/install/vagrant.rst
 
 .PHONY: bwclivedocs
 bwclivedocs: ewcdocs .livedocs

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,6 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	cp -R ipfabric/docs/source/* docs/source/
 	rm docs/source/install/docker.rst
 	rm docs/source/install/puppet.rst
-	rm docs/source/install/vagrant.rst
 
 .PHONY: .git-checkout-local-changes
 .git-checkout-local-changes:
@@ -129,7 +128,6 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	git checkout docs/source/_includes/community_only_installs_toctree.rst
 	git checkout docs/source/install/docker.rst
 	git checkout docs/source/install/puppet.rst
-	git checkout docs/source/install/vagrant.rst
 
 .PHONY: bwclivedocs
 bwclivedocs: ewcdocs .livedocs

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -217,3 +217,4 @@ code.
     Code Structure <code_structure>
     testing
     Pack Testing <pack_testing>
+    Vagrant Development Environment </install/vagrant>


### PR DESCRIPTION
Add steps to remove docker.rst, puppet.rst, and vagrant.rst in the ewc patching section of Makefile. Add steps to restore these files in the ewc unpatching section of Makefile.