### PR TITLE
Update documentation for Python 3.8 upgrade on EL8

### DIFF
--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -9,7 +9,9 @@ Environment Prerequisites
 Requirements:
 
 -  git
--  python3.6 (or python3.8 for Ubuntu 20.04), pip, virtualenv, tox
+-  python3.6 for Ubuntu 18.04 and CentOS/RHEL 7
+-  python3.8 for Ubuntu 20.04 and RockyLinux/CentOS/RHEL 8
+-  pip, virtualenv, tox
 -  MongoDB (http://docs.mongodb.org/manual/installation)
 -  RabbitMQ (http://www.rabbitmq.com/download.html)
 -  screen

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -172,6 +172,14 @@ The following sections call out the migration scripts that need to be run when u
 respective version. If you are upgrading across multiple versions, make sure you run the scripts for
 any skipped versions:
 
+v3.7
+''''
+*  *RockyLinux/RHEL/CentOS 8 only*. Due to the upgrade from python3.6 to python 3.8, it is recommended that all packs installed prior to upgrade have their virtual environment re-created after upgrading |st2| packages (on all nodes which run st2actionrunner services), using the following command:
+
+.. sourcecode:: bash
+
+    sudo st2ctl reload --register-setup-recreate-virtualenvs
+
 v3.5
 ''''
 * Node.js v14 is now used by ChatOps (previously v10 was used). The following procedure should be

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -174,7 +174,7 @@ any skipped versions:
 
 v3.7
 ''''
-*  *RockyLinux/RHEL/CentOS 8 only*. Due to the upgrade from python3.6 to python 3.8, it is recommended that all packs installed prior to upgrade have their virtual environment re-created after upgrading |st2| packages (on all nodes which run st2actionrunner services), using the following command:
+*  *RockyLinux/RHEL/CentOS 8 only*. Due to the upgrade from python3.6 to python 3.8, all packs installed prior to upgrade will need to have their virtual environment re-created after upgrading |st2| packages (on all nodes which run st2actionrunner services), using the following command:
 
 .. sourcecode:: bash
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -174,7 +174,7 @@ any skipped versions:
 
 v3.7
 ''''
-*  *RockyLinux/RHEL/CentOS 8 only*. Due to the upgrade from python3.6 to python 3.8, all packs installed prior to upgrade will need to have their virtual environment re-created after upgrading |st2| packages (on all nodes which run st2actionrunner services), using the following command:
+*  *RockyLinux/RHEL/CentOS 8 only*. Due to the upgrade from python3.6 to python 3.8, all packs installed prior to upgrade will need to have their virtual environment re-created after upgrading |st2| packages (on all nodes which run st2actionrunner or st2sensorcontainer services), using the following command:
 
 .. sourcecode:: bash
 

--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -180,6 +180,8 @@ v3.7
 
     sudo st2ctl reload --register-setup-recreate-virtualenvs
 
+* As ``_global`` is used for the global overrides file, if your |st2| uses a pack called _global then it will need to be renamed prior to upgrade.
+
 v3.5
 ''''
 * Node.js v14 is now used by ChatOps (previously v10 was used). The following procedure should be

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -12,6 +12,8 @@ Upgrade Notes
   reserved, and cannot be used for pack names or pack references, to avoid conflict between
   the global override file and individual pack override files.
 
+* On RockyLinux/CentOS/RHEL 8 the ST2 python version has changed from python 3.6 to python 3.8.
+
 .. _ref-upgrade-notes-v3-6:
 
 |st2| v3.6


### PR DESCRIPTION
Update documentation as Python 3.8 will now be used on EL 8 distributions