### PR TITLE
Pinning docutils version 0.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.16.0
 sphinx>=2.4.4,<3.0
 sphinx-autobuild
 sphinx-sitemap==2.1.0


### PR DESCRIPTION
Due to some bug in `docutils` 0.17.0 there are missing caption class in `<p>` tags.
Pin `docutils` to version 0.16.0 solves the issue.
This is similar issue like here readthedocs/sphinx_rtd_theme#1111