### PR TITLE
Removing unnecessary references to mistral in U18 and RHEL8 install docs

### DIFF
--- a/docs/source/install/common/configure_components_no_mistral.rst
+++ b/docs/source/install/common/configure_components_no_mistral.rst
@@ -1,0 +1,7 @@
+If you are not running RabbitMQ, MongoDB on the same system, or have changed the
+defaults, please adjust these settings:
+
+* RabbitMQ connection at ``/etc/st2/st2.conf``
+* MongoDB at ``/etc/st2/st2.conf``
+
+See the :doc:`Configuration documentation </install/config/config>` for more information.

--- a/docs/source/install/rhel8.rst
+++ b/docs/source/install/rhel8.rst
@@ -100,7 +100,7 @@ Install |st2| Components
 
   sudo yum install -y st2
 
-.. include:: common/configure_components.rst
+.. include:: common/configure_components_no_mistral.rst
 
 Setup Datastore Encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/install/u18.rst
+++ b/docs/source/install/u18.rst
@@ -67,7 +67,7 @@ Install |st2| Components
 
   sudo apt-get install -y st2
 
-.. include:: common/configure_components.rst
+.. include:: common/configure_components_no_mistral.rst
 
 Setup Datastore Encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Mistal isn't installed for RHEL8 or Ubuntu18 but it still appeared in the list of config files to edit under "Install ST2 Components".

As it's a shared section I created a new shared section without the references to Mistral and included that from both the RHEL8 and Ubuntu18 install docs.