### PR TITLE
Build from source updates

### DIFF
--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -38,6 +38,38 @@ Fedora
     systemctl enable rabbitmq-server
     systemctl restart rabbitmq-server
 
+CentOS
+------
+
+.. code-block:: bash
+
+    yum install python-pip python-virtualenv python-tox gcc-c++ git-all screen icu libicu libicu-devel openssl-devel openldap-devel python3-devel
+
+    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+    # Add key and repo for the latest stable MongoDB (4.0)
+    rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc
+    sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-4.repo
+    [mongodb-org-4]
+    name=MongoDB Repository
+    baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.0/x86_64/
+    gpgcheck=1
+    enabled=1
+    gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc
+    EOT"
+
+    yum install crudini
+    yum install mongodb-org
+    yum install rabbitmq-server
+    systemctl start mongod rabbitmq-server
+    systemctl enable mongod rabbitmq-server
+
+Project Requirements
+~~~~~~~~~~~~~~~~~~~~
+
+Once the environment is setup, clone the git repo, and make the project. This will create the
+Python virtual environment under StackStorm, download and install required dependencies, and run
+
 Project Requirements
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -137,7 +169,7 @@ virtualenv. However, the client may need to be installed with sudo if not in the
 .. code-block:: bash
 
     cd ./st2client
-    python setup.py develop
+    python3 setup.py develop
 
 Verify Installation
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -19,7 +19,7 @@ Ubuntu
 
 .. code-block:: bash
 
-    apt-get install python-pip python-virtualenv python-dev gcc git make realpath screen libffi-dev libssl-dev
+    apt-get install python-pip python-virtualenv python-dev gcc git make realpath screen libffi-dev libssl-dev python3-dev libldap2-dev libsasl2-dev
     apt-get install mongodb mongodb-server
     apt-get install rabbitmq-server
 

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -9,7 +9,7 @@ Environment Prerequisites
 Requirements:
 
 -  git
--  python, pip, virtualenv, tox
+-  python3.6, pip, virtualenv, tox
 -  MongoDB (http://docs.mongodb.org/manual/installation)
 -  RabbitMQ (http://www.rabbitmq.com/download.html)
 -  screen
@@ -39,20 +39,22 @@ Fedora
     systemctl restart rabbitmq-server
 
 CentOS
-------
+-----------
 
 .. code-block:: bash
 
+    OSRELEASE_VERSION=`rpm --eval '%{centos_ver}'`
+
     yum install python-pip python-virtualenv python-tox gcc-c++ git-all screen icu libicu libicu-devel openssl-devel openldap-devel python3-devel
 
-    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OSRELEASE_VERSION}.noarch.rpm
 
     # Add key and repo for the latest stable MongoDB (4.0)
     rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc
     sh -c "cat <<EOT > /etc/yum.repos.d/mongodb-org-4.repo
     [mongodb-org-4]
     name=MongoDB Repository
-    baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.0/x86_64/
+    baseurl=https://repo.mongodb.org/yum/redhat/${OSRELEASE_VERSION}/mongodb-org/4.0/x86_64/
     gpgcheck=1
     enabled=1
     gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc
@@ -63,12 +65,6 @@ CentOS
     yum install rabbitmq-server
     systemctl start mongod rabbitmq-server
     systemctl enable mongod rabbitmq-server
-
-Project Requirements
-~~~~~~~~~~~~~~~~~~~~
-
-Once the environment is setup, clone the git repo, and make the project. This will create the
-Python virtual environment under StackStorm, download and install required dependencies, and run
 
 Project Requirements
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -17,33 +17,26 @@ Requirements:
 Ubuntu
 ------
 
+.. note::
+  For Ubuntu 16.04 you will need to source python3.6 from a suitable PPA
+
+
 .. code-block:: bash
 
-    apt-get install python-pip python-virtualenv python-dev gcc git make realpath screen libffi-dev libssl-dev python3-dev libldap2-dev libsasl2-dev
+    apt-get install python-pip python-virtualenv gcc git make realpath screen libffi-dev libssl-dev python3.6-dev libldap2-dev libsasl2-dev
     apt-get install mongodb mongodb-server
     apt-get install rabbitmq-server
 
-Fedora
-------
-
-.. code-block:: bash
-
-    yum install python-pip python-virtualenv python-tox gcc-c++ git-all screen icu libicu libicu-devel openssl-devel
-
-    yum install mongodb mongodb-server
-    systemctl enable mongod
-    systemctl restart mongod
-
-    yum install rabbitmq-server
-    systemctl enable rabbitmq-server
-    systemctl restart rabbitmq-server
-
-CentOS
+CentOS/RHEL
 -----------
 
+.. note::
+  For RHEL 7.x you may need to enable the optional server rpms repository to be able to install the python3-devel RPM
+
+
 .. code-block:: bash
 
-    OSRELEASE_VERSION=`rpm --eval '%{centos_ver}'`
+    OSRELEASE_VERSION=`lsb_release -s -r | cut -d'.' -f 1`
 
     yum install python-pip python-virtualenv python-tox gcc-c++ git-all screen icu libicu libicu-devel openssl-devel openldap-devel python3-devel
 


### PR DESCRIPTION
Update instructions to build from sources to include instructions for CentOS/RHEL and remove Fedora.

Updated Ubuntu instructions as they did not include python3.6-dev or the LDAP libraries.
