### PR TITLE
Fix the name of expected s3 object on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,11 @@ jobs:
               aws s3 sync generated-site/ewcdocs/ \
               s3://${EWCDOCS_BUCKET}/latest
             else
+              S3_OBJ=$(echo "${CIRCLE_BRANCH}" | sed 's/^v\(.*\)$/\1/')
               aws s3 sync generated-site/st2docs/ \
-              s3://${ST2DOCS_BUCKET}/${CIRCLE_BRANCH}
+              s3://${ST2DOCS_BUCKET}/${S3_OBJ}
               aws s3 sync generated-site/ewcdocs/ \
-              s3://${EWCDOCS_BUCKET}/${CIRCLE_BRANCH}
+              s3://${EWCDOCS_BUCKET}/${S3_OBJ}
             fi
       - run:
           # Check the install scripts to see if this is the current GA version


### PR DESCRIPTION
The st2 and ewc docs websites are expecting the name of s3 objects (folder) to be the major.minor version number without the "v" prefix. The deploy step in circleci is modified to use sed to extract just the major.minor version from the circleci branch variable and use the result as the name of the s3 objects where the docs are uploaded to.