### PR TITLE
 Make st2 venv and requirements with python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== st2docs virtualenv ===================="
 	@echo
-	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages --python=python3.6 $(VIRTUALENV_DIR)
+	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR)
 
 	# Setup PYTHONPATH in bash activate script...
 	echo '' >> $(VIRTUALENV_DIR)/bin/activate
@@ -240,7 +240,8 @@ PHONY: .requirements-st2
 	@echo
 	@echo "==================== st2 requirements ===================="
 	@echo
-	cd st2; make requirements
+	test -d $(ST2_VIRTUALENV_DIR) || virtualenv --no-site-packages --python=$(PYTHON_VERSION) $(ST2_VIRTUALENV_DIR)
+	cd ./st2; make requirements
 
 .PHONY: docker
 docker: docker-build docker-run

--- a/docs/source/_includes/internal_trigger_types.rst
+++ b/docs/source/_includes/internal_trigger_types.rst
@@ -6,29 +6,14 @@ Action
 +---------------------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | Reference                 | Description                                                     | Properties                                                                                                  |
 +===========================+=================================================================+=============================================================================================================+
-| st2.generic.actiontrigger | Trigger encapsulating the completion of an action execution.    | status, start_timestamp, result, parameters, action_ref, runner_ref, execution_id, action_name              |
+| st2.generic.actiontrigger | Trigger encapsulating the completion of an action execution.    | execution_id, status, start_timestamp, action_name, action_ref, runner_ref, parameters, result              |
 +---------------------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| st2.generic.notifytrigger | Notification trigger.                                           | status, data, start_timestamp, channel, route, action_ref, message, runner_ref, execution_id, end_timestamp |
+| st2.generic.notifytrigger | Notification trigger.                                           | execution_id, status, start_timestamp, end_timestamp, action_ref, runner_ref, channel, route, message, data |
 +---------------------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| st2.action.file_writen    | Trigger encapsulating action file being written on disk.        | host_info, ref, file_path                                                                                   |
+| st2.action.file_writen    | Trigger encapsulating action file being written on disk.        | ref, file_path, host_info                                                                                   |
 +---------------------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| st2.generic.inquiry       | Trigger indicating a new "inquiry" has entered "pending" status | route, id                                                                                                   |
+| st2.generic.inquiry       | Trigger indicating a new "inquiry" has entered "pending" status | id, route                                                                                                   |
 +---------------------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-
-Key Value Pair
-~~~~~~~~~~~~~~
-
-+---------------------------------+---------------------------------------------------------+------------------------+
-| Reference                       | Description                                             | Properties             |
-+=================================+=========================================================+========================+
-| st2.key_value_pair.create       | Trigger encapsulating datastore item creation.          | object                 |
-+---------------------------------+---------------------------------------------------------+------------------------+
-| st2.key_value_pair.update       | Trigger encapsulating datastore set action.             | object                 |
-+---------------------------------+---------------------------------------------------------+------------------------+
-| st2.key_value_pair.value_change | Trigger encapsulating a change of datastore item value. | new_object, old_object |
-+---------------------------------+---------------------------------------------------------+------------------------+
-| st2.key_value_pair.delete       | Trigger encapsulating datastore item deletion.          | object                 |
-+---------------------------------+---------------------------------------------------------+------------------------+
 
 Sensor
 ~~~~~~
@@ -40,3 +25,18 @@ Sensor
 +--------------------------+--------------------------------------------------+------------+
 | st2.sensor.process_exit  | Trigger indicating sensor process is stopped.    | object     |
 +--------------------------+--------------------------------------------------+------------+
+
+Key Value Pair
+~~~~~~~~~~~~~~
+
++---------------------------------+---------------------------------------------------------+------------------------+
+| Reference                       | Description                                             | Properties             |
++=================================+=========================================================+========================+
+| st2.key_value_pair.create       | Trigger encapsulating datastore item creation.          | object                 |
++---------------------------------+---------------------------------------------------------+------------------------+
+| st2.key_value_pair.update       | Trigger encapsulating datastore set action.             | object                 |
++---------------------------------+---------------------------------------------------------+------------------------+
+| st2.key_value_pair.value_change | Trigger encapsulating a change of datastore item value. | old_object, new_object |
++---------------------------------+---------------------------------------------------------+------------------------+
+| st2.key_value_pair.delete       | Trigger encapsulating datastore item deletion.          | object                 |
++---------------------------------+---------------------------------------------------------+------------------------+

--- a/docs/source/_includes/runner_parameters/announcement.rst
+++ b/docs/source/_includes/runner_parameters/announcement.rst
@@ -1,4 +1,4 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``route`` (string) - The routing_key used to route the message to consumers. Might be a list of words, delimited by dots.
 * ``experimental`` (boolean) - Flag to indicate acknowledgment of using experimental runner
+* ``route`` (string) - The routing_key used to route the message to consumers. Might be a list of words, delimited by dots.

--- a/docs/source/_includes/runner_parameters/http_request.rst
+++ b/docs/source/_includes/runner_parameters/http_request.rst
@@ -1,11 +1,11 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``username`` (string) - Username required by basic authentication.
+* ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
 * ``cookies`` (object) - Optional cookies to send with the request.
 * ``headers`` (object) - HTTP headers for the request.
-* ``url`` (string) - URL to the HTTP endpoint.
 * ``http_proxy`` (string) - URL of HTTP proxy to use (e.g. http://10.10.1.10:3128).
 * ``https_proxy`` (string) - URL of HTTPS proxy to use (e.g. http://10.10.1.10:3128).
-* ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
 * ``password`` (string) - Password required by basic authentication.
+* ``url`` (string) - URL to the HTTP endpoint.
+* ``username`` (string) - Username required by basic authentication.
 * ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.

--- a/docs/source/_includes/runner_parameters/inquirer.rst
+++ b/docs/source/_includes/runner_parameters/inquirer.rst
@@ -1,7 +1,7 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``route`` (string) - An arbitrary value for allowing rules to route to proper notification channel
 * ``schema`` (object) - A JSON schema that will be used to validate the response data
-* ``users`` (array) - A list of usernames that are permitted to respond to the action (if nothing provided, all are permitted)
+* ``route`` (string) - An arbitrary value for allowing rules to route to proper notification channel
 * ``roles`` (array) - A list of roles that are permitted to respond to the action (if nothing provided, all are permitted) - REQUIRES ENTERPRISE FEATURES
+* ``users`` (array) - A list of usernames that are permitted to respond to the action (if nothing provided, all are permitted)
 * ``ttl`` (integer) - Time (in minutes) to wait before timing out the inquiry if no response is received

--- a/docs/source/_includes/runner_parameters/local_shell_cmd.rst
+++ b/docs/source/_includes/runner_parameters/local_shell_cmd.rst
@@ -1,9 +1,9 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
 * ``cmd`` (string) - Arbitrary Linux command to be executed on the host.
-* ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
-* ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
-* ``sudo`` (boolean) - The command will be executed with sudo.
 * ``cwd`` (string) - Working directory where the command will be executed in
+* ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``sudo`` (boolean) - The command will be executed with sudo.
+* ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.

--- a/docs/source/_includes/runner_parameters/local_shell_script.rst
+++ b/docs/source/_includes/runner_parameters/local_shell_script.rst
@@ -1,10 +1,10 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
-* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
-* ``sudo`` (boolean) - The command will be executed with sudo.
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
 * ``debug`` (boolean) - Enable runner debug mode.
 * ``content_version`` (string) - Git revision of the pack content to use for this action execution (git commit sha / tag / branch). Only applies to packs which are git repositories.
 * ``cwd`` (string) - Working directory where the script will be executed in
+* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``sudo`` (boolean) - The command will be executed with sudo.
+* ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.

--- a/docs/source/_includes/runner_parameters/mistral_v2.rst
+++ b/docs/source/_includes/runner_parameters/mistral_v2.rst
@@ -1,6 +1,6 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``skip_notify`` (array) - List of tasks to skip notifications for.
 * ``context`` (object) - Additional workflow inputs.
+* ``skip_notify`` (array) - List of tasks to skip notifications for.
 * ``task_name`` (string) - The name of the task to run for reverse workflow.
 * ``workflow`` (string) - The name of the workflow to run if the entry_point is a workbook of many workflows. The name should be in the format "<pack_name>.<action_name>.<workflow_name>". If entry point is a workflow or a workbook with a single workflow, the runner will identify the workflow automatically.

--- a/docs/source/_includes/runner_parameters/python_script.rst
+++ b/docs/source/_includes/runner_parameters/python_script.rst
@@ -2,6 +2,6 @@
 
 * ``debug`` (boolean) - Enable runner debug mode.
 * ``content_version`` (string) - Git revision of the pack content to use for this action execution (git commit sha / tag / branch). Only applies to packs which are git repositories.
-* ``log_level`` (string) - Default log level for Python runner actions.
 * ``env`` (object) - Environment variables which will be available to the script.
 * ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``log_level`` (string) - Default log level for Python runner actions.

--- a/docs/source/_includes/runner_parameters/remote_shell_cmd.rst
+++ b/docs/source/_includes/runner_parameters/remote_shell_cmd.rst
@@ -1,18 +1,18 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``username`` (string) - Username used to log-in. If not provided, default username from config is used.
-* ``private_key`` (string) - Private key material or path to the private key file on disk used to log in.
-* ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
-* ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
-* ``sudo`` (boolean) - The remote command will be executed with sudo.
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
-* ``bastion_host`` (string) - The host SSH connections will be proxied through. Note: This connection is made using the same parameters as the final connection, and is only used in ParamikoSSHRunner.
-* ``passphrase`` (string) - Passphrase for the private key, if needed.
-* ``password`` (string) - Password used to log in. If not provided, private key from the config file is used.
-* ``port`` (integer) - SSH port. Note: This parameter is used only in ParamikoSSHRunner.
+* ``bastion_host`` (string) - The host SSH connections will be proxied through. Note: This connection is made using the same parameters as the final connection.
 * ``cmd`` (string) - Arbitrary Linux command to be executed on the remote host(s).
-* ``parallel`` (boolean) - Default to parallel execution.
-* ``hosts`` (string) - A comma delimited string of a list of hosts where the remote command will be executed.
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
 * ``cwd`` (string) - Working directory where the script will be executed in
 * ``dir`` (string) - The working directory where the script will be copied to on the remote host.
+* ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
+* ``hosts`` (string) - A comma delimited string of a list of hosts where the remote command will be executed. For example: example1.com,example2.com,example3.com:5555
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``parallel`` (boolean) - Default to parallel execution.
+* ``passphrase`` (string) - Passphrase for the private key, if needed.
+* ``password`` (string) - Password used to log in. If not provided, private key from the config file is used.
+* ``port`` (integer) - SSH port. If not specified as part of the hosts list, default port will be used (22).
+* ``private_key`` (string) - Private key material or path to the private key file on disk used to log in.
+* ``sudo`` (boolean) - The remote command will be executed with sudo.
+* ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``username`` (string) - Username used to log-in. If not provided, default username from config is used.

--- a/docs/source/_includes/runner_parameters/remote_shell_script.rst
+++ b/docs/source/_includes/runner_parameters/remote_shell_script.rst
@@ -1,17 +1,17 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``username`` (string) - Username used to log-in. If not provided, default username from config is used.
+* ``bastion_host`` (string) - The host SSH connections will be proxied through. Note: This connection is made using the same parameters as the final connection.
+* ``cwd`` (string) - Working directory where the script will be executed in.
+* ``dir`` (string) - The working directory where the script will be copied to on the remote host.
+* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
+* ``hosts`` (string) - A comma delimited string of a list of hosts where the remote command will be executed. For example: example1.com,example2.com,example3.com:5555
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``parallel`` (boolean) - Default to parallel execution.
+* ``passphrase`` (string) - Passphrase for the private key, if needed.
+* ``password`` (string) - Password used to log in. If not provided, private key from the config file is used.
+* ``port`` (integer) - SSH port. If not specified as part of the hosts list, default port will be used (22).
 * ``private_key`` (string) - Private key material to log in. Note: This needs to be actual private key data and NOT path.
+* ``sudo`` (boolean) - The remote command will be executed with sudo.
 * ``sudo_password`` (string) - Sudo password. To be used when passwordless sudo is not allowed.
 * ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
-* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
-* ``sudo`` (boolean) - The remote command will be executed with sudo.
-* ``cwd`` (string) - Working directory where the script will be executed in.
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
-* ``bastion_host`` (string) - The host SSH connections will be proxied through. Note: This connection is made using the same parameters as the final connection, and is only used in ParamikoSSHRunner.
-* ``hosts`` (string) - A comma delimited string of a list of hosts where the remote command will be executed.
-* ``passphrase`` (string) - Passphrase for the private key, if needed.
-* ``parallel`` (boolean) - Default to parallel execution.
-* ``password`` (string) - Password used to log in. If not provided, private key from the config file is used.
-* ``port`` (integer) - SSH port. Note: This parameter is used only in ParamikoSSHRunner.
-* ``dir`` (string) - The working directory where the script will be copied to on the remote host.
+* ``username`` (string) - Username used to log-in. If not provided, default username from config is used.

--- a/docs/source/_includes/runner_parameters/winrm_cmd.rst
+++ b/docs/source/_includes/runner_parameters/winrm_cmd.rst
@@ -1,14 +1,14 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``username`` (string) - Username used to log-in.
-* ``password`` (string) - Password used to log in.
-* ``env`` (object) - Environment variables which will be available to the command (e.g. key1=val1,key2=val2)
 * ``cmd`` (string) - Arbitrary Command Prompt command to be executed on the remote host.
 * ``cwd`` (string) - Working directory where the command will be executed in
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "-" or "/".
+* ``env`` (object) - Environment variables which will be available to the command (e.g. key1=val1,key2=val2)
 * ``host`` (string) - A host where the command will be run
-* ``transport`` (string) - The type of transport that WinRM will use to communicate. See https://github.com/diyan/pywinrm#valid-transport-options
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
-* ``scheme`` (string) - Scheme to use in the WinRM URL. If using scheme "http" port must be 5985
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "-" or "/".
+* ``password`` (string) - Password used to log in.
 * ``port`` (integer) - WinRM port to connect on. If using port 5985 scheme must be "http"
+* ``scheme`` (string) - Scheme to use in the WinRM URL. If using scheme "http" port must be 5985
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``transport`` (string) - The type of transport that WinRM will use to communicate. See https://github.com/diyan/pywinrm#valid-transport-options
+* ``username`` (string) - Username used to log-in.
 * ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.

--- a/docs/source/_includes/runner_parameters/winrm_ps_cmd.rst
+++ b/docs/source/_includes/runner_parameters/winrm_ps_cmd.rst
@@ -1,14 +1,14 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``username`` (string) - Username used to log-in.
-* ``password`` (string) - Password used to log in.
-* ``env`` (object) - Environment variables which will be available to the command (e.g. key1=val1,key2=val2)
 * ``cmd`` (string) - Arbitrary PowerShell command to be executed on the remote host.
 * ``cwd`` (string) - Working directory where the command will be executed in
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "-" or "/".
+* ``env`` (object) - Environment variables which will be available to the command (e.g. key1=val1,key2=val2)
 * ``host`` (string) - A host where the command will be run
-* ``transport`` (string) - The type of transport that WinRM will use to communicate. See https://github.com/diyan/pywinrm#valid-transport-options
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
-* ``scheme`` (string) - Scheme to use in the WinRM URL. If using scheme "http" port must be 5985
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "-" or "/".
+* ``password`` (string) - Password used to log in.
 * ``port`` (integer) - WinRM port to connect on. If using port 5985 scheme must be "http"
+* ``scheme`` (string) - Scheme to use in the WinRM URL. If using scheme "http" port must be 5985
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``transport`` (string) - The type of transport that WinRM will use to communicate. See https://github.com/diyan/pywinrm#valid-transport-options
+* ``username`` (string) - Username used to log-in.
 * ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.

--- a/docs/source/_includes/runner_parameters/winrm_ps_script.rst
+++ b/docs/source/_includes/runner_parameters/winrm_ps_script.rst
@@ -1,13 +1,13 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``username`` (string) - Username used to log-in.
-* ``password`` (string) - Password used to log in.
-* ``env`` (object) - Environment variables which will be available to the command (e.g. key1=val1,key2=val2)
 * ``cwd`` (string) - Working directory where the command will be executed in
-* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "-" or "/".
+* ``env`` (object) - Environment variables which will be available to the command (e.g. key1=val1,key2=val2)
 * ``host`` (string) - A host where the command will be run
-* ``transport`` (string) - The type of transport that WinRM will use to communicate. See https://github.com/diyan/pywinrm#valid-transport-options
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
-* ``scheme`` (string) - Scheme to use in the WinRM URL. If using scheme "http" port must be 5985
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "-" or "/".
+* ``password`` (string) - Password used to log in.
 * ``port`` (integer) - WinRM port to connect on. If using port 5985 scheme must be "http"
+* ``scheme`` (string) - Scheme to use in the WinRM URL. If using scheme "http" port must be 5985
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``transport`` (string) - The type of transport that WinRM will use to communicate. See https://github.com/diyan/pywinrm#valid-transport-options
+* ``username`` (string) - Username used to log-in.
 * ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.


### PR DESCRIPTION
Add a step before making st2 requirements to create the virtualenv with python3. The default make in the st2 repo creates the virtualenv with python2. This conflicts with the auto generation scripts in make docs where some method calls are python3 specific. The updated include files are a result of fixing make docs and running the auto-generation scripts.