### PR TITLE
Remove gnupg-curl from Ubuntu18 manual install

### DIFF
--- a/docs/source/install/u18.rst
+++ b/docs/source/install/u18.rst
@@ -30,7 +30,6 @@ Install MongoDB, and RabbitMQ:
 .. code-block:: bash
 
   sudo apt-get update
-  sudo apt-get install -y gnupg-curl
   sudo apt-get install -y curl
 
   # Add key and repo for MongoDB (4.0)


### PR DESCRIPTION
Resolves https://github.com/StackStorm/st2/issues/4725