### PR TITLE
Update the quick install command to support interactive scripts

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -53,7 +53,7 @@ on Ubuntu, or ``sudo yum install curl nss`` on RHEL/CentOS. Then run this comman
 
 .. code-block:: bash
 
-   curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=st2admin --password='Ch@ngeMe'
+   curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=st2admin --password=Ch@ngeMe
 
 This is an opinionated installation of |st2|. It will download and install all components, as per
 the :doc:`single host reference deployment <./overview>`. It assumes that you have a clean, basic

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -53,7 +53,7 @@ on Ubuntu, or ``sudo yum install curl nss`` on RHEL/CentOS. Then run this comman
 
 .. code-block:: bash
 
-   bash <(curl -sSL https://stackstorm.com/packages/install.sh) --user=st2admin --password=Ch@ngeMe --unstable
+   bash <(curl -sSL https://stackstorm.com/packages/install.sh) --user=st2admin --password=Ch@ngeMe
 
 This is an opinionated installation of |st2|. It will download and install all components, as per
 the :doc:`single host reference deployment <./overview>`. It assumes that you have a clean, basic

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -53,7 +53,7 @@ on Ubuntu, or ``sudo yum install curl nss`` on RHEL/CentOS. Then run this comman
 
 .. code-block:: bash
 
-   curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=st2admin --password=Ch@ngeMe
+   bash <(curl -sSL https://stackstorm.com/packages/install.sh) --user=st2admin --password=Ch@ngeMe --unstable --u16-add-insecure-py3-ppa
 
 This is an opinionated installation of |st2|. It will download and install all components, as per
 the :doc:`single host reference deployment <./overview>`. It assumes that you have a clean, basic

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -53,7 +53,7 @@ on Ubuntu, or ``sudo yum install curl nss`` on RHEL/CentOS. Then run this comman
 
 .. code-block:: bash
 
-   bash <(curl -sSL https://stackstorm.com/packages/install.sh) --user=st2admin --password=Ch@ngeMe --unstable --u16-add-insecure-py3-ppa
+   bash <(curl -sSL https://stackstorm.com/packages/install.sh) --user=st2admin --password=Ch@ngeMe --unstable
 
 This is an opinionated installation of |st2|. It will download and install all components, as per
 the :doc:`single host reference deployment <./overview>`. It assumes that you have a clean, basic


### PR DESCRIPTION
The previous command had issues with interactive scripts. See https://github.com/StackStorm/discussions/issues/66#issuecomment-787154902 for an example (st2.conf was updated and the user was asked whether to keep/override the file). 

All options Y/I, N/O, Z and D were tested on Ubuntu 16.04 and 18.04.