### PR TITLE
remove a t

### DIFF
--- a/docs/source/reference/monitoring.rst
+++ b/docs/source/reference/monitoring.rst
@@ -93,7 +93,7 @@ the average execution time. Busy systems will need to scale out the number of ``
 processes.
 
 |st2| exposes some of those metrics via statsd using the metrics framework. For more information,
-please refert to :doc:`/reference/metrics` section.
+please refer to :doc:`/reference/metrics` section.
 
 MongoDB
 -------


### PR DESCRIPTION
Found a rogue `t`. Squashed it. 