### PR TITLE
St2chatops docs update + mac friendly changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get -qq update && apt-get -q install -y \
     curl git \
     libffi-dev libldap2-dev libsasl2-dev libssl-dev \
-    python3-dev python3-pip python-virtualenv
+    python3-dev python3-pip python3-virtualenv python3-venv
 
 ADD . /st2docs
 WORKDIR /st2docs

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ docker-build:
 	@echo
 	@echo "==================== Building st2docs Docker ===================="
 	@echo
-	docker build -t st2/st2docs -f Dockerfile .
+	docker build --platform=linux/amd64 -t st2/st2docs -f Dockerfile .
 
 .PHONY: docker-run
 docker-run:

--- a/docs/source/chatops/aliases.rst
+++ b/docs/source/chatops/aliases.rst
@@ -373,6 +373,26 @@ depending on execution status:
 
 To disable the result message, you can use the ``enabled`` flag in the same way as in ``ack``.
 
+Threading Replies (Slack)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can configure the hubot ``ack`` and ``result`` messages to be sent as a threaded reply to the invoked command in slack. This defaults to false if not set.
+
+.. code-block:: yaml
+
+    ack:
+      extra:
+        slack:
+          thread_response: true
+      format: ":green-check: Querying those items for you..."
+      append_url: false
+    result:
+      extra:
+        slack:
+          thread_response: true
+      format: |
+        ```{{execution.result.output.results}}```
+
 Plaintext Messages (Slack)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -50,32 +50,24 @@ Officially Supported Chat Providers
 
 We officially provide support for the following chat providers with hubot:
 
-* `Slack <https://github.com/slackapi/hubot-slack>`_
-* Microsoft Teams (via `BotFramework <https://github.com/Microsoft/BotFramework-Hubot>`_)
-* `Mattermost version 5 <https://github.com/loafoe/hubot-matteruser>`_
-* `Rocket.Chat <https://github.com/RocketChat/hubot-rocketchat>`_
-* `Cisco Spark <https://github.com/tonybaloney/hubot-spark>`_
+* `Slack <https://github.com/hubot-friends/hubot-slack>`_
 
 Officially Unsupported Chat Providers
 =====================================
 
-We do not provide support for the following adapters, but they are still bundled in the
-st2chatops package, can be configured in ``st2chatops.env``, and still work (as far as we
-know).
+We do not provide support for the following adapters as of st2chatops 3.9. They are still bundled in the
+st2chatops 3.8 package, and can be configured in ``st2chatops.env``, and may still work.
 
+* Microsoft Teams (via `BotFramework <https://github.com/Microsoft/BotFramework-Hubot>`_) See :doc:`3.8 documentation <msteams>`
+* `Mattermost version 5 <https://github.com/loafoe/hubot-matteruser>`_
+* `Rocket.Chat <https://github.com/RocketChat/hubot-rocketchat>`_
+* `Cisco Spark <https://github.com/tonybaloney/hubot-spark>`_
 * `Flowdock <https://github.com/flowdock/hubot-flowdock>`_
 * `XMPP <https://github.com/markstory/hubot-xmpp>`_
 * `IRC <https://github.com/nandub/hubot-irc>`_
 
 Configuration
 =============
-
-.. note::
-
-    Configuring st2chatops with Microsoft Teams is a more involved process. Please see
-    :doc:`our documentation <msteams>` specifically for that chat provider.
-    All other chat providers can be configured in ``st2chatops.env`` with the instructions
-    below.
 
 Package-based Install
 ~~~~~~~~~~~~~~~~~~~~~
@@ -84,7 +76,7 @@ If you installed |st2| following the :doc:`install docs </install/index>`, the `
 package will take care of `almost` everything for you. Hubot with the necessary adapters is already
 installed, and StackStorm :ref:`API keys <authentication-apikeys>` have been configured. 
 
-You just need to tell |st2| which Chat service to use - e.g. Slack, MatterMost, etc. You will also need
+You just need to tell |st2| which Chat service to use - e.g. Slack. You will also need
 to give it credentials. Your Chat service may also need configuration. For example, to configure Slack,
 you first need to add a new Hubot integration to Slack. You can do this through Slack's admin interface.
 Take note of the ``HUBOT_SLACK_TOKEN`` that Slack provides.
@@ -94,27 +86,25 @@ your adapter. For example, if you are configuring Slack, look for this section:
 
 .. code-block:: bash
 
-    # Slack settings (https://github.com/slackhq/hubot-slack):
-    #
+    # Slack App YAML settings (https://github.com/hubot-friends/hubot-slack?tab=readme-ov-file#sample-yaml)
+    # Confirm your existing Modern Slack App or a newly created Modern slack app has the above permissions
     # export HUBOT_ADAPTER=slack
-    # Obtain the Slack token from your app page at api.slack.com, it's the "Bot
-    # User OAuth Access Token" in the "OAuth & Permissions" section.
-    # export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
-    # Uncomment the following line to force hubot to exit if disconnected from slack.
-    # export HUBOT_SLACK_EXIT_ON_DISCONNECT=1
+    # Obtain the Bot user OAuth Token on the Oauth & Permissions section
+    # export HUBOT_SLACK_BOT_TOKEN=xoxb-CHANGE-ME-PLEASE
+    # Obtain a App-Level Token on the Basic Information section, scopes required: connections:write
+    # export HUBOT_SLACK_APP_TOKEN=xapp-CHANGE-ME-PLEASE
 
 Edit this file so it looks something like this:
 
 .. code-block:: bash
 
-    # Slack settings (https://github.com/slackhq/hubot-slack):
-    #
+    # Slack App YAML settings (https://github.com/hubot-friends/hubot-slack?tab=readme-ov-file#sample-yaml)
+    # Confirm your existing Modern Slack App or a newly created Modern slack app has the above permissions
     export HUBOT_ADAPTER=slack
-    # Obtain the Slack token from your app page at api.slack.com, it's the "Bot
-    # User OAuth Access Token" in the "OAuth & Permissions" section.
-    export HUBOT_SLACK_TOKEN=xoxb-SUPER-SECRET-TOKEN
-    # Uncomment the following line to force hubot to exit if disconnected from slack.
-    export HUBOT_SLACK_EXIT_ON_DISCONNECT=1
+    # Obtain the Bot user OAuth Token on the Oauth & Permissions section
+    export HUBOT_SLACK_BOT_TOKEN=xoxb-####-####-####
+    # Obtain a App-Level Token on the Basic Information section, scopes required: connections:write
+    export HUBOT_SLACK_APP_TOKEN=xapp-####-####-####
 
 Your specific Chat service may require different settings. Any environment settings needed can be
 added to this file. 
@@ -144,8 +134,8 @@ Restart ``st2chatops`` after creating that file.
 Using an External Adapter
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``st2chatops`` package includes adapters for common chat services, but if an
-adapter for a service you use isn't bundled there, don't worry: you can install it manually.
+The ``st2chatops`` package includes adapters for Slack, but if an
+adapter for a service you use isn't bundled there, don't worry: you can install it manually or try st2chatops 3.8.
 
 For example, here's how to connect |st2| to Yammer using the ``hubot-yammer`` adapter:
 

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -251,5 +251,5 @@ Logging
 =======
 
 ChatOps logs are written to ``/var/log/st2/st2chatops.log`` on non systemd-based distros. For
-systemd-based distros (Ubuntu 18/20, RHEL/RockyLinux/CentOS 7/8), you can access the logs via
+systemd-based distros (Ubuntu 18/20, RHEL/RockyLinux8+), you can access the logs via
 ``journalctl --unit=st2chatops``

--- a/docs/source/chatops/index.rst
+++ b/docs/source/chatops/index.rst
@@ -50,7 +50,7 @@ Interested in learning more? Here are some things to get you started on your voy
     :maxdepth: 1
 
     chatops
-    Configuration for Microsoft Teams <msteams>
+    Configuration for Microsoft Teams (3.8) <msteams>
     Action Aliases <aliases>
     notifications
     Pack Deployment <pack_deploy>

--- a/docs/source/chatops/msteams.rst
+++ b/docs/source/chatops/msteams.rst
@@ -1,6 +1,10 @@
 Using Microsoft Teams (with BotFramework)
 =========================================
 
+.. warning:: 
+
+    This is documentation assumes you are using st2chatops 3.8. Support for Microsoft Teams was removed in 3.9.
+
 Configurating st2chatops with Microsoft Teams is **much** more involved than configuring
 other chat providers.
 


### PR DESCRIPTION
**Local Build Updates**
1. Update the base image to 22.04, and package names
2. Pin the `docker build` to linux/amd64 (mac will default to arm and fail)

**Docs Updates**
st2chatops
1. Slack is the only supported version in 3.9
2. keep the older 3.8 docs (msteams) there, but warn that it won't work in 3.9
3. Add tip about threading replies in slack (added in 3.9)