### PR TITLE
Various improvements and cleanups

### DIFF
--- a/docs/source/_redirects/proxy.html
+++ b/docs/source/_redirects/proxy.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-<meta http-equiv="Refresh" content="0; url=reference/proxy.html" />
+<meta http-equiv="Refresh" content="0; url=packs.html#installing-packs-from-behind-a-proxy" />
 </head>
 <body>
-<p>This page has moved to <a href="reference/proxy.html">here</a>.</p>
+<p>This page has moved to <a href="packs.html#installing-packs-from-behind-a-proxy">here</a>.</p>
 </body>
 </html>

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -225,7 +225,7 @@ The example above applies to a scenario where you have two related workflows and
 
 If you have two independent workflows and you want to pass data between them or use data from one
 workflow in another, the most common approach to that is using the built-in key-value
-:doc:`datastore`<datastore>`.
+:doc:`datastore <datastore>`.
 
 Inside the first workflow you store data in the datastore and inside the second workflow you retrieve
 this data from a datastore. This approach creates tighter coupling between two workflows and makes

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -145,6 +145,9 @@ the `examples` pack shows a complete working example of using ``vars`` and ``pub
    :language: yaml
    :lines: 1-29
 
+These published variables could also be used to pass data between workflows. See below for more information
+about passing data between workflows.
+
 Passing Data between Tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -205,6 +205,15 @@ In the example above, the ``to_number`` parameter contains the attribute ``secre
 ``true``. If an attribute is marked as a secret, the value of that attribute will be masked in the
 |st2| service logs.
 
+.. tip::
+
+  Does your parameter only accept certain values? Use ``enum:`` with a list of allowed values. When the
+  action is executed, it will only allow those specific values. And the in Web UI, it will be rendered
+  as a drop-down list. 
+
+  See the `examples.weather <https://github.com/StackStorm/st2/blob/master/contrib/examples/actions/weather.yaml#L16>`_
+  action in the examples pack for how to use this.
+
 
 Output Schema
 ~~~~~~~~~~~~~

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -123,9 +123,9 @@ the following runners:
 
 
 Runners come with their own set of input parameters. When an action is executed, it inherits the
-runner parameters, in addition to its own parameters.
+runner parameters, in addition to its own parameters. The built-in parameters can be over-ridden on a per-action basis.
 
-For a complete list of Runners and their parameters, see :doc:`/reference/runners`
+For a complete list of Runners and their parameters, see :doc:`/reference/runners`.
 
 
 .. _ref-actions-writing-custom:
@@ -346,9 +346,13 @@ To reload all actions, use ``st2ctl reload --register-actions``
 Built-in Parameters
 -------------------
 
-When configuring the metadata, there are several built-in parameters that can be used and
-overwritten to change the default functionality of the various runners:
+Action runners have their own built-in parameters. These are inherited by the action, and be over-ridden either
+in the action metadata, or by passing additional parameters when running the action.
 
+Some common parameters include:
+
+* ``timeout`` - (all runners) The default timeout varies by runner type. This is frequently over-ridden
+  for long-running actions.
 * ``args`` - (``local-shell-script``, ``remote-shell-script``) By default, |st2| will assemble
   arguments based on whether a user defines named or positional arguments. Adjusts the format of
   arguments passed to ``cmd``.
@@ -362,6 +366,8 @@ overwritten to change the default functionality of the various runners:
 * ``dir``  - (``local-shell-script``, ``remote-shell-script``) Configure the directory where
   scripts are copied from a pack to the target machine prior to execution.
   Defaults to ``/tmp``.
+
+For a full list of built-in parameters for each runner type, see :doc:`/reference/runners`.
 
 Overriding Runner Parameters
 ----------------------------

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -82,7 +82,7 @@ know).
 Configuration
 =============
 
-.. note:: Microsoft Teams
+.. note::
 
     Configuring st2chatops with Microsoft Teams is a more involved process. Please see
     :doc:`our documentation <msteams>` specifically for that chat provider.
@@ -142,6 +142,16 @@ the web UI. To do so, edit the ``webui`` section in ``/etc/st2/st2.conf``. For e
 
     [webui]
     webui_base_url = https://st2web001.stackstorm.net
+
+Chatops Behind a Proxy
+~~~~~~~~~~~~~~~~~~~~~~
+
+If you use proxies in your environment, you may need to configure ``st2chatops`` to use the proxy. If you used
+the scripted installation, this has been done for you. If not, configure either ``/etc/default/st2chatops`` or
+``/etc/sysconfig/st2chatops`` (depending on your Linux distribution), following the same pattern as used for
+configuring :ref:`st2api and st2actionrunner <packs-behind-proxy>`.
+
+Restart ``st2chatops`` after creating that file.
 
 Using an External Adapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -4,6 +4,11 @@ Rules
 |st2| uses rules and workflows to capture operational patterns as automations. Rules map triggers
 to actions (or workflows), apply matching criteria and map trigger payloads to action inputs.
 
+.. note::
+   
+   Rules not working as expected? Check the :doc:`Rules Troubleshooting </troubleshooting/rules>`
+   documentation. This walks through rules testing, checking enforcements, logging and troubleshooting.
+
 Rule Structure
 --------------
 
@@ -865,6 +870,16 @@ Run action every full hour every day of the week
 
   action:
     ...
+
+
+Troubleshooting Rule Enforcements
+---------------------------------
+
+Rules not working as expected? Or just want to see which rules have been enforced? 
+
+Run ``st2 rule-enforcement list`` to see all rule enforcements. You can filter this output by rule to narrow it down.
+
+For further troubleshooting steps, check the :doc:`Rules Troubleshooting </troubleshooting/rules>` documentation.
 
 -------------------------------
 

--- a/docs/source/troubleshooting/purging_old_data.rst
+++ b/docs/source/troubleshooting/purging_old_data.rst
@@ -36,8 +36,11 @@ manual purge scripts below.
 
 The garbage collector service also cleans up old Inquiries by marking them as "timed out".
 Unlike action executions or trigger instances, each Inquiry has its own configured TTL.
-See :doc:`Inquiries </inquiries>` for more information on how to enable garbage collection
-for Inquiries.
+Inquiries garbage collection is enabled by setting ``garbagecollector.purge_inquiries = True``. See
+:doc:`Inquiries </inquiries>` for more information on garbage collection for Inquiries.
+
+Real-time Streaming Action Output garbage collection is enabled **by default**, with an expiry period of 7 days.
+See :doc:`Real-time Action Streaming Output </reference/action_output_streaming>` for more information.
 
 2. Manual Purging Using Purge Scripts
 -------------------------------------


### PR DESCRIPTION
Resolves #418, #402, #678, #560, #556, #693.

Topics include proxy docs, references to built-in parameters, enums, rules troubleshooting, GC.

Additional small fixes to remove double-redirect, and stray chars.