### PR TITLE
Erlang 24 instructions for 3.7 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
             make st2
       - restore_cache:
           key: v2-dependency-cache-{{ checksum "st2/requirements.txt" }}
+      - run: sudo apt-get update
       - run: sudo apt install python3-dev
       - run: sudo apt install libldap2-dev 
       - run: sudo apt install libsasl2-dev

--- a/docs/source/install/u18.rst
+++ b/docs/source/install/u18.rst
@@ -39,23 +39,30 @@ Install MongoDB, RabbitMQ, and Redis:
   # Add keys latest RabbitMQ and RabbitMQ-erlang
   # Team RabbitMQ's main signing key
   curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
-  # Launchpad PPA that provides modern Erlang releases
-  curl -1sLf "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf77f1eda57ebb1cc" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg > /dev/null
-  # PackageCloud RabbitMQ repository
-  curl -1sLf "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.packagecloud.rabbitmq.gpg > /dev/null
+  # CloudSmith PPA that provides modern Erlang releases
+  curl -1sLf "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.dl.rabbitmq.erlang.gpg > /dev/null
+  # CloudSmith RabbitMQ repository
+  curl -1sLf "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.dl.rabbitmq.gpg > /dev/null
 
   # Add apt repositories maintained by Team RabbitMQ
   sudo tee /etc/apt/sources.list.d/rabbitmq.list <<EOF
 
   ## Provides modern Erlang/OTP releases
   ##
-  deb [signed-by=/usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg] http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main
-  deb-src [signed-by=/usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg] http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu bionic main
+  deb [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.erlang.gpg] http://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu ${SUBTYPE} main
+  deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.erlang.gpg] http://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu ${SUBTYPE} main
 
   ## Provides RabbitMQ
   ##
-  deb [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ bionic main
-  deb-src [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ bionic main
+  deb [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu/ ${SUBTYPE} main
+  deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu/ ${SUBTYPE} main
+  EOF
+
+  sudo tee /etc/apt/preferences.d/erlang <<EOF
+  # prefer packages erlang less than 25 repository
+  Package: erlang-*
+  Pin: version 1:24.*
+  Pin-Priority: 800
   EOF
 
   sudo apt-get update
@@ -70,6 +77,13 @@ Install MongoDB, RabbitMQ, and Redis:
 
   sudo apt-get install rabbitmq-server -y --fix-missing
   sudo apt-get install -y redis-server
+
+.. note::
+
+    RabbitMQ currently only has preview support for Erlang 25, however it is available in the
+    RabbitMQ-Erlang repository. Whilst Erlang 25 support is in preview (https://www.rabbitmq.com/which-erlang.html)
+    it is advised to install the latest Erlang 24 version instead. This is achieved by setting the apt
+    preferences to prioritize erlang 24.
 
 For Ubuntu ``Bionic`` you may need to enable and start MongoDB.
 

--- a/docs/source/install/u20.rst
+++ b/docs/source/install/u20.rst
@@ -38,22 +38,29 @@ Install MongoDB, RabbitMQ, and Redis:
   # Add keys latest RabbitMQ and RabbitMQ-erlang
   # Team RabbitMQ's main signing key
   curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
-  # Launchpad PPA that provides modern Erlang releases
-  curl -1sLf "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf77f1eda57ebb1cc" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg > /dev/null
-  # PackageCloud RabbitMQ repository
-  curl -1sLf "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.packagecloud.rabbitmq.gpg > /dev/null
+  # CloudSmith PPA that provides modern Erlang releases
+  curl -1sLf "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.dl.rabbitmq.erlang.gpg > /dev/null
+  # CloudSmith RabbitMQ repository
+  curl -1sLf "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.dl.rabbitmq.gpg > /dev/null
 
   # Add apt repositories maintained by Team RabbitMQ
   sudo tee /etc/apt/sources.list.d/rabbitmq.list <<EOF
   ## Provides modern Erlang/OTP releases
   ##
-  deb [signed-by=/usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg] http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main
-  deb-src [signed-by=/usr/share/keyrings/net.launchpad.ppa.rabbitmq.erlang.gpg] http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu focal main
+  deb [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.erlang.gpg] http://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu ${SUBTYPE} main
+  deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.erlang.gpg] http://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu ${SUBTYPE} main
 
   ## Provides RabbitMQ
   ##
-  deb [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ focal main
-  deb-src [signed-by=/usr/share/keyrings/io.packagecloud.rabbitmq.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ focal main
+  deb [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu/ ${SUBTYPE} main
+  deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.dl.rabbitmq.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu/ ${SUBTYPE} main
+  EOF
+
+  sudo tee /etc/apt/preferences.d/erlang <<EOF
+  # prefer packages erlang less than 25 repository
+  Package: erlang-*
+  Pin: version 1:24.*
+  Pin-Priority: 800
   EOF
 
   sudo apt-get update
@@ -68,6 +75,13 @@ Install MongoDB, RabbitMQ, and Redis:
 
   sudo apt-get install rabbitmq-server -y --fix-missing
   sudo apt-get install -y redis-server
+
+.. note::
+
+    RabbitMQ currently only has preview support for Erlang 25, however it is available in the
+    RabbitMQ-Erlang repository. Whilst Erlang 25 support is in preview (https://www.rabbitmq.com/which-erlang.html)
+    it is advised to install the latest Erlang 24 version instead. This is achieved by setting the apt
+    preferences to prioritize erlang 24.
 
 For Ubuntu ``Focal`` you may need to enable and start MongoDB.
 


### PR DESCRIPTION
Cherry pick changes from master to 3.7 branch, so that 3.7 documentation includes use of Erlang 24 for Ubuntu releases.