### PR TITLE
Update development docs for Rocky 8.4+ changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOC_BUILD_DIR := docs/build
 
 BINARIES := bin
 
-PYTHON_VERSION := python3.6
+PYTHON_VERSION := python3.8
 
 # All components are prefixed by st2
 COMPONENTS := $(wildcard st2*)

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -33,8 +33,13 @@ RockyLinux/CentOS/RHEL
 ----------------------
 
 .. note::
-  For RHEL 7.x you may need to enable the optional server rpms repository to be able to install the python3-devel RPM
+  For Rocky Linux release 8.4 (Green Obsidian) and up, you will have to install the ``redhat-lsb-core`` package with the following command.
 
+.. code-block:: bash
+  dnf --enablerepo=devel install redhat-lsb-core
+
+.. note::
+  For RHEL 7.x you may need to enable the optional server rpms repository to be able to install the python3-devel RPM
 
 .. code-block:: bash
 


### PR DESCRIPTION
Update development docs for how to add lsb_release command to rocky 8.4 and up manual build process.