### PR TITLE
EL7 migration from python 2 to python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
       - restore_cache:
           key: v2-dependency-cache-{{ checksum "st2/requirements.txt" }}
       - run: sudo apt install python-dev
+      - run: sudo apt install libldap2-dev
+      - run: sudo apt install libsasl2-dev
       - run: make docs
       - run:
           name: Store HTML docs in workspace dir

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -11,6 +11,11 @@ System Requirements
 
 Please check the :doc:`supported versions and system requirements <system_requirements>`.
 
+.. note::
+
+    |st2| on RHEL 7/CentOS 7 runs all services, actions and sensors using Python 3 **only**. It
+    does not support Python 2 actions. 
+
 Minimal Installation
 --------------------
 
@@ -33,6 +38,9 @@ you may want to tweak them according to your security practices.
 
     # SELINUX management tools, not available for some minimal installations
     sudo yum install -y policycoreutils-python
+
+    # SELINUX python3 rules
+    sudo yum install -y libselinux-python3
 
     # Allow network access for nginx
     sudo setsebool -P httpd_can_network_connect 1

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -81,6 +81,26 @@ Install MongoDB, and RabbitMQ:
   sudo systemctl start mongod rabbitmq-server
   sudo systemctl enable mongod rabbitmq-server
 
+The default python on CentOS/RHEL 7.x is python 2, |st2| uses python3 and requires the python3-devel package. The installation of the st2 package will automatically install python3-devel if it is available in an enabled repository. On CentOS distributions the relevant repository is typically enabled however on RHEL distributions it is provided by the rhel-7-server-optional-rpms repository (repository name dependant on RHEL distribution).
+
+Use the following command to verify that the python3-devel package is available in an enabled repository:
+
+.. code-block:: bash
+
+  sudo yum info python3-devel
+
+If it is not available, then locate the optional-rpms repository:
+
+.. code-block:: bash
+
+  sudo yum repolist disabled | grep optional | grep server
+
+Then either enable the optional repository using subscription-manager or yum-config-manager, or install python3-devel with a temporary repository enablement, e.g.:
+
+.. code-block:: bash
+
+  sudo yum install python3-devel --enablerepo <optional-server-rpm repo>
+
 Setup Repositories
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -39,9 +39,6 @@ you may want to tweak them according to your security practices.
     # SELINUX management tools, not available for some minimal installations
     sudo yum install -y policycoreutils-python
 
-    # SELINUX python3 rules
-    sudo yum install -y libselinux-python3
-
     # Allow network access for nginx
     sudo setsebool -P httpd_can_network_connect 1
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -80,13 +80,15 @@ Install MongoDB, and RabbitMQ:
 
 The default python on CentOS/RHEL 7.x is python 2, |st2| uses python3 and requires the python3-devel package. The installation of the st2 package will automatically install python3-devel if it is available in an enabled repository. On CentOS distributions the relevant repository is typically enabled however on RHEL distributions it is provided by the rhel-7-server-optional-rpms repository (repository name dependant on RHEL distribution).
 
+The following steps in this section are only required on RHEL 7.x systems. On CentOS 7.x systems these steps can be ignored, and you can proceed to Setup Repositories.
+
 Use the following command to verify that the python3-devel package is available in an enabled repository:
 
 .. code-block:: bash
 
   sudo yum info python3-devel
 
-If it is not available, then locate the optional-rpms repository:
+If it is not available, locate the repository that contains the RPM. On RHEL 7.x it is located in the optional server RPMs repository (the name of that repository differs between RHEL distributions):
 
 .. code-block:: bash
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -171,11 +171,34 @@ v3.4dev
 '''''''
 
 *  |st2| now uses python 3 on RHEL/CentOS 7. Therefore any packs that only support python 2 will need to be upgraded to python 3.
-  * If SELINUX is enabled, install the python 3 SELinux rules with:
+
+
+* If SELINUX is enabled, install the python 3 SELinux rules with:
 
   .. sourcecode:: bash
 
     sudo yum install -y libselinux-python3
+
+* Ensure python3-devel can be installed from an enabled repository:
+
+  * Check if python3-devel is already available in an enabled repository:
+
+  .. sourcecode:: bash
+
+    sudo yum info python3-devel
+
+  * If it is not available, then locate the name of the optional server RPMs repository:
+
+  .. sourcecode:: bash
+
+    sudo yum repolist disabled | grep optional | grep server
+
+  * Either enable the optional repository using subscription-manager or yum-config-manager, or install python3-devel with a temporary repository enablement, e.g.:
+
+  .. sourcecode:: bash
+
+    sudo yum install python3-devel --enablerepo <optional-server-rpm repo>
+
 
 v3.3
 ''''

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -167,8 +167,8 @@ The following sections call out the migration scripts that need to be run when u
 respective version. If you are upgrading across multiple versions, make sure you run the scripts for
 any skipped versions:
 
-v3.4dev
-'''''''
+v3.4
+''''
 
 *  |st2| now uses python 3 on RHEL/CentOS 7. Therefore any packs that only support python 2 will need to be upgraded to python 3.
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -167,6 +167,15 @@ The following sections call out the migration scripts that need to be run when u
 respective version. If you are upgrading across multiple versions, make sure you run the scripts for
 any skipped versions:
 
+v3.4dev
+''''
+
+*  |st2| now uses python 3 on RHEL/CentOS 7. Therefore any packs that only support python 2 will need to be upgraded to python 3.
+  * If SELINUX is enabled, install the python 3 SELinux rules with:
+
+  .. sourcecode:: bash
+
+    sudo yum install -y libselinux-python3
 
 v3.3
 ''''

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -173,13 +173,12 @@ v3.4
 *  |st2| now uses python 3 on RHEL/CentOS 7. Therefore any packs that only support python 2 will need to be upgraded to python 3.
 
 
-* If SELINUX is enabled, install the python 3 SELinux rules with:
+* RHEL 7.x only. Ensure python3-devel can be installed from an enabled repository:
 
-  .. sourcecode:: bash
+  .. note::
 
-    sudo yum install -y libselinux-python3
+     On CentOS 7.x these steps are not required as python3-devel is available by default in the enabled repositories, and therefore will get installed automatically when the st2 RPM is upgraded:
 
-* Ensure python3-devel can be installed from an enabled repository:
 
   * Check if python3-devel is already available in an enabled repository:
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -168,7 +168,7 @@ respective version. If you are upgrading across multiple versions, make sure you
 any skipped versions:
 
 v3.4dev
-''''
+'''''''
 
 *  |st2| now uses python 3 on RHEL/CentOS 7. Therefore any packs that only support python 2 will need to be upgraded to python 3.
   * If SELINUX is enabled, install the python 3 SELinux rules with:

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -293,13 +293,13 @@ Python versions in Pack Python Virtual Environment
 
 When installing a pack, a Python virtual environment is created using the Python binary defined by
 the ``actionrunner.python_binary`` config option. By default, the same binary which is
-used by all the |st2| components and services is used for pack virtual environments. On CentOS/RHEL 7 and Ubuntu 16.04 the Python binary currently used is Python 2.7, on all other distributions Python 3 is used.
+used by all the |st2| components and services is used for pack virtual environments. On Ubuntu 16.04 the Python binary currently used is Python 2.7, on all other distributions Python 3 is used.
 
 .. warning ::
 
    Python 2 support will be dropped from |st2| in future releases. Please consider updating any Python 2 only packs to work with Python 3.
 
-On CentOS/RHEL 7 and Ubuntu 16.04 if you want to use Python 3 for running your pack Python actions, you can do that by passing  the
+On Ubuntu 16.04 if you want to use Python 3 for running your pack Python actions, you can do that by passing the
 ``--python3`` flag to the ``st2 pack install`` command (e.g. ``st2 pack install libcloud
 --python3``).
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,6 +3,13 @@
 Upgrade Notes
 =============
 
+.. _ref-upgrade-notes-v3-4dev:
+
+|st2| v3.4dev
+----------
+
+* RHEL/CentOS 7.x ST2 distributions now uses python version 3 for ST2 and all packs, therefore any packs that only support python 2 will need to be migrated to python 3.
+
 .. _ref-upgrade-notes-v3-3:
 
 |st2| v3.3

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -6,7 +6,7 @@ Upgrade Notes
 .. _ref-upgrade-notes-v3-4dev:
 
 |st2| v3.4dev
-----------
+-------------
 
 * RHEL/CentOS 7.x ST2 distributions now uses python version 3 for ST2 and all packs, therefore any packs that only support python 2 will need to be migrated to python 3.
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -3,9 +3,9 @@
 Upgrade Notes
 =============
 
-.. _ref-upgrade-notes-v3-4dev:
+.. _ref-upgrade-notes-v3-4:
 
-|st2| v3.4dev
+|st2| v3.4
 -------------
 
 * RHEL/CentOS 7.x ST2 distributions now uses python version 3 for ST2 and all packs, therefore any packs that only support python 2 will need to be migrated to python 3.


### PR DESCRIPTION
Documentation changes for python3 use on EL7 distributions

Part of StackStorm/discussions#54