### PR TITLE
Refactor Kubernetes docs to cover changes to our Helm Chart

### DIFF
--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -54,16 +54,17 @@ or ``st2`` CLI client:
 .. figure :: /_static/images/helm-chart-notes.png
     :align: center
 
+.. todo:: Update this screenshot. It is out of date.
 
 The installation uses some unsafe defaults which we recommend you change for production use via Helm ``values.yaml``.
 
 Helm Values
 ___________
 Helm package ``stackstorm-ha`` comes with default settings (see `values.yaml <https://github.com/StackStorm/stackstorm-ha/blob/master/values.yaml>`_).
-Fine-tune them to achieve desired configuration for the StackStorm HA K8s cluster.
+Fine-tune them to achieve desired configuration for your StackStorm HA K8s cluster.
 
 .. note::
-    Keep custom values you want to override in a separated yaml file so they won't get lost.
+    Keep custom values you want to override in a separate yaml file so they won't get lost.
     Example: ``helm install -f custom_values.yaml`` or ``helm upgrade -f custom_values.yaml``
 
 You can configure:
@@ -73,13 +74,22 @@ You can configure:
 - st2.conf settings
 - RBAC roles, assignments and mappings (enterprise only for StackStorm v3.2 and before, open source
   for StackStorm v3.4 and later)
-- custom st2 packs and its configs
+- custom st2 packs (in persistent volumes or via custom docker images) and their configs
 - SSH private key
-- K8s resources and settings to control pod/deployment placement
-- Mongo, RabbitMQ clusters
+- K8s resources, annotations, and settings to control pod/deployment placement
+- Image tag and repository settings to select the ST2 version or use customized/private component images
+- DNS and Ingress configuration
+- Miscellaneous other ST2 cluster customizations
+- Mongo, RabbitMQ, and Redis clusters
+
+If not defined, these values are auto-generated on install and preserved across upgrades:
+
+- SSH private key
+- st2 auth secrets (ie: the password for the st2admin user)
 
 .. warning::
-    It's highly recommended to set your own secrets as the file contains unsafe defaults like SSH keys, StackStorm access credentials and MongoDB/RabbitMQ passwords!
+    It's highly recommended to set your own secrets to replace the unsafe defaults for for the MongoDB and RabbitMQ subhcarts!
+	If you disable the subcharts, make sure to secure the services and add the relevant secrets to st2.conf.
 
 Upgrading
 _________

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -306,6 +306,14 @@ By default ``3`` nodes (1 primary and 2 secondaries) of MongoDB are deployed via
 For more advanced MongoDB configuration, refer to official `mongodb-replicaset <https://github.com/helm/charts/tree/master/stable/mongodb-replicaset>`_
 Helm chart settings, which might be fine-tuned via ``values.yaml``.
 
+The deployment of MongoDB to the k8s cluster can be disabled by setting the mongodb-ha.enabled key in values.yaml to false.
+
+.. note::
+   Stackstorm relies heavily on connections to a MongoDB instance. If the in-cluster deployment of MongoDB is disabled,
+   a connection to an external instance of MongoDB must be configured. The st2.config key in values.yaml provides a way
+   to configure stackstorm.
+   See `Configure MongoDB <https://docs.stackstorm.com/install/config/config.html#configure-mongodb>`_ for configuration details.
+
 `RabbitMQ HA Cluster <https://docs.stackstorm.com/latest/reference/ha.html#rabbitmq>`_
 ______________________________________________________________________________________
 RabbitMQ is a message bus StackStorm relies on for inter-process communication and load distribution.
@@ -313,6 +321,14 @@ External Helm Chart is used to deploy `RabbitMQ cluster <https://www.rabbitmq.co
 By default ``3`` nodes of RabbitMQ are deployed via K8s StatefulSet.
 For more advanced RabbitMQ configuration, please refer to official `rabbitmq-ha <https://github.com/helm/charts/tree/master/stable/rabbitmq-ha>`_
 Helm chart repository, - all settings could be overridden via ``values.yaml``.
+
+The deployment of RabbitMQ to the k8s cluster can be disabled by setting the rabbitmq-ha.enabled key in values.yaml to false.
+
+.. note::
+	Stackstorm relies heavily on connections to a RabbitMQ instance. If the in-cluster deployment of RabbitMQ is disabled,
+	a connection to an external instance of RabbitMQ must be configured. The st2.config key in values.yaml provides a way
+	to configure stackstorm.
+	See `Configure RabbitMQ <https://docs.stackstorm.com/install/config/config.html#configure-rabbitmq>`_ for configuration details.
 
 redis
 _____

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -197,7 +197,7 @@ st2web
 ______
 st2web is a StackStorm Web UI admin dashboard. By default, st2web K8s config includes a Pod Deployment and a Service.
 ``2`` replicas (configurable) of st2web serve the web app and proxy requests to st2auth, st2api, st2stream.
-By default, st2web uses HTTP instead of HTTPS. We recommend you rely on ``LoadBalancer`` or ``Ingress`` to add HTTPS layer on top of it.
+By default, st2web uses HTTP instead of HTTPS. We recommend you rely on ``LoadBalancer`` (a ``Service`` type) or ``Ingress`` to add HTTPS layer on top of it.
 
 .. note::
   By default, st2web is a NodePort Service and is not exposed to the public net.
@@ -221,7 +221,7 @@ if you are planning a high-volume environment.
 
 st2stream
 _________
-StackStorm st2stream - exposes a server-sent event stream, used by the clients like WebUI and ChatOps to receive updates from the st2stream server.
+The StackStorm ``st2stream`` service exposes a server-sent event stream, used by the clients like WebUI and ChatOps to receive updates from the st2stream server.
 Similar to st2auth and st2api, st2stream K8s configuration includes Pod Deployment with ``2`` replicas for HA (can be increased in ``values.yaml``)
 and ClusterIP Service listening on port ``9102``.
 
@@ -275,8 +275,8 @@ st2actionrunner
 _______________
 Stackstorm workers that actually execute actions.
 ``5`` replicas for K8s Deployment are configured by default to increase StackStorm ability to execute actions without excessive queuing.
-Relies on ``redis`` for coordination. This is likely the first thing to lift if you have a lot of actions
-to execute per time period in your StackStorm cluster.
+Relies on ``redis`` for coordination. The ``st2actionrunner`` replicas count is likely the first thing to increase if you have
+a lot of actions to execute per time period in your StackStorm cluster.
 
 st2scheduler
 ____________
@@ -324,7 +324,7 @@ Feedback Needed!
 ----------------
 As this deployment method new and beta is in progress, we ask you to try it and provide your feedback via
 bug reports, ideas, feature or pull requests in `StackStorm/stackstorm-ha <https://github.com/StackStorm/stackstorm-ha>`_,
-and ecourage discussions in `Slack <https://stackstorm.com/community-signup>`_ ``#docker`` channel or write us an email.
+and ecourage discussions in `Slack <https://stackstorm.com/community-signup>`_ ``#k8s`` channel or write us an email.
 
 
 .. only:: community

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -172,21 +172,16 @@ using private Docker registry and more.
 Method 2: Shared Volumes
 ________________________
 
-This method uses shared volumes to enable ``st2 pack install``. This sacrifices the stateless infrastructure model.
-When multiple teams are involved in managing StackStorm, however, that tradeoff can be vital.
-For example, if one team maintains StackStorm itself as shared infrastructure, but another
-team handles installing packs and creating auto-remediation or other workflows, it may be necessary to separate
-the StackStorm deployment process from StackStorm pack install process.
+Pack content can also be shared via ReadWriteMany volumes such as NFS (Network File System) as :doc:`/reference/ha` recommends.
+Using shared volumes sacrifices the stateless infrastructure model, but enables normal pack management features
+such as ``st2 pack install``.
 
-Stateful infrastructure is generally more complex than stateless infrastructure. In our case, relying on
-shared volumes requires cluster-specific storage setup and configuration. That storage setup varies
-widely. Several attempts to include storage setup in our helm chart were not flexible enough
-to handle that variation. As such, you must configure your storage solution before using the chart.
-Then, just include your volume definitions in values.
-
-.. note::
-  There is an alternative approach, - sharing pack content via read-write-many NFS (Network File System) as :doc:`/reference/ha` recommends.
-  As beta is in progress and both methods have their pros and cons, we'd like to hear your feedback and which way would work better for you.
+Relying on shared volumes requires cluster-specific storage setup and configuration. As that storage setup varies
+widely, manging that storage is out-of-scope for this helm chart. For example, before you can install this chart to use NFS,
+you would have to create the NFS exports, and you might need ``PersistentVolume`` and ``PersistentVolumeClaim`` k8s objects.
+Then, you add some volume definitions to your ``values.yaml``, and install or upgrade StackStorm with Helm.
+Not every cluster uses NFS or PV/PVCs to manage the storage, so the chart treats your volume definitions as opaque data,
+merely including your volume definitions in the appropriate place in various ``Deployment`` and ``Job`` k8s objects.
 
 Ingress
 -------

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -183,6 +183,15 @@ Then, you add some volume definitions to your ``values.yaml``, and install or up
 Not every cluster uses NFS or PV/PVCs to manage the storage, so the chart treats your volume definitions as opaque data,
 merely including your volume definitions in the appropriate place in various ``Deployment`` and ``Job`` k8s objects.
 
+.. note::
+    With care, ``st2packs`` images can be used with ``volumes``. Just make sure to keep the ``st2packs`` images up-to-date
+	with any changes made via ``st2 pack install``. If a pack is installed via an ``st2packs`` image and then it gets updated
+	with ``st2 pack install``, a subsequent ``helm upgrade`` will revert back to the version in the ``st2packs`` image.
+
+Please refer to `StackStorm/stackstorm-ha#install-custom-st2-packs-in-the-cluster <https://github.com/stackstorm/stackstorm-ha#install-custom-st2-packs-in-the-cluster>`_
+Helm chart repository with more information about how to pass custom volume definitions for ``packs``, ``virtualenvs``
+and pack ``configs`` in Helm values.
+
 Ingress
 -------
 

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -64,7 +64,7 @@ Helm package ``stackstorm-ha`` comes with default settings (see `values.yaml <ht
 Fine-tune them to achieve desired configuration for your StackStorm HA K8s cluster.
 
 .. note::
-    Keep custom values you want to override in a separate yaml file so they won't get lost.
+    Keep custom values you want to override in a separate YAML file so they won't get lost.
     Example: ``helm install -f custom_values.yaml`` or ``helm upgrade -f custom_values.yaml``
 
 You can configure:
@@ -376,8 +376,9 @@ As any other Helm dependency, it's possible to further configure it for specific
 Feedback Needed!
 ----------------
 As this deployment method new and beta is in progress, we ask you to try it and provide your feedback via
+
 bug reports, ideas, feature or pull requests in `StackStorm/stackstorm-ha <https://github.com/StackStorm/stackstorm-ha>`_,
-and ecourage discussions in `Slack <https://stackstorm.com/community-signup>`_ ``#k8s`` channel or write us an email.
+and encourage discussions in `Slack <https://stackstorm.com/community-signup>`_ ``#k8s`` channel.
 
 
 .. only:: community

--- a/docs/source/install/k8s_ha.rst
+++ b/docs/source/install/k8s_ha.rst
@@ -4,11 +4,13 @@
 This document provides an installation blueprint for a Highly Available StackStorm cluster
 based on `Kubernetes <https://kubernetes.io/>`__, a container orchestration platform at planet scale.
 
-The cluster deploys a minimum of 2 replicas for each component of StackStorm microservices for redundancy and reliability. It
-also configures backends like MongoDB HA Replicaset, RabbitMQ HA and Redis Sentinel cluster that st2 relies on for database,
-communication bus, and distributed coordination respectively. That raises a fleet of more than ``30`` pods total.
+A StackStorm HA cluster consists of 2 replicas for most StackStorm microservices for redundancy and reliability.
+The cluster must also have access to backend services like MongoDB HA Replicaset, RabbitMQ HA and a Redis Sentinel cluster
+that st2 relies on for database, communication bus, and distributed coordination respectively. These services are
+included in the default StackStorm HA cluster, but StackStorm can also use services provisioned separately.
+By default, the StackStorm HA cluster consists of a fleet of more than ``30`` pods.
 
-The source code for K8s resource templates is available as a GitHub repo:
+The source code for K8s resource templates (part of our Helm chart) is available as a GitHub repo:
 `StackStorm/stackstorm-ha <https://github.com/StackStorm/stackstorm-ha>`_.
 
 .. warning::
@@ -23,13 +25,13 @@ The source code for K8s resource templates is available as a GitHub repo:
 Requirements
 ------------
 * `Kubernetes <https://kubernetes.io/docs/setup/pick-right-solution/>`__ cluster
-* `Helm <https://docs.helm.sh/using_helm/#install-helm>`__, the K8s package manager and `Tiller <https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller>`_
+* `Helm <https://helm.sh/docs/intro/install>`__ 3, the K8s package manager (Helm 2 is not supported)
 * Enough computing resources for production use, respecting :doc:`/install/system_requirements`
 
 Usage
 -----
 This document assumes some basic knowledge of Kubernetes and Helm.
-Please refer to `K8s <https://kubernetes.io/docs/home/>`__ and `Helm <https://docs.helm.sh/>`__
+Please refer to `K8s <https://kubernetes.io/docs/home/>`__ and `Helm <https://helm.sh/docs/>`__
 documentation if you find any difficulties using these tools.
 
 However, here are some minimal instructions to get started.

--- a/docs/source/reference/ha.rst
+++ b/docs/source/reference/ha.rst
@@ -18,7 +18,7 @@ a reference to layer on some HA deployment-specific details.
 
 .. note::
 
-    A reproducible blueprint of StackStorm HA cluster is available as a code based on Docker and Kubernetes, see :doc:`/install/k8s_ha`.
+    A reproducible blueprint of StackStorm HA cluster is available as a helm chart, which is based on Docker and Kubernetes. See :doc:`/install/k8s_ha`.
 
 
 Components
@@ -122,9 +122,10 @@ You have to have exactly one active ``st2timersengine`` process running to sched
 Having more than one active ``st2timersengine`` will result in duplicate timer events and therefore
 duplicate rule evaluations leading to duplicate workflows or actions.
 
-In HA deployments, external monitoring needs to setup and a new ``st2timersengine`` process needs
-to be spun up to address failover. Losing the ``st2timersengine`` will mean no timer events will be
-injected into |st2| and therefore no timer rules would be evaluated.
+To address failover in HA deployments, use external monitoring of the ``st2timersengine`` process to ensure
+one process is running, and to trigger spinning up a new ``st2timersengine`` process if it fails.
+Losing the ``st2timersengine`` will mean no timer events will be injected into |st2| and therefore
+no timer rules would be evaluated.
 
 st2workflowengine
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
- k8s_ha: Refactor intro paragraph and drop helm 2 reference
- k8s_ha: Refactor configurable values list
- k8s_ha: Reword a few sections for clarity.
- k8s_ha: Copy notes about deploying mongo/rabbitmq from chart readme
- k8s_ha: begin documenting st2packs vs volumes methods
- k8s_ha: reword description of using Shared Volumes
- k8s_ha: add more notes about Storage Volumes
