### PR TITLE
WIP: Document using pantsbuild

### DIFF
--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -1,6 +1,8 @@
 Development
 ===========
 
+<!-- TODO: update to describe development using pantsbuild -->
+
 This page describes the |st2| development processes and contains general
 guidelines and information on how to contribute to the project.
 


### PR DESCRIPTION
### Background

This is part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105) and [02 Aug 2022](https://github.com/StackStorm/community/issues/107). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

### Overview of this PR

As we replace the Makefile and other parts of our CI and development infrastructure, the development and contributing guidelines need to be updated. As we integrate pantsbuild in the main st2 repo, we can document changed processes in the `pantsbuild` branch (this PR). Any of the TSC members can push to this branch, so we can collaboratively update the documentation.

### PRs in StackStorm/st2

- StackStorm/st2#5713