### PR TITLE
Add support for building docs on ReadTheDocs (esp for PRs)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,63 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Declare the Python requirements required to build docs
+python:
+  install:
+    - requirements: requirements.txt
+    # st2/ is st2.git cloned in post_checkout job
+    - requirements: st2/requirements.txt
+
+# Set the version of Python and other tools, and customize the build process
+build:
+  os: ubuntu-20.04
+  tools:
+    # python: "3.6"
+    python: "3.8"
+  apt_packages:
+    - python3-dev
+    - libldap2-dev
+    - libsasl2-dev
+
+  # https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process
+  # NOTE: use " instead of ' for all quoting or RTD gives some weird errors.
+  jobs:
+    post_checkout:
+      - ./scripts/clone-st2.sh
+      - ./scripts/clone-orquesta.sh
+
+    # We can't control the version of pip installed because it is part of the `install` stage.
+    #pre_install:
+    #  # switch to version of pip from cloned copy of st2
+    #  - >
+    #    export PIP_VERSION=$(grep "PIP_VERSION ?= " st2/Makefile | awk "{ print \$3 }");
+    #    echo PIP_VERSION=${PIP_VERSION};
+    #    pip install --upgrade "pip==${PIP_VERSION}";
+
+    # install: see python.install above
+
+    post_install:
+      - cd ./st2; make virtualenv
+      - cd ./st2; make requirements
+      # generate-runner-parameters-documentation.py needs this in the st2 virtualenv
+      - . st2/virtualenv/bin/activate; pip install pytablewriter
+
+    pre_build:
+      - . st2/virtualenv/bin/activate; ./scripts/generate-runner-parameters-documentation.py
+      - . st2/virtualenv/bin/activate; ./scripts/generate-internal-triggers-table.py
+      - . st2/virtualenv/bin/activate; ./scripts/generate-available-permission-types-table.py
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -225,7 +225,13 @@ html_js_files = [
 html_baseurl = info.base_url
 sitemap_filename = "sitemap.xml"
 if "READTHEDOCS" in os.environ:
-    sitemap_url_scheme = "{lang}{version}{link}"
+    if "dev" in version and os.environ["READTHEDOCS_VERSION_TYPE"] != "external":
+        # use latest/ instead of 3.8dev/ unless this is external (ie a PR)
+        _sitemap_version = os.environ["READTHEDOCS_VERSION"] + "/"
+    else:
+        # prefer 3.7/ over stable/ in sitemap
+        _sitemap_version = "{version}"
+    sitemap_url_scheme = "{lang}" + _sitemap_version + "{link}"
 elif "dev" in version:
     # use latest/ instead of 3.8dev/
     sitemap_url_scheme = "latest/{link}"


### PR DESCRIPTION
This adds the `.readthedocs.yaml` config file that RTD needs to be able to build our docs.

Once this is in, RTD will build PRs for us. For example, this PR was built on RTD. To see it, under checks, click on the `docs/readthedocs.org:st2docs` [details](https://readthedocs.org/projects/st2docs/builds/19412386/) link, and then click the little [View docs](https://st2docs--1157.org.readthedocs.build/en/1157/) link on the right hand side under the build statistics (not the big "View Docs" button at the top, look farther down the page).

_There are no current plans to switch docs.stackstorm.com over to RTD._