### PR TITLE
Mention caveat to 'disabled by default'

### DIFF
--- a/docs/source/troubleshooting/purging_old_data.rst
+++ b/docs/source/troubleshooting/purging_old_data.rst
@@ -13,7 +13,8 @@ The Garbage Collector service is designed to periodically remove old data (actio
 live action, action execution output, and trigger instance database objects). 
 
 The actual collection threshold is very user-specific because it depends on your requirements and
-policies. Therefore garbage collection is disabled by default.
+policies. Therefore garbage collection is disabled by default, with the exception of Real-Time Streaming
+Action Output.
 
 To enable it, configure a TTL (in days) for action executions and trigger instances in ``st2.conf``
 as shown below:


### PR DESCRIPTION
We've been tweaking our GC configuration recently and had been confused by the wording in the documentation stating "garbage collection is disabled by default", only to then later come back to the same document and see the "Real-time Streaming Action Output garbage collection is enabled **by default**" statement.

I'm proposing this to raise that caveat on the line that led us to think that **no** GC was enabled by default.