### PR TITLE
Rabbitmq repo

### DIFF
--- a/docs/source/install/rhel8.rst
+++ b/docs/source/install/rhel8.rst
@@ -75,8 +75,10 @@ Install MongoDB, RabbitMQ:
 
   sudo yum -y install crudini
   sudo yum -y install mongodb-org 
+  curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
+  sudo yum -y install erlang
   sudo yum -y install rabbitmq-server
   sudo systemctl start mongod rabbitmq-server
   sudo systemctl enable mongod rabbitmq-server

--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -148,7 +148,7 @@ below. Only execute the instructions for your distribution.
 
     sudo rm -f /etc/yum.repos.d/mongodb-org* /etc/yum.repos.d/StackStorm*
     sudo rm -f /etc/yum.repos.d/pgdg-94* /etc/yum.repos.d/nginx* /etc/yum.repos.d/nodesource*
-    sudo rm -f /etc/yum.repos.d/rabbitmq_erlang* /etc/yum.repos.d/rabbitmq-server*
+    sudo rm -f /etc/yum.repos.d/rabbitmq_erlang* /etc/yum.repos.d/*rabbitmq-server*
 
 
 5. Clean Up Remaining Content

--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -148,6 +148,7 @@ below. Only execute the instructions for your distribution.
 
     sudo rm -f /etc/yum.repos.d/mongodb-org* /etc/yum.repos.d/StackStorm*
     sudo rm -f /etc/yum.repos.d/pgdg-94* /etc/yum.repos.d/nginx* /etc/yum.repos.d/nodesource*
+    sudo rm -f /etc/yum.repos.d/rabbitmq_erlang* /etc/yum.repos.d/rabbitmq-server*
 
 
 5. Clean Up Remaining Content


### PR DESCRIPTION
Install latest version of rabbitmq from packagecloud, and therefore as that requires newer version of erlang, install the minimal erlang provided by rabbitmq - as per instructions at https://github.com/rabbitmq/erlang-rpm

Update install instructions to install erlang from rabbitmq_erlang. Also update the uninstall to include removal of the rabbitmq and erlang repos.

Relates to StackStorm/st2-packages#699