### PR TITLE
Add coordination service requirement for single node and HA install

### DIFF
--- a/docs/source/coordination.rst
+++ b/docs/source/coordination.rst
@@ -1,0 +1,51 @@
+Coordination
+============
+
+Coordination backend is required to support workflows with multiple branches or tasks with items and
+actions with concurrency policies defined.
+
+StackStorm utilizes the ``OpenStack Tooz`` library for communicating with the coordination backend.
+The coordination backend must support the ``Locking`` functionality as defined by the ``Tooz`` 
+interface. Please refrence the `OpenStack Tooz compatability page <https://docs.openstack.org/tooz/latest/user/compatibility.html>`_
+for more information what interfaces are implemented by various backends.
+
+The following is a list of backends that can be configured for the coordination service. For the
+full list of the supported backends and how to configure them, please visit
+`OpenStack Tooz documentation <https://docs.openstack.org/tooz/latest/>`_.
+ 
+ * Redis
+ * Zookeeper
+ * consul
+ * etcd
+ * file (for testing when all the services are running on a single host)
+
+The configuration of the coordination service is done in the ``coordination`` section
+of ``/etc/st2/st2.conf``. The following are configuration examples for Redis and Zookeeper.
+
+Redis:
+
+.. code-block:: ini
+
+    [coordination]
+    url = redis://:password@host:port
+
+ZooKeeper:
+
+.. code-block:: ini
+
+    [coordination]
+    url = kazoo://username:password@host:port
+
+Some of these coordination backends also require corresponding client libraries to be installed
+in |st2| virtualenv. We do not ship these libraries by default. As an example, to install the client
+library in |st2| virtualenv, run:
+
+.. sourcecode:: bash
+
+    sudo su
+
+    # Example when using redis backend
+    /opt/stackstorm/st2/bin/pip install redis
+
+    # Example when using consul backend
+    /opt/stackstorm/st2/bin/pip install consul

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Contents:
 
     authentication
     rbac
+    coordination
     inquiries
     reference/index
     troubleshooting/index

--- a/docs/source/install/common/configure_components.rst
+++ b/docs/source/install/common/configure_components.rst
@@ -1,7 +1,8 @@
-If you are not running RabbitMQ or MongoDB on the same system, or have changed the
+If you are not running RabbitMQ, MongoDB, or Redis on the same system, or have changed the
 defaults, please adjust these settings:
 
 * RabbitMQ connection at ``/etc/st2/st2.conf``
 * MongoDB at ``/etc/st2/st2.conf``
+* Redis connection at coordination section of ``/etc/st2/st2.conf``
 
 See the :doc:`Configuration documentation </install/config/config>` for more information.

--- a/docs/source/install/overview.rst
+++ b/docs/source/install/overview.rst
@@ -94,10 +94,13 @@ ChatOps can be also enabled by installing `hubot-stackstorm plugin
 
 Dependencies
 ------------
-The required dependencies are RabbitMQ, and MongoDB. The optional dependencies are:
+The required dependencies are RabbitMQ, MongoDB, and Redis (or Zookeeper).
+
+The coordination service is required for workflows that has multiple branches and tasks with items. Previously, the coordination service is optional to support concurrency policies. The backend for the coordination service can be configured to use Redis, Zookeeper, or other. Since v3.5, redis server is installed as part of the single node installation script. The python redis client is also installed into the |st2| virtualenv. If using Zookeeper, the kazoo module needs to be manually installed into the |st2| virtualenv.
+
+The optional dependencies are:
 
   - nginx for SSL termination, reverse-proxying API endpoints and serving static HTML.
-  - Redis or Zookeeper for concurrency policies (see :doc:`/reference/policies`).
   - LDAP authentication.
 
 

--- a/docs/source/install/rhel7.rst
+++ b/docs/source/install/rhel7.rst
@@ -55,7 +55,7 @@ Install Dependencies
 
 .. include:: __mongodb_note.rst
 
-Install MongoDB, and RabbitMQ:
+Install MongoDB, RabbitMQ, and Redis
 
 .. code-block:: bash
 
@@ -75,8 +75,9 @@ Install MongoDB, and RabbitMQ:
   sudo yum -y install crudini
   sudo yum -y install mongodb-org
   sudo yum -y install rabbitmq-server
-  sudo systemctl start mongod rabbitmq-server
-  sudo systemctl enable mongod rabbitmq-server
+  sudo yum -y install redis
+  sudo systemctl start mongod rabbitmq-server redis
+  sudo systemctl enable mongod rabbitmq-server redis
 
 The default python on CentOS/RHEL 7.x is python 2, |st2| uses python3 and requires the python3-devel package. The installation of the st2 package will automatically install python3-devel if it is available in an enabled repository. On CentOS distributions the relevant repository is typically enabled however on RHEL distributions it is provided by the rhel-7-server-optional-rpms repository (repository name dependant on RHEL distribution).
 

--- a/docs/source/install/rhel8.rst
+++ b/docs/source/install/rhel8.rst
@@ -56,7 +56,7 @@ Install Dependencies
 
 .. include:: __mongodb_note.rst
 
-Install MongoDB, RabbitMQ:
+Install MongoDB, RabbitMQ, and Redis:
 
 .. code-block:: bash
 
@@ -80,8 +80,9 @@ Install MongoDB, RabbitMQ:
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
   sudo yum -y install erlang
   sudo yum -y install rabbitmq-server
-  sudo systemctl start mongod rabbitmq-server
-  sudo systemctl enable mongod rabbitmq-server
+  sudo yum -y install redis
+  sudo systemctl start mongod rabbitmq-server redis
+  sudo systemctl enable mongod rabbitmq-server redis
 
 
 Setup Repositories

--- a/docs/source/install/system_requirements.rst
+++ b/docs/source/install/system_requirements.rst
@@ -57,6 +57,7 @@ By default, |st2| and related services use these TCP ports:
 * nginx (80, 443)
 * mongodb (27017)
 * rabbitmq (4369, 5672, 25672)
+* redis (6379) or zookeeper (2181, 2888, 3888)
 * st2auth (9100)
 * st2api (9101)
 * st2stream (9102)

--- a/docs/source/install/u18.rst
+++ b/docs/source/install/u18.rst
@@ -22,7 +22,7 @@ Minimal Installation
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
-Install MongoDB, and RabbitMQ:
+Install MongoDB, RabbitMQ, and Redis:
 
 .. code-block:: bash
 
@@ -39,6 +39,7 @@ Install MongoDB, and RabbitMQ:
   sudo apt-get install -y crudini
   sudo apt-get install -y mongodb-org
   sudo apt-get install -y rabbitmq-server
+  sudo apt-get install -y redis-server
 
 For Ubuntu ``Bionic`` you may need to enable and start MongoDB.
 

--- a/docs/source/install/u20.rst
+++ b/docs/source/install/u20.rst
@@ -21,7 +21,7 @@ Minimal Installation
 Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
-Install MongoDB, and RabbitMQ:
+Install MongoDB, RabbitMQ, and Redis:
 
 .. code-block:: bash
 
@@ -38,6 +38,7 @@ Install MongoDB, and RabbitMQ:
   sudo apt-get install -y crudini
   sudo apt-get install -y mongodb-org
   sudo apt-get install -y rabbitmq-server
+  sudo apt-get install -y redis-server
 
 For Ubuntu ``Focal`` you may need to enable and start MongoDB.
 

--- a/docs/source/install/uninstall.rst
+++ b/docs/source/install/uninstall.rst
@@ -48,6 +48,7 @@ below. Only execute the instructions for your distribution.
     sudo service nginx stop
     sudo service mongod stop
     sudo service rabbitmq-server stop
+    sudo service redis-server stop
 
 * RHEL/CentOS 7.x/8.x:
 
@@ -57,6 +58,7 @@ below. Only execute the instructions for your distribution.
     sudo systemctl stop nginx
     sudo systemctl stop mongod
     sudo systemctl stop rabbitmq-server
+    sudo systemctl stop redis
 
 .. note::
 
@@ -119,13 +121,13 @@ below. Only execute the instructions for your distribution.
 
   .. sourcecode:: bash
 
-    sudo apt-get purge mongodb-org* rabbitmq-server erlang* nginx nodejs
+    sudo apt-get purge mongodb-org* rabbitmq-server erlang* nginx nodejs redis-server
 
 * RHEL/CentOS:
 
   .. sourcecode:: bash
 
-    sudo yum erase mongodb-org* rabbitmq-server erlang* nginx nodejs
+    sudo yum erase mongodb-org* rabbitmq-server erlang* nginx nodejs redis
 
 .. note::
 
@@ -164,6 +166,8 @@ last pieces.
     sudo rm -rf /etc/st2 /opt/stackstorm
     sudo rm -rf /var/log/st2 /var/log/mongodb
     sudo rm -rf /var/lib/mongodb /var/run/mongodb.pid 
+    sudo rm -rf /etc/redis/redis.conf /var/lib/redis
+    sudo userdel -r redis
 
 * RHEL/CentOS:
 
@@ -172,7 +176,8 @@ last pieces.
     sudo rm -rf /etc/st2 /etc/mongod* /etc/rabbitmq /etc/nginx /opt/stackstorm
     sudo rm -rf /var/log/st2 /var/log/mongodb /var/log/rabbitmq /var/log/nginx
     sudo rm -rf /var/lib/rabbitmq /var/lib/mongo
-
+    sudo rm -rf /etc/redis/redis.conf /var/lib/redis
+    sudo userdel -r redis
 
 At this point, your system is no longer running any |st2|-related services, and all the main
 dependencies have been removed. You can either re-install |st2|, or use this system for other

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -197,7 +197,7 @@ v3.5
   by default in the single node installation script to support workflows with multiple
   branches and tasks with items. Upgrade requires coordination service to be setup
   manually, For workflows to be executed properly, setup the coordination service
-  accordingly. See :doc:`../reference/policies` for setup instruction.
+  accordingly. See :doc:`../coordination` for setup instruction.
 
 v3.4
 ''''

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -193,6 +193,12 @@ v3.5
      sudo rpm -e --nodeps nodejs
      sudo yum upgrade st2chatops
 
+* Redis server is installed and configured as backend for the coordination service
+  by default in the single node installation script to support workflows with multiple
+  branches and tasks with items. Upgrade requires coordination service to be setup
+  manually, For workflows to be executed properly, setup the coordination service
+  accordingly. See :doc:`../reference/policies` for setup instruction.
+
 v3.4
 ''''
 

--- a/docs/source/reference/policies.rst
+++ b/docs/source/reference/policies.rst
@@ -22,6 +22,11 @@ can specify that new executions are canceled, rather than delayed.
 
 There are two forms of concurrency policy: ``action.concurrency`` and ``action.concurrency.attr``.
 
+.. note::
+
+    The concurrency policy type is not enabled by default and requires a backend coordination
+    service such as ZooKeeper or Redis to work. See :doc:`../coordination` for setup instruction.
+
 action.concurrency
 ~~~~~~~~~~~~~~~~~~
 
@@ -82,63 +87,6 @@ host.
         threshold: 10
         attributes:
             - hostname
-
-.. note::
-
-    The concurrency policy type is not enabled by default and requires a backend coordination
-    service such as ZooKeeper or Redis to work.
-
-If you have installed a coordination service in your network, you need to configure |st2| to
-connect to that backend service. This is done in the ``coordination`` section of
-``/etc/st2/st2.conf``.
-
-The following are examples for ZooKeeper and Redis:
-
-ZooKeeper:
-
-.. code-block:: ini
-
-    [coordination]
-    url = kazoo://username:password@host:port
-
-
-Redis:
-
-.. code-block:: ini
-
-    [coordination]
-    url = redis://:password@host:port
-
-Other supported coordination backends include:
-
-* consul
-* etcd
-* MySQL
-* PostgreSQL
-* file (for testing when all the services are running on a single host)
-
-StackStorm utilizes the ``OpenStack Tooz`` library for communicating with the
-coordination backend. The coordination backend must support the ``Locking``
-functionality as defined by the ``Tooz`` interface. Please refrence the
-`OpenStack Tooz compatability page <https://docs.openstack.org/tooz/latest/user/compatibility.html>`_
-for more information what interfaces are implemented by various backends.
-
-For the full list of the supported backends and how to configure them, please visit
-`OpenStack Tooz documentation <https://docs.openstack.org/tooz/latest/>`_.
-
-Some of these coordination backends also require corresponding client libraries to be installed
-in |st2| virtualenv. We do not ship these libraries by default. As an example, to install the client
-library in |st2| virtualenv, run:
-
-.. sourcecode:: bash
-
-    sudo su
-
-    # Example when using redis backend
-    /opt/stackstorm/st2/bin/pip install redis
-
-    # Example when using consul backend
-    /opt/stackstorm/st2/bin/pip install consul
 
 Retry
 -----

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -10,6 +10,11 @@ Upgrade Notes
 
 * Node was upgraded from v10 to v14. Node 14 repository will be required to be
   setup, prior to upgrade of st2chatops.
+* Redis server is installed and configured as backend for the coordination service
+  by default in the single node installation script to support workflows with multiple
+  branches and tasks with items. Upgrade requires coordination service to be setup
+  manually, For workflows to be executed properly, setup the coordination service
+  accordingly.
 
 .. _ref-upgrade-notes-v3-4:
 


### PR DESCRIPTION
The coordination service is required to support multiple workflow use cases. Update docs to let users know that redis is installed by default in single node installation script and that redis/zookeeper needs to be included in a HA deployment.