### PR TITLE
Docs/correct syntax to register single packs

### DIFF
--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -255,8 +255,8 @@ a schema defined in ``/opt/stackstorm/packs/<pack_dir>/config.schema.yaml``. See
 :doc:`/reference/pack_configs` section for details.
 
 When the pack content changes, it has to be registered again (reloaded). To register individual
-packs, use ``st2 pack register --packs=pack1,pack2``. To register everything at once, use
-``sudo st2ctl reload``. Use ``-h`` to explore the fine-tuning flags.
+packs, use ``st2 pack register pack1 pack2``. Packs are provided as positional space-separated arguments.
+To register everything at once, use ``sudo st2ctl reload``. Use ``-h`` to explore the fine-tuning flags.
 
 Installing Packs from Private Repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The docs say `To register individual packs, use st2 pack register --packs=pack1,pack2.`

Doing so gave me the following error: 
```st2: error: unrecognized arguments: --packs=boto3_demo_orquesta```

According to `st2 pack register --help` the correct syntax seems to be ` st2 pack register boto3_demo_orquesta`.

Tested and verified it with st2 3.1.0, on Python 2.7.6 in the st2-docker setup.