### PR TITLE
Fix HA docs build failure caused by updated nginx config in st2 repo

### DIFF
--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -421,7 +421,7 @@ Install Required Dependencies
     ``st2auth`` and ``mistral-api``. Nginx also serves as the webserver for ``st2web``.
 
   .. literalinclude:: /../../st2/conf/HA/nginx/st2.conf.controller.sample
-     :language: nginx
+     :language: none
 
 11. Create the st2 logs directory and the st2 user:
 


### PR DESCRIPTION
A follow-up to https://github.com/StackStorm/st2/pull/4673 which changed HA `nginx` config samples that broke `st2docs` build: https://circleci.com/gh/StackStorm/st2docs/1973
```
Warning, treated as error:
/home/circleci/project/docs/source/reference/ha.rst:423:Could not lex literal_block as "nginx". Highlighting skipped.
Makefile:65: recipe for target '.community-docs' failed
make: *** [.community-docs] Error 2
Exited with code 2
```

Caused by the following block in nginx conf https://github.com/StackStorm/st2/pull/4673/files#diff-28aca2ba0b7e5f1549f65890e1d534d9R53:
```nginx
  location @apiError {
    add_header Content-Type application/json always;
    return 503 '{ "faultstring": "Nginx is unable to reach st2api. Make sure service is running." }';
  }
```
which `Pygments` can't parse correctly due to `{` present in `return` message (confused with nginx blocks).

Switch to `:language: none` with no highlighting for this specific case since nginx highlighter doesn't threat correctly new included config.