### PR TITLE
Fixed metrics config so that it actually works when you copy/paste from it

### DIFF
--- a/docs/source/reference/metrics.rst
+++ b/docs/source/reference/metrics.rst
@@ -28,8 +28,11 @@ Right now, the only supported driver is ``statsd``. To configure it, add the fol
     # "production" and key is "action.executions" actual key would be
     # "st2.production.action.executions". This comes handy when you want to
     # utilize the same backend instance for multiple environments or similar.
-    host = 127.0.0.1  # statsd collection and aggregation server address
-    port = 8125  # statsd collection and aggregation server port
+    
+    # statsd collection and aggregation server address
+    host = 127.0.0.1
+    # statsd collection and aggregation server port
+    port = 8125
 
 After you have configured it, you need to restart all the services using ``st2ctl restart``.
 
@@ -40,6 +43,9 @@ outgoing access to the configured host and port.
 For debugging and troubleshooting purposes, you can also set driver to ``echo``. This will cause
 |st2| to log under ``DEBUG`` log level any metrics operation which would have otherwise be performed
 (increasing a counter, timing an operation, etc.) without actually performing it.
+
+For a full list of config options, see the ``[metrics]`` section in the |st2| sample
+config here: https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample
 
 Configuring StatsD
 ==================


### PR DESCRIPTION
I tried copy/pasting the config from the Metrics docs and when i started the StackStorm services i received the following error: 

```
[2019-05-06 08:49:54 +0000] [14483] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/workers/geventlet.py", line 102, in init_process
    super(EventletWorker, self).init_process()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2api/wsgi.py", line 25, in <module>
    application = app.setup_app(config)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2api/app.py", line 65, in setup_app
    config_args=config.get('config_args', None))
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/service_setup.py", line 181, in setup
    metrics_initialize()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/metrics/base.py", line 224, in metrics_initialize
    METRICS = get_plugin_instance(PLUGIN_NAMESPACE, cfg.CONF.metrics.driver)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/util/loader.py", line 215, in get_plugin_instance
    manager = DriverManager(namespace=namespace, name=name, invoke_on_load=invoke_on_load)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/stevedore/driver.py", line 61, in __init__
    warn_on_missing_entrypoint=warn_on_missing_entrypoint
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/stevedore/named.py", line 81, in __init__
    verify_requirements)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/stevedore/extension.py", line 203, in _load_plugins
    self._on_load_failure_callback(self, ep, err)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/stevedore/extension.py", line 195, in _load_plugins
    verify_requirements,
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/stevedore/named.py", line 158, in _load_one_plugin
    verify_requirements,
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/stevedore/extension.py", line 227, in _load_one_plugin
    obj = plugin(*invoke_args, **invoke_kwds)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/metrics/drivers/statsd_driver.py", line 58, in __init__
    statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port,
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/oslo_config/cfg.py", line 2547, in __getattr__
    return self._conf._get(name, self._group)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/oslo_config/cfg.py", line 2264, in _get
    value = self._do_get(name, group, namespace)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/oslo_config/cfg.py", line 2307, in _do_get
    % (opt.name, str(ve)))
ConfigFileValueError: Value for option port is not valid: invalid literal for int() with base 10: '8125  # statsd collection and aggregation server port'
```

By simply putting the comments in the config on their own line instead of on the same line as the key/values this fixes the problem and allows the services to start up.