### PR TITLE
Bring back original MongoDB 3.6 message from #949

### DIFF
--- a/docs/source/install/__mongodb_note.rst
+++ b/docs/source/install/__mongodb_note.rst
@@ -2,4 +2,8 @@
 
   The currently supported versions of MongoDB are 3.4 and 4.0. This is the version installed by
   the installer script. MongoDB 4.0 is installed by default on Ubuntu 18.04 and RHEL/CentOS8.
-  MongoDB 3.6 does not currently work with StackStorm. Support for MongoDB 4.0 was added in ST2 v3.1.
+
+  MongoDB 3.6 is also supported by StackStorm >= 3.0.0, but we have observed some
+  performance regressions with MongoDB 3.6 so the default version which is installed on Ubuntu
+  Xenial (16.04) and EL7 (CentOS 7 and RHEL 7) is still 3.4.
+  


### PR DESCRIPTION
Looks like https://github.com/StackStorm/st2docs/pull/949 came with a messed git conflict resolve resulting in a lost message about MongoDB v3.6 compatibility and performance.

See original diff https://github.com/StackStorm/st2docs/pull/949/commits/4a65ac5ceeaa2cd7eea2928e5ce27bec53cb83f7 comparing to #949

This PR fixes it.