### PR TITLE
Add doc section for orquesta tools and resources (v3.1)

### DIFF
--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -22,12 +22,16 @@ workflow can be traced back to the original parent action that invoked the workf
 
 **Essential Mistral Links:**
 
+.. note::
+
+    The following tools and resources are not owned by |st2|. Please use at your own risk.
+
 * Mistral workflow definition language, aka `v2 WorkFlow Language
   <https://docs.openstack.org/mistral/latest/user/wf_lang_v2.html>`_
 * `YAQL documentation <https://yaql.readthedocs.io/en/latest/>`_ and `YAQL online evaluator
   <http://yaqluator.com/>`_
 * `Jinja2 template engine documentation <http://jinja.pocoo.org>`_ and `Jinja2 online evaluator
-  <http://jinja2test.tk/>`_
+  <http://jinja.quantprogramming.com/>`_
 
 
 .. note::

--- a/docs/source/orquesta/start.rst
+++ b/docs/source/orquesta/start.rst
@@ -162,3 +162,15 @@ More Examples
 -------------
 
 There are more workflow examples under :github_st2:`/usr/share/doc/st2/examples <contrib/examples/actions/workflows/>` and include workflows that demonstrates branches, joins, decision tree, error handling, rollback/retry, and others.
+
+Additional Tools and Resources
+------------------------------
+
+.. note::
+
+    The following tools and resources are not owned by |st2|. Please use at your own risk.
+
+* `YAQL documentation <https://yaql.readthedocs.io/en/latest/>`_ and `YAQL online evaluator
+  <http://yaqluator.com/>`_
+* `Jinja2 template engine documentation <http://jinja.pocoo.org>`_ and `Jinja2 online evaluator
+  <http://jinja.quantprogramming.com/>`_


### PR DESCRIPTION
Add a doc section in get started on additional tools and resources. Fix the Jinja2 online evaluator link.