### PR TITLE
Removed outdated advice about alias ordering

### DIFF
--- a/docs/source/chatops/aliases.rst
+++ b/docs/source/chatops/aliases.rst
@@ -205,12 +205,6 @@ The above alias supports the following commands:
     !list sensors from examples limit=2
 
 
-Note: formats are matched in the exact order they are specified in a YAML array, and must be
-ordered from the most specific (first) to the most generic (last).
-``deploy {{ pack }} to {{ host }}`` should come before ``deploy {{ pack }}``, otherwise everything
-after ``deploy`` will always be mapped to ``pack``, ignoring more specific format strings that
-come after.
-
 "Display-representation" Format Objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Did some tests, this doesn't apply any more. Resolves https://github.com/StackStorm/st2docs/issues/586