### PR TITLE
Add a note on combining URL + config level SSL options messaging transport

### DIFF
--- a/docs/source/install/config/config.rst
+++ b/docs/source/install/config/config.rst
@@ -146,6 +146,14 @@ documented below are also supported:
 
 .. note::
 
+    If you want to use custom SSL settings (e.g. using a different ca bundle or similar) you
+    should specify all those options as part of the st2.conf and also do the same for enabling ssl
+    using ``messaging.ssl`` option. Combining URL and config parameters for SSL doesn't work - if
+    you enable ssl as part of the  URL it will use default SSL settings, but you won't be able to
+    specify a custom value for ``cert_reqs`` ``ca_certs`` and other SSL related options.
+
+.. note::
+
    RabbitMQ doesn't expose an SSL / TLS listener by default and needs to be configured to enable
    TLS support. For more information, refer to the official documentation -
    `Enabling TLS Support in RabbitMQ <https://www.rabbitmq.com/ssl.html#enabling-tls>`_.


### PR DESCRIPTION
This pull request adds some a note on mixing SSL related messaging transport options inside the URL and inside the config file.

Part of https://github.com/StackStorm/st2/pull/5237.