### PR TITLE
update start docs with more authentication token information for clarity

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -52,7 +52,9 @@ You will almost certainly have authentication enabled. The easiest way to login 
 
     st2 login st2admin --password 'Ch@ngeMe'
 
-This will obtain an authentication token, and cache it. The following will display the authentication token. 
+This will obtain an authentication token, and cache it.
+
+The following will display the authentication token. 
 
 .. code-block:: bash
 
@@ -202,7 +204,7 @@ Deploy a Rule
     # Get the rule that was just created
     st2 rule get examples.sample_rule_with_webhook
 
-Once the rule is created, the webhook begins to listen on ``https://{host}/api/v1/webhooks/{url}``. Fire the POST, check out the file, and see that it appends the payload to the ``/home/stanley/st2.webhook_sample.out`` file.
+Once the rule is created, the webhook begins to listen on ``https://{host}/api/v1/webhooks/{url}``. Fire the POST, check out ``/home/stanley/st2.webhook_sample.out``, and see that it appends the payload to the file.
 
 .. code-block:: bash
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -52,7 +52,11 @@ You will almost certainly have authentication enabled. The easiest way to login 
 
     st2 login st2admin --password 'Ch@ngeMe'
 
-This will obtain an authentication token, and cache it.
+This will obtain an authentication token, and cache it. The following will display the authentication token. 
+
+.. code-block:: bash
+
+    st2 auth st2admin -p 'Ch@ngeMe'
 
 There are other options for authentication: check the :doc:`docs<authentication>` for more details.
 
@@ -198,11 +202,13 @@ Deploy a Rule
     # Get the rule that was just created
     st2 rule get examples.sample_rule_with_webhook
 
-Once the rule is created, the webhook begins to listen on ``https://{host}/api/v1/webhooks/{url}``.
-Fire the POST, check out the file and see that it appends the payload if the name=Joe.
+Once the rule is created, the webhook begins to listen on ``https://{host}/api/v1/webhooks/{url}``. Fire the POST, check out the file, and see that it appends the payload to the ``/home/stanley/st2.webhook_sample.out`` file.
 
 .. code-block:: bash
 
+    # Obtain authentication token
+    st2 auth st2admin -p 'Ch@ngeMe'
+    
     # Post to the webhook
     curl -k https://localhost/api/v1/webhooks/sample -d '{"foo": "bar", "name": "st2"}' -H 'Content-Type: application/json' -H 'X-Auth-Token: put_token_here'
 


### PR DESCRIPTION
I'm a new user and just getting things installed and reading through the docs. The Quick Start guide was super helpful, but I hit a stumbling block when I couldn't figure out where to get the authentication token to execute the example curl `POST` request in the **[Deploy a Rule](https://docs.stackstorm.com/start.html#deploy-a-rule)** section. Just adding some clarification for future new users who might have a similar question.

## Proposed Changes

- update `start.rst`to clarify where to find the authentication token