### PR TITLE
Fix upgrade notes for v3.7

### DIFF
--- a/docs/source/install/upgrades.rst
+++ b/docs/source/install/upgrades.rst
@@ -178,7 +178,7 @@ v3.7
 
 .. sourcecode:: bash
 
-    sudo st2ctl reload --register-setup-recreate-virtualenvs
+    sudo st2ctl reload --register-recreate-virtualenvs
 
 * As ``_global`` is used for the global overrides file, if your |st2| uses a pack called _global then it will need to be renamed prior to upgrade.
 
@@ -282,7 +282,7 @@ v3.4
 
 .. sourcecode:: bash
 
-    sudo st2ctl reload --register-setup-recreate-virtualenvs
+    sudo st2ctl reload --register-recreate-virtualenvs
 
 
 v3.3

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -8,6 +8,15 @@ Upgrade Notes
 |st2| v3.7
 ----------
 
+* *RockyLinux/RHEL/CentOS 8 only*. Due to the upgrade from python3.6 to python 3.8, all
+  packs installed prior to upgrade will need to have their virtual environment re-created
+  after upgrading |st2| packages (on all nodes which run st2actionrunner or st2sensorcontainer
+  services), using the following command:
+
+  .. sourcecode:: bash
+
+      sudo st2ctl reload --register-recreate-virtualenvs
+
 * API will now set ``Secure`` and ``Samesite=lax`` cookie attribute for the auth cookie which
   is set when authenticating via auth token / API key in query parameter (this approach is
   primarily used by st2web).


### PR DESCRIPTION
The recreate virtualenvs option went through several iterations in https://github.com/StackStorm/st2/pull/5167, but the docs were not updated after the flag was changed.

So, replace `--register-setup-recreate-virtualenvs` with `--register-recreate-virtualenvs` which is what was actually merged.

I will cherry-pick this to the v3.7 branch.
