### PR TITLE
[3.0] Fix HA docs build failure caused by updated nginx config in st2 repo

### DIFF
--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -421,7 +421,7 @@ Install Required Dependencies
     ``st2auth`` and ``mistral-api``. Nginx also serves as the webserver for ``st2web``.
 
   .. literalinclude:: /../../st2/conf/HA/nginx/st2.conf.controller.sample
-     :language: nginx
+     :language: none
 
 11. Create the st2 logs directory and the st2 user:
 


### PR DESCRIPTION
Switch to ':language: none' since nginx highlighter doesn't threat correctly nginx config

Same as #900, but for 3.0 branch