### PR TITLE
Bump sphinx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=2.1.2,<2.2
+sphinx>=2.4.4,<3.0
 sphinx-autobuild
-sphinx-sitemap==1.0.2
+sphinx-sitemap==2.1.0


### PR DESCRIPTION
Bumping Sphinx version. Not going to 3.x yet, as there are some other build warnings to fix
```
docs/source/_themes/sphinx_rtd_theme/search.html:20: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  {{ super() }}
```

Related fix to sphinx_rtd_themes is [here](https://github.com/readthedocs/sphinx_rtd_theme/pull/728/files), but that upstream is getting a fair bit away from ours. Need to resync our version with upstream. When trying to just make some of those changes, it broke search, which is unacceptable for now. Am sure it will be fixed if all the upstream changes are integrated.