### PR TITLE
Update docker set-up -- seemed like  missing steps

### DIFF
--- a/docs/source/install/docker.rst
+++ b/docs/source/install/docker.rst
@@ -129,7 +129,7 @@ To stop the containers, run:
 
 To run from the command line inside the container:
 
-.. sourcecode::bash
+.. sourcecode:: bash
 
   docker-compose exec stackstorm bash
   

--- a/docs/source/install/docker.rst
+++ b/docs/source/install/docker.rst
@@ -135,6 +135,6 @@ To run from the command line inside the container:
   
 The installation tutorial can continue from here.
 
-To run the UI, look for the password in `st2-docker/conf/stackstorm.env` and run http://localhost
+To run the UI, look for the password in ``st2-docker/conf/stackstorm.env`` and run http://localhost/
 
 More information can be found in the README

--- a/docs/source/install/docker.rst
+++ b/docs/source/install/docker.rst
@@ -127,3 +127,14 @@ To stop the containers, run:
 
   docker-compose down
 
+To run from the command line inside the container:
+
+.. sourcecode::bash
+
+  docker-compose exec stackstorm bash
+  
+The installation tutorial can continue from here.
+
+To run the UI, look for the password in `st2-docker/conf/stackstorm.env` and run http://localhost
+
+More information can be found in the README


### PR DESCRIPTION
I got stuck at the end of the docker install set up, so went to the README  and found more to get unblocked.

It seemed to just end at starting the container, but the install tutorials don't pick up on how to execute at the command line within the container.