### PR TITLE
Add section on pack dependencies

### DIFF
--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -133,6 +133,35 @@ version or **upgrade to latest** if the version is not specified. Your config fi
 overwritten, so you can revert to an older version just as easily, but for production deployments
 we recommend to always specify versions in case there are major changes in ``latest``.
 
+Pack Dependencies
+~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    New feature! As of StackStorm 3.2.
+
+If your pack uses actions from other packs, you can specify them in the ``dependencies`` section of
+the ``pack.yaml`` file and StackStorm will install them automatically when installing your pack.
+
+Similar to using the ``st2 pack install`` subcommand, you can reference packs from StackStorm
+Exchange using just their names, or you can specify a pack's Git repository URL. You can also use
+the same syntax to install a specific version, tag, or branch:
+
+.. code-block:: yaml
+
+    dependencies:
+      - excel
+      - powerpoint=0.2.2
+      - https://github.com/StackStorm/stackstorm-ms.git
+
+If you have dependency conflicts, the ``st2 pack install`` subcommand may error out, without
+installing any packs. If you would like to forcibly install a pack without installing its
+dependencies, you can use the ``--skip-dependencies`` flag:
+
+.. code-block:: bash
+
+    st2 pack install --skip-dependencies my-custom-pack
+
 To uninstall a pack, use ``remove``:
 
 .. code-block:: bash


### PR DESCRIPTION
Documentation for https://github.com/StackStorm/st2/pull/4769, which adds support for specifying pack dependencies to `pack.yaml`.