### PR TITLE
Revert "fix type in YAQL expression"

### DIFF
--- a/docs/source/orquesta/start.rst
+++ b/docs/source/orquesta/start.rst
@@ -147,7 +147,7 @@ workflow definition, and other information specific to the error type.
           spec_path: tasks.task1.input
           type: yaql
         expressions:
-        - expression: <% succeeded() %>
+        - expression: <% <% succeeded() %>
           message: 'Parse error: unexpected ''<'' at position 0 of expression ''<% succeeded()'''
           schema_path: properties.tasks.patternProperties.^\w+$.properties.next.items.properties.when
           spec_path: tasks.task2.next[0].when


### PR DESCRIPTION
We actually intentionally want to keep that invalid YAQL as an example of
Orquesta's inspection capabilities.

This reverts commit 541918b0f5d94fcb8ccaf050ced46bf2da8396f1.