### PR TITLE
Added upgrade specific instructions for 3.3

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -178,14 +178,17 @@ v3.3
   * https://docs.mongodb.com/manual/release-notes/4.0-upgrade-standalone/
 
   A summary of the steps to take is outlined below assuming you will be migrating
-  through the path ``3.4 -> 3.6 -> 4.0``
+  through the path ``3.4 -> 3.6 -> 4.0``.
+
+  In the following steps, if you receive an error when setting the FeatureComptabilityVersion stating that admin is not authorized to execute the command, then you may need to add the root role to the admin user, e.g.
+
+  .. sourcecode:: bash
+
+    mongo admin --username admin --password Password --quiet --eval "db.grantRolesToUser('admin',[{role: 'root', db: 'admin'}])"
 
   Ubuntu 16.04:
 
   .. sourcecode:: bash
-
-     # Stop StackStorm
-     sudo st2ctl stop
 
      # Ensure current MongoDB feature compatability level is set to 3.4
      mongo admin --username admin --password Password --quiet --eval "db.adminCommand( { setFeatureCompatibilityVersion: '3.4' } )"
@@ -199,7 +202,6 @@ v3.3
      sudo apt-get update
      sudo apt-get -y clean
      sudo apt-get -y update
-     # TODO: Missing something as after upgrade - as cannot set feature to 3.6
      sudo apt-get -y install mongodb-* --only-upgrade
 
      # Set MongoDB feature compatability level to 3.6
@@ -219,16 +221,15 @@ v3.3
      # Set MongoDB feature compatability level to 4.0
      mongo admin --username admin --password Password --quiet --eval "db.adminCommand( { setFeatureCompatibilityVersion: '4.0' } )"
 
-     # Start StackStorm
-     sudo st2ctl start
+
+  .. note::
+
+     If after upgrading packages you cannot set the FeatureCompatibilityVersion to the upgraded software, then you may need to restart the mongod service.
 
 
   RHEL/CentOS 7.x:
 
   .. sourcecode:: bash
-
-     # Stop StackStorm
-     sudo st2ctl stop
 
      # Ensure current MongoDB feature compatability level is set to 3.4
      mongo admin --username admin --password Password --quiet --eval "db.adminCommand( { setFeatureCompatibilityVersion: '3.4' } )"
@@ -251,15 +252,7 @@ v3.3
      # Set MongoDB feature compatability level to 4.0
      mongo admin --username admin --password Password --quiet --eval "db.adminCommand( { setFeatureCompatibilityVersion: '4.0' } )"
 
-     # Start StackStorm
-     sudo st2ctl start
 
-
-  If you receive an error when setting the FeatureComptabilityVersion stating that admin is not authorized to execute the command, then you may need to add the root role to the admin user, e.g.
-
-  .. sourcecode:: bash
-
-    mongo admin --username admin --password Password --quiet --eval "db.grantRolesToUser('admin',[{role: 'root', db: 'admin'}])"
 
 
 * Mistral is no longer included in StackStorm and consequently Postgres is no longer required. Mistral and Postgres were previously installed on CentOS 7.x and Ubuntu 16.04 releases only.

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -192,13 +192,14 @@ v3.3
 
      # Upgrade MongoDB packages to 3.6
      wget -qO - https://www.mongodb.org/static/pgp/server-3.6.asc | sudo apt-key add -
+     sudo rm -f /etc/apt/sources.list.d/mongodb-org-3.4.list
      sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-3.6.list
      deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -c | awk '{print $2}')/mongodb-org/3.6 multiverse
      EOT"
      sudo apt-get update
      sudo apt-get -y clean
      sudo apt-get -y update
-     # TODO: Missing something as get conflicts on mongodb-clients and server when try this. If just do othe mongodb-org then can't set compatability to 3.4
+     # TODO: Missing something as after upgrade - as cannot set feature to 3.6
      sudo apt-get -y install mongodb-* --only-upgrade
 
      # Set MongoDB feature compatability level to 3.6
@@ -206,6 +207,7 @@ v3.3
 
      # Upgrade MongoDB packages to 4.0
      wget -qO - https://www.mongodb.org/static/pgp/server-4.0.asc | sudo apt-key add -
+     sudo rm -f /etc/apt/sources.list.d/mongodb-org-3.6.list
      sudo sh -c "cat <<EOT > /etc/apt/sources.list.d/mongodb-org-4.0.list
      deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -c | awk '{print $2}')/mongodb-org/4.0  multiverse
      EOT"


### PR DESCRIPTION
Closes #1027 

Adds upgrade specific instructions for:
* MongoDB 4.0 upgrade
* Mistral and Postgres removal