### PR TITLE
Update pack documentation to state it uses last tagged commit

### DIFF
--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -102,7 +102,7 @@ Exchange, and you can install your own packs from git just as easily.
     # Install your own pack from git
     st2 pack install https://github.com/emedvedev/chatops_tutorial
 
-By default, the latest commit to a pack repository will be installed, but you can specify a particular
+By default, the latest tagged commit to a pack repository will be installed, but you can specify a particular
 version, branch, tag, or even a commit hash. Just use `=`:
 
 .. code-block:: bash

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -102,7 +102,7 @@ Exchange, and you can install your own packs from git just as easily.
     # Install your own pack from git
     st2 pack install https://github.com/emedvedev/chatops_tutorial
 
-By default, the latest tagged commit to a pack repository will be installed, but you can specify a particular
+By default, the latest release of the pack will be installed, but you can specify a particular
 version, branch, tag, or even a commit hash. Just use `=`:
 
 .. code-block:: bash


### PR DESCRIPTION
Minor update to the pack documentation to state that it uses the last 'tagged' commit rather than just last commit - new for v3.2