### PR TITLE
Update to use latest erlang (i.e. 25)

### DIFF
--- a/docs/source/install/rhel8.rst
+++ b/docs/source/install/rhel8.rst
@@ -81,17 +81,11 @@ Install MongoDB, RabbitMQ, and Redis:
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/erlang/script.rpm.sh | sudo bash
   curl -sL https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
   sudo yum makecache -y --disablerepo='*' --enablerepo='rabbitmq_rabbitmq-server'
-  sudo yum -y install erlang-24*
+  sudo yum -y install erlang-*
   sudo yum -y install rabbitmq-server
   sudo yum -y install redis
   sudo systemctl start mongod rabbitmq-server redis
   sudo systemctl enable mongod rabbitmq-server redis
-
-.. note::
-
-    RabbitMQ currently only has preview support for Erlang 25, however it is available in the
-    RabbitMQ-Erlang repository. Whilst Erlang 25 support is in preview (https://www.rabbitmq.com/which-erlang.html)
-    it is advised to install the latest Erlang 24 version instead.
 
 
 Setup Repositories

--- a/docs/source/install/u18.rst
+++ b/docs/source/install/u18.rst
@@ -59,11 +59,6 @@ Install MongoDB, RabbitMQ, and Redis:
   EOF
 
   sudo tee /etc/apt/preferences.d/erlang <<EOF
-  # prefer packages erlang less than 25 repository
-  Package: erlang-*
-  Pin: version 1:24.*
-  Pin-Priority: 800
-  EOF
 
   sudo apt-get update
 
@@ -78,12 +73,6 @@ Install MongoDB, RabbitMQ, and Redis:
   sudo apt-get install rabbitmq-server -y --fix-missing
   sudo apt-get install -y redis-server
 
-.. note::
-
-    RabbitMQ currently only has preview support for Erlang 25, however it is available in the
-    RabbitMQ-Erlang repository. Whilst Erlang 25 support is in preview (https://www.rabbitmq.com/which-erlang.html)
-    it is advised to install the latest Erlang 24 version instead. This is achieved by setting the apt
-    preferences to prioritize erlang 24.
 
 For Ubuntu ``Bionic`` you may need to enable and start MongoDB.
 

--- a/docs/source/install/u20.rst
+++ b/docs/source/install/u20.rst
@@ -57,11 +57,6 @@ Install MongoDB, RabbitMQ, and Redis:
   EOF
 
   sudo tee /etc/apt/preferences.d/erlang <<EOF
-  # prefer packages erlang less than 25 repository
-  Package: erlang-*
-  Pin: version 1:24.*
-  Pin-Priority: 800
-  EOF
 
   sudo apt-get update
 
@@ -76,12 +71,6 @@ Install MongoDB, RabbitMQ, and Redis:
   sudo apt-get install rabbitmq-server -y --fix-missing
   sudo apt-get install -y redis-server
 
-.. note::
-
-    RabbitMQ currently only has preview support for Erlang 25, however it is available in the
-    RabbitMQ-Erlang repository. Whilst Erlang 25 support is in preview (https://www.rabbitmq.com/which-erlang.html)
-    it is advised to install the latest Erlang 24 version instead. This is achieved by setting the apt
-    preferences to prioritize erlang 24.
 
 For Ubuntu ``Focal`` you may need to enable and start MongoDB.
 


### PR DESCRIPTION
Pinning to erlang 24 is causing issues, and erlang 25 is now RabbitMQ's preferred erlang - so use latest instead of pinning to 24.*