### PR TITLE
st2docs misc mistral removal

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,8 +103,6 @@ version_minus_2 = previous_version(version_minus_1)
 # extlink configurator sphinx.ext.extlinks
 extlinks = {
     'github_st2': ('https://github.com/StackStorm/st2/tree/master/%s', None),
-    'github_st2mistral': ('https://github.com/StackStorm/st2mistral/tree/master/%s', None),
-    'github_mistral': ('https://github.com/StackStorm/mistral/tree/master/%s', None),
     'github_exchange':
         ('https://github.com/StackStorm-Exchange/%s', None),
     'web_exchange':

--- a/docs/source/install/puppet.rst
+++ b/docs/source/install/puppet.rst
@@ -71,7 +71,6 @@ classes available for configuration:
 - ``::st2`` - The main configuration point for the StackStorm installation.
 - ``::st2::profile::client`` - Profile to install all client libraries for StackStorm
 - ``::st2::profile::fullinstall`` - Full installation of StackStorm and dependencies
-- ``::st2::profile::mistral`` - Install of OpenStack Mistral
 - ``::st2::profile::mongodb`` - StackStorm configured MongoDB installation
 - ``::st2::profile::nodejs`` - StackStorm configured NodeJS installation
 - ``::st2::profile::python`` - Python installed and configured for StackStorm

--- a/docs/source/install/puppet_chef_salt_ansible.rst
+++ b/docs/source/install/puppet_chef_salt_ansible.rst
@@ -34,7 +34,6 @@ Chef
 We don't have documentation for Chef yet. If you'd like to help us fill in this section, pull requests are gladly accepted. In the meantime, here are some resources to get you started:
 
    * |st2| Cookbook: https://supermarket.chef.io/cookbooks/stackstorm
-   * OpenStack Mistral Cookbook: https://supermarket.chef.io/cookbooks/openstack-mistral
 
 
 Salt


### PR DESCRIPTION
Covers the mistral removal from st2docs not covered by specific chapter PRs.

Includes: puppet updates and conf.py changes