### PR TITLE
Fix broken references to Jinja docs

### DIFF
--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -106,7 +106,7 @@ ActionChain definition:
       # ...
 
 ``action1_input`` has value ``{{input1}}``. This syntax is variable referencing as supported by
-`Jinja templating <http://jinja.pocoo.org/docs/dev/templates/>`__.
+`Jinja templating <https://jinja.palletsprojects.com/en/2.11.x/templates/>`__.
 
 Similar constructs are also used in :doc:`Rule </rules>` criteria and action fields.
 

--- a/docs/source/orquesta/start.rst
+++ b/docs/source/orquesta/start.rst
@@ -199,6 +199,6 @@ Additional Tools and Resources
 
 * `YAQL documentation <https://yaql.readthedocs.io/en/latest/>`_ and `YAQL online evaluator
   <http://yaqluator.com/>`_
-* `Jinja2 template engine documentation <http://jinja.pocoo.org>`_ and `Jinja2 online evaluator
+* `Jinja2 template engine documentation <https://jinja.palletsprojects.com/en/2.11.x/>`_ and `Jinja2 online evaluator
   <http://jinja.quantprogramming.com/>`_
 * `Workflow visualization tool <http://www.orquestaedit.com/>`_

--- a/docs/source/reference/jinja.rst
+++ b/docs/source/reference/jinja.rst
@@ -1,7 +1,7 @@
 Jinja
 =====
 
-|st2| uses `Jinja <http://jinja.pocoo.org/>`_ extensively for templating. Jinja allows you to
+|st2| uses `Jinja <https://jinja.palletsprojects.com/en/2.11.x/>`_ extensively for templating. Jinja allows you to
 manipulate parameter values in |st2| by allowing you to refer to other parameters, applying filters
 or refer to system specific constructs (like datastore access). This document is here to help you
 with Jinja in the context of |st2|. Please refer to the `Jinja docs 

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -577,7 +577,7 @@ Variable Interpolation
 
 Occasionally, it will be necessary to pass along context of a trigger to an action when a rule is \
 matched. The rules engine is able to interpolate variables by leveraging `Jinja templating syntax
-<http://jinja.pocoo.org/docs/dev/templates/>`__.
+<https://jinja.palletsprojects.com/en/2.11.x/templates/>`__.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
#1130 missed some of the old references. This commit updates each one remaining to the new Jinja 2.11.x docs.