### PR TITLE
Add core actions to documentation for better visibility.

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -808,36 +808,36 @@ pack:
 
     st2 run core.http url="http://httpbin.org/get" method="GET" username=user1 password=pass1
 
-* ``core.announcement`` : Action that broadcasts the announcement to all stream consumers.
+* ``core.announcement`` : This action broadcasts an announcement to all stream consumers.
 
-* ``core.ask`` : Action for initiating an Inquiry (usually in a workflow)
+* ``core.ask`` : This action is for initiating an Inquiry (usually in a workflow)
 
-* ``core.echo`` : Action that executes the Linux echo command on the localhost.
+* ``core.echo`` : This action executes the Linux echo command on the localhost.
 
-* ``core.error`` : Action that executes the Linux echo command (to stderr) on the localhost.
+* ``core.error`` : This action executes the Linux echo command (to stderr) on the localhost.
 
-* ``core.inject_trigger`` : Action which injects a new trigger in the system.
+* ``core.inject_trigger`` : This action injects a new trigger in the system.
 
   This action allows loose coupling of independent workflows, where workflow1 will execute workflow2
   indirectly through the IFTTT rule engine.
 
-* ``core.local_sudo`` : Action that executes an arbitrary Linux command on the localhost.
+* ``core.local_sudo`` : This action executes an arbitrary Linux command using sudo on the localhost.
 
-* ``core.noop`` : Action that does nothing.
+* ``core.noop`` : This action does nothing (No Operation).
 
-  This action can be used to implement conditional branches in Orquesta workflows without incurring
+  The noop action can be used to implement conditional branches in Orquesta workflows without incurring
   the cost of executing action code.  A YAQL/Jinja statement is general used to evaluate the criteria
   to choose a path of execution in a workflow.
 
-* ``core.pause`` Action to pause current thread of workflow/sub workflow.
+* ``core.pause`` : This action  pauses the current thread of workflow/sub workflow.
 
-* ``core.sendmail`` : This sends an email.
+* ``core.sendmail`` : This action sends an email using the sendmail binary (requires sendmail to be configured).
 
-* ``core.uuid`` : Generate a new UUID (default uuid4)
+* ``core.uuid`` : This action generates a new UUID (default uuid4).
 
-* ``core.winrm_cmd`` : Action to execute arbitrary Windows Command Prompt command remotely via WinRM.
+* ``core.winrm_cmd`` : This action executes arbitrary Windows Command Prompt command remotely via WinRM.
 
-* ``core.winrm_ps_cmd`` : Action to execute arbitrary Windows PowerShell command remotely via WinRM.
+* ``core.winrm_ps_cmd`` : This action executes arbitrary Windows PowerShell command remotely via WinRM.
 
 
 To see all actions in the ``core`` pack:

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -808,6 +808,38 @@ pack:
 
     st2 run core.http url="http://httpbin.org/get" method="GET" username=user1 password=pass1
 
+* ``core.announcement`` : Action that broadcasts the announcement to all stream consumers.
+
+* ``core.ask`` : Action for initiating an Inquiry (usually in a workflow)
+
+* ``core.echo`` : Action that executes the Linux echo command on the localhost.
+
+* ``core.error`` : Action that executes the Linux echo command (to stderr) on the localhost.
+
+* ``core.inject_trigger`` : Action which injects a new trigger in the system.
+
+  This action allows loose coupling of independent workflows, where workflow1 will execute workflow2
+  indirectly through the IFTTT rule engine.
+
+* ``core.local_sudo`` : Action that executes an arbitrary Linux command on the localhost.
+
+* ``core.noop`` : Action that does nothing.
+
+  This action can be used to implement conditional branches in Orquesta workflows without incurring
+  the cost of executing action code.  A YAQL/Jinja statement is general used to evaluate the criteria
+  to choose a path of execution in a workflow.
+
+* ``core.pause`` Action to pause current thread of workflow/sub workflow.
+
+* ``core.sendmail`` : This sends an email.
+
+* ``core.uuid`` : Generate a new UUID (default uuid4)
+
+* ``core.winrm_cmd`` : Action to execute arbitrary Windows Command Prompt command remotely via WinRM.
+
+* ``core.winrm_ps_cmd`` : Action to execute arbitrary Windows PowerShell command remotely via WinRM.
+
+
 To see all actions in the ``core`` pack:
 
 .. code-block:: bash


### PR DESCRIPTION
This PR adds the currently available core actions for better visibility.  In particularly the `core.inject_trigger` and `core.noop` which are very useful in workflow development but are not obvious to people that they exist or what their purpose is. 