### PR TITLE
[3.0] Remove support@stackstorm references

### DIFF
--- a/docs/source/__engage_community.rst
+++ b/docs/source/__engage_community.rst
@@ -2,4 +2,3 @@
 
 * `Support Forum <https://forum.stackstorm.com/>`_
 * Slack community channel: `stackstorm-community.slack.com <https://stackstorm-community.slack.com>`__ (Register `here <https://stackstorm.com/community-signup>`__)
-* Support: support@stackstorm.com

--- a/docs/source/troubleshooting/ask_for_support.rst
+++ b/docs/source/troubleshooting/ask_for_support.rst
@@ -10,7 +10,6 @@ channels:
 * `Slack <https://stackstorm-community.slack.com>`_: If you're not a Slacker yet, here's a good
   excuse to become one! Come hang out, chat to us, search the archives to see if anyone else has
   faced the same problem. Register `here <https://stackstorm.com/community-signup>`_.
-* `Email support <support@stackstorm.com/>`_ and we'll get back to you as soon as we can.
 
 Please have the following list ready so we can help you faster:
 


### PR DESCRIPTION
Same as #909, for 3.0 branch