### PR TITLE
Update orquesta doc sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/source/orquesta/context.rst
 docs/source/orquesta/yaql.rst
 docs/source/orquesta/jinja.rst
 docs/source/orquesta/languages
+docs/source/orquesta/development
 
 # Local Sphinx build output
 .doctrees

--- a/docs/source/orquesta/index.rst
+++ b/docs/source/orquesta/index.rst
@@ -15,6 +15,7 @@ it does not require a separate authentication system and database like Mistral.
    Getting Started <start>
    Workflow Definition <languages/orquesta>
    Expressions and Context <expressions>
+   StackStorm Runtime <stackstorm>
    Workflow Operations <operations>
    Upcoming Features <upcoming>
    Development <development/index>

--- a/docs/source/orquesta/index.rst
+++ b/docs/source/orquesta/index.rst
@@ -17,3 +17,4 @@ it does not require a separate authentication system and database like Mistral.
    Expressions and Context <expressions>
    Workflow Operations <operations>
    Upcoming Features <upcoming>
+   Development <development/index>

--- a/docs/source/orquesta/stackstorm.rst
+++ b/docs/source/orquesta/stackstorm.rst
@@ -1,8 +1,8 @@
 StackStorm Runtime
 ==================
 
-StackStorm Runtime Context
---------------------------
+StackStorm Context
+------------------
 
 During workflow execution, runtime information on the StackStorm action execution cooresponding to
 this workflow execution can be access via ``ctx().st2`` or ``ctx("st2")``. The following is a list
@@ -25,8 +25,8 @@ the expression ``ctx().st2.action_execution_id``.
 | user                 | The user that invoked the action execution for this workflow.       |
 +----------------------+---------------------------------------------------------------------+
 
-StackStorm Runtime Functions
-----------------------------
+StackStorm Functions
+--------------------
 
 task
 """"

--- a/docs/source/orquesta/stackstorm.rst
+++ b/docs/source/orquesta/stackstorm.rst
@@ -1,0 +1,93 @@
+StackStorm Runtime
+==================
+
+StackStorm Runtime Context
+--------------------------
+
+During workflow execution, runtime information on the StackStorm action execution cooresponding to
+this workflow execution can be access via ``ctx().st2`` or ``ctx("st2")``. The following is a list
+of attributes available under the st2 context. For example, to reference action_execution_id, use
+the expression ``ctx().st2.action_execution_id``.
+
++----------------------+---------------------------------------------------------------------+
+| Attribute            | Description                                                         |
++======================+=====================================================================+
+| action_execution_id  | Action execution ID corresponding to the workflow execution.        |
++----------------------+---------------------------------------------------------------------+
+| api_url              | URL of the st2 API endpoint.                                        |
++----------------------+---------------------------------------------------------------------+
+| api_user             | The user who runs the ChatOps command from the client.              |
++----------------------+---------------------------------------------------------------------+
+| pack                 | The pack that the action and corresponding workflow belongs to.     |
++----------------------+---------------------------------------------------------------------+
+| source_channel       | The ChatOps channel associated with the action execution.           |
++----------------------+---------------------------------------------------------------------+
+| user                 | The user that invoked the action execution for this workflow.       |
++----------------------+---------------------------------------------------------------------+
+
+StackStorm Runtime Functions
+----------------------------
+
+task
+""""
+
+The ``task`` function can be used to access the task execution record during runtime. The
+following is the list of input parameters for the function.
+
++-----------+----------+---------------------------------------------------------------------+
+| Parameter | Required | Description                                                         |
++===========+==========+=====================================================================+
+| task_name | No       | Valid name of any tasks in the workflow. Default to current task    |
+|           |          | if task_name is not given.                                          |
++-----------+----------+---------------------------------------------------------------------+
+
+This task function can be used wherever YAQL or Jinja expression is accepted in the workflow
+definition. The YAQL expression ``<% task() %>`` returns the record for the current task. The
+YAQL expression ``<% task("xyz") %>`` returns the record for a task named "xyz" under the
+same execution branch. The function returns a dictionary with the following list of
+attributes. To reference the task result, use ``task("xyz").result``.
+
++-----------------------+--------------------------------------------------------------------+
+| Attribute             | Description                                                        |
++=======================+====================================================================+
+| task_execution_id     | Task execution ID for the referenced task.                         |
++-----------------------+--------------------------------------------------------------------+
+| workflow_execution_id | Workflow execution ID where this task belongs to.                  |
++-----------------------+--------------------------------------------------------------------+
+| task_name             | Name of the task.                                                  |
++-----------------------+--------------------------------------------------------------------+
+| task_id               | Unique ID for the task. This may be different than task_name.      |
++-----------------------+--------------------------------------------------------------------+
+| route                 | Route ID for the branch of workflow execution.                     |
++-----------------------+--------------------------------------------------------------------+
+| result                | Result of the action execution for the task.                       |
++-----------------------+--------------------------------------------------------------------+
+| status                | Status of the task execution.                                      |
++-----------------------+--------------------------------------------------------------------+
+| start_timestamp       | Timestamp when the task execution started.                         |
++-----------------------+--------------------------------------------------------------------+
+| end_timestamp         | Timestamp when the task execution ended.                           |
++-----------------------+--------------------------------------------------------------------+
+
+st2kv
+"""""
+
+The ``st2kv`` function queries the StackStorm datastore and returns the value for the given
+key. The following is the list of input parameters for the function.
+
++-----------+----------+---------------------------------------------------------------------+
+| Parameter | Required | Description                                                         |
++===========+==========+=====================================================================+
+| key       | Yes      | Name of the key.                                                    |
++-----------+----------+---------------------------------------------------------------------+
+| decrypt   | No       | Decrypt the value if True. Default to False if not given.           |
++-----------+----------+---------------------------------------------------------------------+
+| default   | No       | Returns this default value if key does not exist.                   |
++-----------+----------+---------------------------------------------------------------------+ 
+
+For example, the expression ``<% st2kv('system.shared_key_x') %>`` returns the value for a system
+scoped key named ``shared_key_x`` while the expression ``<% st2kv('my_key_y') %>`` returns the
+value for the user scoped key named ``my_key_y``. Please note that the key name should be in quotes
+otherwise YAQL treats a key name with a dot like ``system.shared_key_x`` as a dict access. The value
+can be encrypted in the StackStorm datastore. To decrypt the retrieved value, the input argument
+``decrypt`` must be set to true such as ``st2kv('st2_key_id', decrypt=>true)``.

--- a/docs/source/orquesta/stackstorm.rst
+++ b/docs/source/orquesta/stackstorm.rst
@@ -90,4 +90,5 @@ scoped key named ``shared_key_x`` while the expression ``<% st2kv('my_key_y') %>
 value for the user scoped key named ``my_key_y``. Please note that the key name should be in quotes
 otherwise YAQL treats a key name with a dot like ``system.shared_key_x`` as a dict access. The value
 can be encrypted in the StackStorm datastore. To decrypt the retrieved value, the input argument
-``decrypt`` must be set to true such as ``st2kv('st2_key_id', decrypt=>true)``.
+``decrypt`` must be set to true like the YAQL example ``<% st2kv('st2_key_id', decrypt=>true) %>``
+or its Jinja equivalent ``{{ st2kv('st2_key_id', decrypt=true) }}``.

--- a/docs/source/orquesta/start.rst
+++ b/docs/source/orquesta/start.rst
@@ -8,23 +8,23 @@ Like any |st2| action, an Orquesta workflow requires an action metadata file in
 ``/opt/stackstorm/packs/<mypack>/actions``. The entry point specified in the action metadata file
 is the path relative to ``/opt/stackstorm/packs/<mypack>/actions`` for the workflow definition.
 
-Let's start with a very basic Orquesta workflow named ``examples.orquesta-basic`` for the
-``examples`` pack. The workflow definition for this example is provide below. This workflow executes
-a shell command on the server where |st2| is installed. A task can reference any registered |st2|
-action directly. In this example, the ``task1`` task calls ``core.local``. The command to execute is
-passed as input from the workflow to the task. The ``core.local`` action is already installed with
-|st2|. Let's save this as ``/opt/stackstorm/packs/examples/actions/workflows/orquesta-basic.yaml``
-on the |st2| server.
+Let's start with a very basic Orquesta workflow named ``examples.orquesta-sequential`` for the
+``examples`` pack. The workflow definition for this example is provide below. This workflow is a
+very simple example that run a few echoes, piece together the output, and return a response. A task
+can reference any registered |st2| action directly. In this example, the tasks call ``core.echo``.
+an action in |st2| that just echo back the message like the shell echo command. The ``core.echo``
+action is already installed by default with |st2|. Let's save this workflow definition as
+``/opt/stackstorm/packs/examples/actions/workflows/orquesta-sequential.yaml`` on the |st2| server.
 
-.. literalinclude:: /../../st2/contrib/examples/actions/workflows/orquesta-basic.yaml
+.. literalinclude:: /../../st2/contrib/examples/actions/workflows/orquesta-sequential.yaml
    :language: yaml
 
 As for the corresponding |st2| action metadata file for the example above. The |st2| pack for this
 workflow action is named ``examples``. The |st2| action runner is ``orquesta``. The entry
 point for the |st2| action is the relative path to the YAML file of the workflow definition. Let's
-save this metadata as ``/opt/stackstorm/packs/examples/actions/orquesta-basic.yaml``:
+save this metadata as ``/opt/stackstorm/packs/examples/actions/orquesta-sequential.yaml``:
 
-.. literalinclude:: /../../st2/contrib/examples/actions/orquesta-basic.yaml
+.. literalinclude:: /../../st2/contrib/examples/actions/orquesta-sequential.yaml
    :language: yaml
 
 The files used in this example are also located under
@@ -32,92 +32,119 @@ The files used in this example are also located under
 :ref:`deploy examples <start-deploy-examples>`).
 
 To create this action in |st2|, run the command
-``st2 action create /opt/stackstorm/packs/examples/actions/orquesta-basic.yaml``. This will
-register the workflow as ``examples.orquesta-basic`` in |st2|. The following is what the output
+``st2 action create /opt/stackstorm/packs/examples/actions/orquesta-sequential.yaml``. This will
+register the workflow as ``examples.orquesta-sequential`` in |st2|. The following is what the output
 should look like.
 
 .. code-block:: shell
 
-    $ st2 action create  /opt/stackstorm/packs/examples/actions/orquesta-basic.yaml
-    +-------------+---------------------------------+
-    | Property    | Value                           |
-    +-------------+---------------------------------+
-    | id          | 5b3150fd8006e627f71c2d34        |
-    | name        | orquesta-basic                  |
-    | pack        | examples                        |
-    | description | Run a local linux command       |
-    | enabled     | True                            |
-    | entry_point | workflows/orquesta-basic.yaml   |
-    | notify      |                                 |
-    | parameters  | {                               |
-    |             |     "cmd": {                    |
-    |             |         "required": true,       |
-    |             |         "type": "string"        |
-    |             |     },                          |
-    |             |     "timeout": {                |
-    |             |         "default": 60,          |
-    |             |         "type": "integer"       |
-    |             |     }                           |
-    |             | }                               |
-    | ref         | examples.orquesta-basic         |
-    | runner_type | orquesta                        |
-    | tags        |                                 |
-    | uid         | action:examples:orquesta-basic  |
-    +-------------+---------------------------------+
+    $ st2 action create /opt/stackstorm/packs/examples/actions/orquesta-sequential.yaml
+    +---------------+------------------------------------+
+    | Property      | Value                              |
+    +---------------+------------------------------------+
+    | id            | 5d3a08a00a08a41a995221a0           |
+    | name          | orquesta-sequential                |
+    | pack          | examples                           |
+    | description   | A basic sequential workflow.       |
+    | enabled       | True                               |
+    | entry_point   | workflows/orquesta-sequential.yaml |
+    | metadata_file |                                    |
+    | notify        |                                    |
+    | output_schema |                                    |
+    | parameters    | {                                  |
+    |               |     "name": {                      |
+    |               |         "default": "Lakshmi",      |
+    |               |         "required": true,          |
+    |               |         "type": "string"           |
+    |               |     }                              |
+    |               | }                                  |
+    | ref           | examples.orquesta-sequential       |
+    | runner_type   | orquesta                           |
+    | tags          |                                    |
+    | uid           | action:default:orquesta-sequential |
+    +---------------+------------------------------------+
 
 Execution
 ---------
 
-To execute the workflow, run the command ``st2 run examples.orquesta-basic cmd=date -a`` where
-``-a`` tells the command to return and not wait for the workflow to complete.
+Before we run the example, let's run the help command ``st2 run examples.orquesta-sequential -h``
+to see what input parameters are required. The following is what the help command returns. The
+workflow requires a value for the input parameter named ``name``. There is an optional parameter
+named ``notify`` which we can ignore for now.
 
 .. code-block:: shell
 
-    $ st2 run examples.orquesta-basic cmd=date -a
+    $ st2 run examples.orquesta-sequential -h
+
+    A basic sequential workflow.
+
+    Required Parameters:
+        name
+            Type: string
+            Default: Lakshmi
+
+    Optional Parameters:
+        notify
+            List of tasks to trigger notifications for.
+            Type: array
+            Default: []`
+
+To execute the workflow, run the command ``st2 run examples.orquesta-sequential name=Earthling -a``
+where the ``-a`` option tells the command to return and not wait for the workflow to complete.
+
+.. code-block:: shell
+
+    $ st2 run examples.orquesta-sequential name=Earthling -a
     To get the results, execute:
-     st2 execution get 5b3151a18006e627f71c2d36
+     st2 execution get 5d3a0a890a08a41a995221a3
 
     To view output in real-time, execute:
-     st2 execution tail 5b3151a18006e627f71c2d36
+     st2 execution tail 5d3a0a890a08a41a995221a3
 
-If the workflow completed successfully, both the workflow ``examples.orquesta-basic`` and the
-action ``core.local`` should be ``succeeded`` under the |st2| action execution list. By default,
+If the workflow completed successfully, both the workflow ``examples.orquesta-sequential`` and the
+sequence of ``core.echo`` should be ``succeeded`` under the |st2| action execution list. By default,
 ``st2 execution list`` only returns top level executions and tasks are not displayed.
 
 .. code-block:: shell
 
     $ st2 execution list
-    +----------------------------+-----------------+--------------+------------------------+-----------------+---------------+
-    | id                         | action.ref      | context.user | status                 | start_timestamp | end_timestamp |
-    +----------------------------+-----------------+--------------+------------------------+-----------------+---------------+
-    | + 5b3151a18006e627f71c2d36 | examples        | stanley      | succeeded (2s elapsed) | Mon, 25 Jun     | Mon, 25 Jun   |
-    |                            | .orquesta-      |              |                        | 2018 20:33:36   | 2018 20:33:38 |
-    |                            | basic           |              |                        | UTC             | UTC           |
-    +----------------------------+-----------------+--------------+------------------------+-----------------+---------------+
+    +--------------------------+-----------------+--------------+------------------------+-----------------+---------------+
+    | id                       | action.ref      | context.user | status                 | start_timestamp | end_timestamp |
+    +--------------------------+-----------------+--------------+------------------------+-----------------+---------------+
+    | 5d3a0a890a08a41a995221a3 | examples        | stanley      | succeeded (4s elapsed) | Thu, 25 Jul     | Thu, 25 Jul   |
+    |                          | .orquesta-      |              |                        | 2019 20:01:13   | 2019 20:01:17 |
+    |                          | sequential      |              |                        | UTC             | UTC           |
+    +--------------------------+-----------------+--------------+------------------------+-----------------+---------------+
 
 Running the command ``st2 execution get <execution-id>`` returns more details about the workflow
 execution such as the action executions related to the tasks and the output of the workflow.
 
 .. code-block:: shell
 
-    $ st2 execution get 5b3151a18006e627f71c2d36
-    id: 5b3151a18006e627f71c2d36
-    action.ref: examples.orquesta-basic
+    $ st2 execution get 5d3a0a890a08a41a995221a3
+    id: 5d3a0a890a08a41a995221a3
+    action.ref: examples.orquesta-sequential
     parameters: 
-      cmd: date
-    status: succeeded (2s elapsed)
-    start_timestamp: Mon, 25 Jun 2018 20:33:36 UTC
-    end_timestamp: Mon, 25 Jun 2018 20:33:38 UTC
+      name: Earthling
+    status: succeeded (4s elapsed)
+    start_timestamp: Thu, 25 Jul 2019 20:01:13 UTC
+    end_timestamp: Thu, 25 Jul 2019 20:01:17 UTC
     result: 
       output:
-        stdout: Mon Jun 25 20:33:37 UTC 2018
-    +--------------------------+------------------------+-------+------------+-----------------+
-    | id                       | status                 | task  | action     | start_timestamp |
-    +--------------------------+------------------------+-------+------------+-----------------+
-    | 5b3151a18006e627a556b7e4 | succeeded (1s elapsed) | task1 | core.local | Mon, 25 Jun     |
-    |                          |                        |       |            | 2018 20:33:37   |
-    |                          |                        |       |            | UTC             |
-    +--------------------------+------------------------+-------+------------+-----------------+
+        greeting: Earthling, All your base are belong to us!
+    +--------------------------+------------------------+-------+-----------+-----------------+
+    | id                       | status                 | task  | action    | start_timestamp |
+    +--------------------------+------------------------+-------+-----------+-----------------+
+    | 5d3a0a890a08a41a426722d5 | succeeded (1s elapsed) | task1 | core.echo | Thu, 25 Jul     |
+    |                          |                        |       |           | 2019 20:01:13   |
+    |                          |                        |       |           | UTC             |
+    | 5d3a0a8a0a08a41a426722d8 | succeeded (1s elapsed) | task2 | core.echo | Thu, 25 Jul     |
+    |                          |                        |       |           | 2019 20:01:14   |
+    |                          |                        |       |           | UTC             |
+    | 5d3a0a8b0a08a41a426722db | succeeded (1s elapsed) | task3 | core.echo | Thu, 25 Jul     |
+    |                          |                        |       |           | 2019 20:01:15   |
+    |                          |                        |       |           | UTC             |
+    +--------------------------+------------------------+-------+-----------+-----------------+
 
 Inspection
 ----------

--- a/docs/source/orquesta/upcoming.rst
+++ b/docs/source/orquesta/upcoming.rst
@@ -6,3 +6,5 @@ Upcoming Features
 
 * Task retry in workflow definition
 * Re-run workflow execution at specific task(s)
+* Workflow unit testing and dry run (|ewc|)
+* Workflow execution runtime view (|ewc|)

--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -28,6 +28,7 @@ contributions. Here's our plans for the next two releases.
 3.3
 ---
 
+* **Ubuntu:** Stop producing Ubuntu 14.04 packages.
 * **Mistral deprecation:** Orquesta replaces Mistral as the workflow engine.
 
 Monitor the `master branch <https://github.com/StackStorm/st2/>`_ to see how we're progressing.
@@ -61,6 +62,14 @@ Submit a PR!
 
 Release History
 ---------------
+
+.. rubric:: Done in v3.1
+
+* **Ubuntu:** GA Support Ubuntu 18.04, with Python 3.6
+* **Ubuntu:** Drop Ubuntu 14.04 support. Packages are still available for a limited time.
+* **MongoDB:** Support MongoDB 4.0 (required for Ubuntu 18.04).
+* **ChatOps:** Microsoft Teams GA.
+* **Core:** Support latest ``pip`` and ``requests()``.
 
 .. rubric:: Done in v3.0
 

--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -16,25 +16,19 @@ contributions. Here's our plans for the next two releases.
     the feature. Pull Requests are open to anyone.
 
 
-3.1
----
-
-* **Ubuntu:** GA Support Ubuntu 18.04, with Python 3.6
-* **MongoDB:** Support MongoDB 4.0 (required for Ubuntu 18.04).
-* **Ubuntu:** Drop Ubuntu 14.04 support.
-* **ChatOps:** Microsoft Teams GA.
-* **Core:** Support latest ``pip`` and ``requests()``.
-
 3.2
 ---
 
-* **Orquesta:** Workflow runtime graph.
 * **RHEL/CentOS:** Support RHEL 8.x (assuming it has been released!)
 * **RHEL/CentOS:** Drop support for RHEL/CentOS 6.x.
-* **WebUI:** Datastore viewer/editor.
-* **ChatOps:** RBAC.
-* **SAML:** Support SAML authentication.
+* **ChatOps:** Support RBAC.
+* **SSO:** Support SSO with SAML2 for |ewc| web UI (beta).
 * **Job Scheduling:** Job scheduling for ad-hoc jobs.
+
+3.3
+---
+
+* **Mistral deprecation:** Orquesta replaces Mistral as the workflow engine.
 
 Monitor the `master branch <https://github.com/StackStorm/st2/>`_ to see how we're progressing.
 
@@ -43,7 +37,9 @@ Backlog
 
 Here's some more things on our list that we haven't scheduled yet:
 
-* **Dry Run Workflows** Simulate running Orquesta workflows without actually making changes.
+* **Workflow runtime graph:** Runtime view of workflow execution in st2flow for |ewc|.
+* **Workflow dry run:** Ability to run unit tests on orquesta workflows for |ewc|.
+* **Datastore viewer/editor:** Datastore viewer/editor at web UI.
 * **History and Audit service:** History view with advanced search over years worth of execution
   records, over multiple versions of continuously upgraded |st2|.
 * **At-scale refinements:** Ensure event handling reliability, and event storm resilience. Complete

--- a/scripts/clone-orquesta.sh
+++ b/scripts/clone-orquesta.sh
@@ -19,3 +19,4 @@ cp ${REPO_DIR}/docs/source/expressions.rst ./docs/source/orquesta/expressions.rs
 cp ${REPO_DIR}/docs/source/yaql.rst ./docs/source/orquesta/yaql.rst
 cp ${REPO_DIR}/docs/source/jinja.rst ./docs/source/orquesta/jinja.rst
 cp -R ${REPO_DIR}/docs/source/languages ./docs/source/orquesta
+cp -R ${REPO_DIR}/docs/source/development ./docs/source/orquesta


### PR DESCRIPTION
Update roadmap for v3.2, v3.3, and backlog. Add orquesta development section to docs. Add doc section for runtime context and functions. Update orquesta authoring section with a better example.