### PR TITLE
Add v3.2 upgrade notes of potential impact to orquesta workflows

### DIFF
--- a/docs/source/_includes/runner_parameters/http_request.rst
+++ b/docs/source/_includes/runner_parameters/http_request.rst
@@ -9,3 +9,5 @@
 * ``url`` (string) - URL to the HTTP endpoint.
 * ``username`` (string) - Username required by basic authentication.
 * ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.
+* ``url_hosts_blacklist`` (array) - Optional list of hosts (network locations) to blacklist (e.g. example.com, 127.0.0.1, ::1, etc.). If action will try to access that endpoint, an exception will be thrown and action will be marked as failed.
+* ``url_hosts_whitelist`` (array) - Optional list of hosts (network locations) to whitelist (e.g. example.com, 127.0.0.1, ::1, etc.). If specified, actions will only be able to hit hosts on this whitelist.

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -24,6 +24,13 @@ Upgrade Notes
   experiment with other values which are supported by Python
   ``subprocess.Popen`` (https://docs.python.org/2/library/subprocess.html#popen-constructor)
   function.
+* The workflow engine orquesta v1.1.0 made changes to the internal state of ``with items`` task.
+  Before upgrading st2 to v3.2, please make sure all workflow executions are completed in the
+  database. For example, if there is a workflow execution that has a ``with items`` task and is
+  paused before st2 is upgraded to v3.2, the workflow execution will fail to run the with items
+  task properly after the upgrade.
+* The key word ``continue`` is now a reserved word in orquesta v1.1.0. Orquesta will complain if the
+  workflow definition contains a task that is named ``continue``.
 
 .. _ref-upgrade-notes-v3-0:
 


### PR DESCRIPTION
Add an entry on internal state change to with items task.  Add an entry for the new reserved word `continue` and that it cannot be used as task name.