### PR TITLE
Rollback temporary patch to replace community_only_installs_overview.rst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,6 @@ ewcdocs: .clone-st2 .clone-orquesta .clone-ipfabric requirements .requirements-s
 	@echo "=========================================================="
 	@echo
 	cp -R ipfabric/docs/source/* docs/source/
-	rm docs/source/_includes/community_only_installs_overview.rst
-	touch docs/source/_includes/community_only_installs_overview.rst
 	rm docs/source/install/puppet_chef_salt_ansible.rst
 	rm docs/source/install/docker.rst
 	rm docs/source/install/puppet.rst


### PR DESCRIPTION
Rollback temporary patch to replace community_only_installs_overview.rst with an empty file for enterprise docs. This temporary patch was needed to fix st2docs and unblock the fix at ipfabric_docs.