### PR TITLE
Remove st2resultstracker from the ha and monitoring reference docs

### DIFF
--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -176,20 +176,6 @@ versioning prevents multiple execution requests from being picked up by
 different schedulers. Scheduler garbage collection handles executions that might
 have failed to be scheduled by a failed ``st2scheduler`` instance.
 
-
-st2resultstracker
-^^^^^^^^^^^^^^^^^
-Tracks results of execution handed over to Orquesta or 3rd pary intergations that implement the 
-result tracker to provide the results. It requires access to MongoDB and RabbitMQ to perform its 
-function.
-
-Multiple ``st2resultstracker`` processes will co-operate with each other to perform work. At
-startup there is a possibility of extra work however there are no negative consequences of this
-duplication. Specifically the jobs to track results also get stored in the DB in case there are no
-workers to take over the work. This pattern makes all result trackers pick up the same work set on
-startup. Once this work set is exhausted all subsequent tasks are round-robined. If needed
-``st2resultstracker`` processes could be started in a staggered manner to avoid extra work.
-
 st2notifier
 ^^^^^^^^^^^
 This is a dual purpose process - its main function is to generate ``st2.core.actiontrigger`` and

--- a/docs/source/reference/monitoring.rst
+++ b/docs/source/reference/monitoring.rst
@@ -53,7 +53,6 @@ You can use ``sudo st2ctl status`` to get a quick overview of current process st
     st2auth PID: 1286
     st2garbagecollector PID: 910
     st2notifier PID: 916
-    st2resultstracker PID: 913
     st2rulesengine PID: 920
     st2timersengine PID: 925
     st2sensorcontainer PID: 907


### PR DESCRIPTION
This PR completes the st2resultstracker deprecation and removes it from the docs. 