### PR TITLE
Update upgrade and uninstall as mistral not used on RHEL/Centos 8 - resolves #977

### DIFF
--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -98,7 +98,7 @@ below. Only execute the instructions for your distribution.
     sudo apt-get purge st2 st2mistral st2chatops st2web bwc-ui st2flow
 
 
-* RHEL/CentOS 6.x/7.x:
+* RHEL/CentOS:
 
   If you are using StackStorm only:
 
@@ -113,19 +113,10 @@ below. Only execute the instructions for your distribution.
     sudo yum erase st2 st2mistral st2chatops st2web st2python bwc-ui st2flow
 
 
-* RHEL/CentOS 8.x:
+.. warning::
 
-  If you are using StackStorm only:
+  Omit st2mistral from list of packages if Mistral is not installed in your installation
 
-  .. sourcecode:: bash
-
-    sudo yum erase st2 st2chatops st2web st2python
-
-  If you have |ewc| installed, instead use: 
-
-  .. sourcecode:: bash
-
-    sudo yum erase st2 st2chatops st2web st2python bwc-ui st2flow
 
 
 3. Remove |st2| System User

--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -113,7 +113,7 @@ below. Only execute the instructions for your distribution.
     sudo yum erase st2 st2mistral st2chatops st2web st2python bwc-ui st2flow
 
 
-.. warning::
+.. note::
 
   Omit st2mistral from list of packages if Mistral is not installed in your installation
 

--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -98,7 +98,7 @@ below. Only execute the instructions for your distribution.
     sudo apt-get purge st2 st2mistral st2chatops st2web bwc-ui st2flow
 
 
-* RHEL/CentOS:
+* RHEL/CentOS 6.x/7.x:
 
   If you are using StackStorm only:
 
@@ -111,6 +111,21 @@ below. Only execute the instructions for your distribution.
   .. sourcecode:: bash
 
     sudo yum erase st2 st2mistral st2chatops st2web st2python bwc-ui st2flow
+
+
+* RHEL/CentOS 8.x:
+
+  If you are using StackStorm only:
+
+  .. sourcecode:: bash
+
+    sudo yum erase st2 st2chatops st2web st2python
+
+  If you have |ewc| installed, instead use: 
+
+  .. sourcecode:: bash
+
+    sudo yum erase st2 st2chatops st2web st2python bwc-ui st2flow
 
 
 3. Remove |st2| System User

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -144,6 +144,8 @@ This is the standard upgrade procedure:
 
 This step can be skipped if Mistral is not installed on your installation.
 
+   .. sourcecode:: bash
+
      /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
      /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v -e openstack -e keystone -e ironicclient
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -130,13 +130,21 @@ This is the standard upgrade procedure:
 
       sudo apt-get install --only-upgrade st2 st2web st2chatops st2mistral
 
-   RHEL/CentOS:
+   RHEL/CentOS 6.x/7.x:
 
    .. sourcecode:: bash
 
       sudo yum update st2 st2web st2chatops st2mistral
 
+   RHEL/CentOS 8.x:
+
+   .. sourcecode:: bash
+
+      sudo yum update st2 st2web st2chatops
+
 3. Upgrade Mistral database:
+
+This section can be skipped if running on RHEL/Centos 8.x as Mistral is not installed on these distributions.
 
    .. sourcecode:: bash
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -136,13 +136,13 @@ This is the standard upgrade procedure:
 
       sudo yum update st2 st2web st2chatops st2mistral
 
-.. note::
+   .. note::
 
-  Omit st2mistral from list of packages if Mistral is not installed in your installation
+      Omit st2mistral from list of packages if Mistral is not installed in your installation
 
 3. Upgrade Mistral database:
 
-This step can be skipped if Mistral is not installed on your installation.
+   This step can be skipped if Mistral is not installed on your installation.
 
    .. sourcecode:: bash
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -130,23 +130,19 @@ This is the standard upgrade procedure:
 
       sudo apt-get install --only-upgrade st2 st2web st2chatops st2mistral
 
-   RHEL/CentOS 6.x/7.x:
+   RHEL/CentOS:
 
    .. sourcecode:: bash
 
       sudo yum update st2 st2web st2chatops st2mistral
 
-   RHEL/CentOS 8.x:
+.. note::
 
-   .. sourcecode:: bash
-
-      sudo yum update st2 st2web st2chatops
+  Omit st2mistral from list of packages if Mistral is not installed in your installation
 
 3. Upgrade Mistral database:
 
-This step can be skipped if running on RHEL/Centos 8.x as Mistral is not installed on these distributions.
-
-   .. sourcecode:: bash
+This step can be skipped if Mistral is not installed on your installation.
 
      /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head
      /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate | grep -v -e openstack -e keystone -e ironicclient

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -144,7 +144,7 @@ This is the standard upgrade procedure:
 
 3. Upgrade Mistral database:
 
-This section can be skipped if running on RHEL/Centos 8.x as Mistral is not installed on these distributions.
+This step can be skipped if running on RHEL/Centos 8.x as Mistral is not installed on these distributions.
 
    .. sourcecode:: bash
 


### PR DESCRIPTION
Updated upgrade and uninstall with separate instructions for RHEL 8/Centos 8 which skip the mistral steps.