### PR TITLE
Update python3 flag for pack install example. Fixes #1008

### DIFF
--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -300,8 +300,8 @@ used by all the |st2| components and services is used for pack virtual environme
    Python 2 support will be dropped from |st2| in future releases. Please consider updating any Python 2 only packs to work with Python 3.
 
 On CentOS/RHEL 7 and Ubuntu 16.04 if you want to use Python 3 for running your pack Python actions, you can do that by passing  the
-``--use-python3`` flag to the ``st2 pack install`` command (e.g. ``st2 pack install libcloud
---use-python3``).
+``--python3`` flag to the ``st2 pack install`` command (e.g. ``st2 pack install libcloud
+--python3``).
 
 This will create the pack virtual environment using the Python 3 binary specified by
 ``actionrunner.python3_binary`` config option. This value defaults to ``/usr/bin/python3``. For


### PR DESCRIPTION
The documentation uses an obsolete version of the python3 flag.  This pull request is to update the example to match the current 3.2 behaviour.

```
# st2 --version
st2 3.3dev (0d143d48b), on Python 3.6.9

# st2 pack install --help | grep python3
                        [--python3] [--force] [--skip-dependencies]
  --python3             Use Python 3 binary for pack virtual environment.
```