### PR TITLE
Remove released feature from up coming list

### DIFF
--- a/docs/source/orquesta/upcoming.rst
+++ b/docs/source/orquesta/upcoming.rst
@@ -4,8 +4,5 @@ Upcoming Features
 .. note::
    The following are features that are work in progress and will be available in a future release.
 
-* With items in workflow definition
 * Task retry in workflow definition
 * Re-run workflow execution at specific task(s)
-* ``notify`` support (like ``skip_notify``, but opt-in rather than opt-out)
-* Mistral workflow migration utility


### PR DESCRIPTION
For task with items in Orquesta workflows has been released in st2 2.10.0.  Remove it from up coming list.