### PR TITLE
Add an Upgrade Note about 'st2 pack install' behavior changes in v3.2

### DIFF
--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -31,6 +31,8 @@ Upgrade Notes
   task properly after the upgrade.
 * The key word ``continue`` is now a reserved word in orquesta v1.1.0. Orquesta will complain if the
   workflow definition contains a task that is named ``continue``.
+* When installing packs from Exchange index ``st2 pack install <pack_name>`` will now download latest
+  release from the remote repository, instead of using latest available git commit from master as before.
 
 .. _ref-upgrade-notes-v3-0:
 


### PR DESCRIPTION
Following the https://github.com/StackStorm/st2docs/pull/973

Part of the 3.2dev pre-release testing findings: https://github.com/StackStorm/discussions/issues/6