### PR TITLE
Add notes for sensors and RBAC on upgrade

### DIFF
--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -32,6 +32,9 @@ roles.
 By default when a new |st2| user is created, this user has no roles assigned to it, meaning it
 doesn't have access to perform any API operation which is behind the RBAC wall.
 
+.. note::
+    ``sensor_service`` is the |st2| user which sensors run as.
+
 Role
 ~~~~
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -44,8 +44,8 @@ Upgrade Notes
   information.
 
 * As part of extending RBAC support to include protecting access to datastore operations, if
-  you have RBAC enabled and any sensors access the datastore, then the ``sensor_service`` will need to
-  be assigned an RBAC role with the appropriate key_value_pair permissions.  
+  you have RBAC enabled and any sensors access the datastore, then the ``sensor_service`` user will
+  need to be assigned an RBAC role with the appropriate key_value_pair permissions.  
   Further information can be found in the :doc:`RBAC documentation <rbac>`.
 
 .. _ref-upgrade-notes-v3-6:

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -43,6 +43,11 @@ Upgrade Notes
   See :doc:`purging old data documentation <troubleshooting/purging_old_data>` for further
   information.
 
+* As part of extending RBAC support to include protecting access to datastore operations, if
+  you have RBAC enabled and any sensors access the datastore, then the ``sensor_service`` will need to
+  be assigned an RBAC role with the appropriate key_value_pair permissions.  
+  Further information can be found in the :doc:`RBAC documentation <rbac>`.
+
 .. _ref-upgrade-notes-v3-6:
 
 |st2| v3.6


### PR DESCRIPTION
Update upgrade notes so that mentions sensor_service RBAC assignment is needed if sensors in 3.7 use the key/value store.